### PR TITLE
Add Balance Sheet Controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
+
+        <spring-test.version>4.3.3.RELEASE</spring-test.version>
     </properties>
 
     <dependencies>
@@ -55,6 +57,19 @@
         </dependency>
 
         <!-- Test scope -->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring-test.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
 
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
 
+        <hamcrest.version>1.3</hamcrest.version>
+
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
 
@@ -60,7 +62,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -1,4 +1,49 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
+import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
+
+@Controller
 public class BalanceSheetController {
+
+    private static final String BALANCE_SHEET_PATH = "/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/balance-sheet";
+
+    private static final String SMALL_FULL_BALANCE_SHEET = "smallfull/balanceSheet";
+
+    @Autowired
+    private BalanceSheetService balanceSheetService;
+
+    @RequestMapping(value = BALANCE_SHEET_PATH, method = RequestMethod.GET)
+    public String getBalanceSheet(@PathVariable String transactionId,
+                                  @PathVariable String companyAccountsId,
+                                  Model model) {
+
+        model.addAttribute(balanceSheetService.getBalanceSheet(transactionId, companyAccountsId));
+
+        return SMALL_FULL_BALANCE_SHEET;
+    }
+
+    @RequestMapping(value = BALANCE_SHEET_PATH, method = RequestMethod.POST)
+    public String postBalanceSheet(@PathVariable String companyNumber,
+                                   @PathVariable String transactionId,
+                                   @PathVariable String companyAccountsId,
+                                   @ModelAttribute("balanceSheet") @Valid BalanceSheet balanceSheet,
+                                   BindingResult bindingResult) {
+
+        if (bindingResult.hasErrors()) {
+            return SMALL_FULL_BALANCE_SHEET;
+        }
+
+        // The next page will be returned once created
+        return SMALL_FULL_BALANCE_SHEET;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -5,10 +5,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 
@@ -22,17 +22,17 @@ public class BalanceSheetController {
     @Autowired
     private BalanceSheetService balanceSheetService;
 
-    @RequestMapping(value = BALANCE_SHEET_PATH, method = RequestMethod.GET)
+    @GetMapping(value = BALANCE_SHEET_PATH)
     public String getBalanceSheet(@PathVariable String transactionId,
                                   @PathVariable String companyAccountsId,
                                   Model model) {
 
-        model.addAttribute(balanceSheetService.getBalanceSheet(transactionId, companyAccountsId));
+        model.addAttribute("balanceSheet", balanceSheetService.getBalanceSheet(transactionId, companyAccountsId));
 
         return SMALL_FULL_BALANCE_SHEET;
     }
 
-    @RequestMapping(value = BALANCE_SHEET_PATH, method = RequestMethod.POST)
+    @PostMapping(value = BALANCE_SHEET_PATH)
     public String postBalanceSheet(@PathVariable String companyNumber,
                                    @PathVariable String transactionId,
                                    @PathVariable String companyAccountsId,

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/BalanceSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/BalanceSheetService.java
@@ -5,5 +5,5 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 
 public interface BalanceSheetService {
 
-    BalanceSheet getBalanceSheet(String companyId, String transactionId, String accountsId);
+    BalanceSheet getBalanceSheet(String transactionId, String companyAccountsId);
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -1,19 +1,19 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTransformer;
 
-@Component
+@Service
 public class BalanceSheetServiceImpl implements BalanceSheetService {
 
     @Autowired
     private BalanceSheetTransformer transformer;
 
     @Override
-    public BalanceSheet getBalanceSheet(String companyId, String transactionId, String accountsId) {
+    public BalanceSheet getBalanceSheet(String transactionId, String companyAccountsId) {
 
         //get data from API
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -8,17 +8,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 
+@ExtendWith(MockitoExtension.class)
 public class BalanceSheetControllerTests {
 
     private MockMvc mockMvc;
@@ -40,30 +43,36 @@ public class BalanceSheetControllerTests {
                                                      "/company-accounts/" + COMPANY_ACCOUNTS_ID +
                                                      "/small-full/balance-sheet";
 
+    private static final String BALANCE_SHEET_MODEL_ATTR = "balanceSheet";
+
+    private static final String BALANCE_SHEET_VIEW = "smallfull/balanceSheet";
+
     @BeforeEach
     private void setup() {
-        MockitoAnnotations.initMocks(this);
+
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
     @Test
+    @DisplayName("Get balance sheet view success path")
     void getRequestSuccess() throws Exception {
 
         when(balanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new BalanceSheet());
 
         this.mockMvc.perform(get(BALANCE_SHEET_PATH))
                     .andExpect(status().isOk())
-                    .andExpect(view().name("smallfull/balanceSheet"))
-                    .andExpect(model().attributeExists("balanceSheet"));
+                    .andExpect(view().name(BALANCE_SHEET_VIEW))
+                    .andExpect(model().attributeExists(BALANCE_SHEET_MODEL_ATTR));
     }
 
     @Test
+    @DisplayName("Post balance sheet success path")
     void postRequestSuccess() throws Exception {
 
         this.mockMvc.perform(post(BALANCE_SHEET_PATH))
                 .andExpect(status().isOk())
-                .andExpect(view().name("smallfull/balanceSheet"))
-                .andExpect(model().attributeExists("balanceSheet"));
+                .andExpect(view().name(BALANCE_SHEET_VIEW))
+                .andExpect(model().attributeExists(BALANCE_SHEET_MODEL_ATTR));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -1,0 +1,69 @@
+package uk.gov.companieshouse.web.accounts.controller.smallfull;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
+import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
+
+public class BalanceSheetControllerTests {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    BalanceSheetService balanceSheetService;
+
+    @InjectMocks
+    BalanceSheetController controller;
+
+    private static final String COMPANY_NUMBER = "companyNumber";
+
+    private static final String TRANSACTION_ID = "transactionId";
+
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    private static final String BALANCE_SHEET_PATH = "/company/" + COMPANY_NUMBER +
+                                                     "/transaction/" + TRANSACTION_ID +
+                                                     "/company-accounts/" + COMPANY_ACCOUNTS_ID +
+                                                     "/small-full/balance-sheet";
+
+    @BeforeEach
+    private void setup() {
+        MockitoAnnotations.initMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void getRequestSuccess() throws Exception {
+
+        when(balanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new BalanceSheet());
+
+        this.mockMvc.perform(get(BALANCE_SHEET_PATH))
+                    .andExpect(status().isOk())
+                    .andExpect(view().name("smallfull/balanceSheet"))
+                    .andExpect(model().attributeExists("balanceSheet"));
+    }
+
+    @Test
+    void postRequestSuccess() throws Exception {
+
+        this.mockMvc.perform(post(BALANCE_SHEET_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name("smallfull/balanceSheet"))
+                .andExpect(model().attributeExists("balanceSheet"));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
@@ -33,7 +33,7 @@ public class BalanceSheetServiceImplTests {
     @Test
     void getBalanceSheetSuccess() {
 
-        BalanceSheet balanceSheet = balanceSheetService.getBalanceSheet("", "", "");
+        BalanceSheet balanceSheet = balanceSheetService.getBalanceSheet("", "");
 
         assertNotNull(balanceSheet);
     }


### PR DESCRIPTION
- Add balance sheet controller. 
- Add base unit tests for the balance sheet controller.
- Update balance sheet service interface to take 2 parameters: transactionId and companyAccountsId.

Required for SFA-43