### PR TITLE
Prefer constructor injection for mandatory dependencies

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -19,8 +19,12 @@ public class BalanceSheetController {
 
     private static final String SMALL_FULL_BALANCE_SHEET = "smallfull/balanceSheet";
 
-    @Autowired
     private BalanceSheetService balanceSheetService;
+
+    @Autowired
+    public BalanceSheetController(BalanceSheetService balanceSheetService) {
+        this.balanceSheetService = balanceSheetService;
+    }
 
     @GetMapping(value = BALANCE_SHEET_PATH)
     public String getBalanceSheet(@PathVariable String transactionId,

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -9,8 +9,12 @@ import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTran
 @Service
 public class BalanceSheetServiceImpl implements BalanceSheetService {
 
-    @Autowired
     private BalanceSheetTransformer transformer;
+
+    @Autowired
+    public BalanceSheetServiceImpl(BalanceSheetTransformer transformer) {
+        this.transformer = transformer;
+    }
 
     @Override
     public BalanceSheet getBalanceSheet(String transactionId, String companyAccountsId) {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
@@ -22,7 +22,7 @@ public class BalanceSheetServiceImplTests {
     private BalanceSheetTransformer transformer;
 
     @InjectMocks
-    private BalanceSheetService balanceSheetService = new BalanceSheetServiceImpl();
+    private BalanceSheetService balanceSheetService = new BalanceSheetServiceImpl(transformer);
 
     @BeforeEach
     private void init() {


### PR DESCRIPTION
As per the Spring documentation on the subject, constructor injection should be preferred for mandatory dependencies.

Reference: https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-constructor-injection

Resolves: SFA-43