### PR TITLE
Add Session Handler to the Filter Chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,12 @@
 
         <hamcrest.version>1.3</hamcrest.version>
 
+        <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
+
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>
+
+        <spring-security-core.version>5.0.7.RELEASE</spring-security-core.version>
 
         <spring-test.version>4.3.3.RELEASE</spring-test.version>
     </properties>
@@ -56,6 +60,29 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>uk.gov.companieshouse</groupId>
+            <artifactId>java-session-handler</artifactId>
+            <version>${java-session-handler.version}</version>
+        </dependency>
+
+        <!-- Security dependencies -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${spring-security-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
         </dependency>
 
         <!-- Test scope -->

--- a/src/main/java/uk/gov/companieshouse/web/accounts/CompanyAccountsWebApplication.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/CompanyAccountsWebApplication.java
@@ -1,12 +1,28 @@
 package uk.gov.companieshouse.web.accounts;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.companieshouse.web.accounts.interceptor.UserDetailsInterceptor;
 
 @SpringBootApplication
-public class CompanyAccountsWebApplication {
+public class CompanyAccountsWebApplication implements WebMvcConfigurer {
+
+    UserDetailsInterceptor userDetailsInterceptor;
+
+    @Autowired
+    public CompanyAccountsWebApplication(UserDetailsInterceptor userDetailsInterceptor) {
+        this.userDetailsInterceptor = userDetailsInterceptor;
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(CompanyAccountsWebApplication.class, args);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(userDetailsInterceptor);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.web.accounts.interceptor;
+
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+
+@Component
+public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
+
+    private static final String USER_EMAIL = "userEmail";
+
+    private static final String SIGN_IN_KEY = "signin_info";
+    private static final String USER_PROFILE_KEY = "user_profile";
+    private static final String EMAIL_KEY = "email";
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
+
+        if (modelAndView != null) {
+            Map<String, Object> sessionData = SessionHandler.getSessionDataFromContext();
+            Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
+            if (signInInfo != null) {
+                Map<String, Object> userProfile = (Map<String, Object>) signInInfo.get(USER_PROFILE_KEY);
+                modelAndView.getModelMap().addAttribute(USER_EMAIL, userProfile.get(EMAIL_KEY));
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/security/WebSecurity.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/security/WebSecurity.java
@@ -1,0 +1,25 @@
+package uk.gov.companieshouse.web.accounts.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+
+@EnableWebSecurity
+public class WebSecurity extends WebSecurityConfigurerAdapter {
+
+    @Configuration
+    @Order(1)
+    public static class CompanyAccountsSecurityFilterConfig extends WebSecurityConfigurerAdapter {
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+
+            http.addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class);
+        }
+    }
+
+}

--- a/src/main/resources/templates/fragments/userBar.html
+++ b/src/main/resources/templates/fragments/userBar.html
@@ -5,10 +5,10 @@
     </head>
     <body>
         <div th:fragment="userBar" class="js-toggle-nav" id="global-nav">
-            <a href="#navigation" id="signed-in-user-href" class="js-header-toggle" text="jsmith@testcompany.co.uk:"></a>
+            <a href="#navigation" id="signed-in-user-href" class="js-header-toggle" th:text="${userEmail + ':'}"></a>
             <nav class="content" role="navigation">
                 <ul id="navigation" class="mobile-hidden">
-                    <li class="user" id="signed-in-user">jsmith@testcompany.co.uk: </li>
+                    <li class="user" id="signed-in-user" th:text="${userEmail + ': '}" />
                     <li><a href="javascript:void(0)">Your details</a></li>
                     <li><a href="javascript:void(0)" id="recent_filings">Your filings</a></li>
                     <li><a href="javascript:void(0)" id="">Companies you follow</a></li>


### PR DESCRIPTION
Add session handler to the request filter chain.
Add user details interceptor which executes before a view renders to retrieve the email from the session and append it to the model.
Update the user bar fragment to display the email from the model.

Required for SFA-43