### PR TITLE
Add lifecycle annotation to balance sheet controller test

### DIFF
--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -22,6 +23,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 
 @ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BalanceSheetControllerTests {
 
     private MockMvc mockMvc;


### PR DESCRIPTION
To be consistent with other test classes—and given that no state will changes will be persisted between tests in this class—the lifecycle for this test class should be `PER_CLASS` (i.e. a single instance of the test class will be instantiated and each test method executed on the same instance).

Resolves: SFA-43