### PR TITLE
Add Current Period to Balance Sheet Transformer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>2.0.0-rc1</api-sdk-java.version>
+        <api-sdk-java.version>2.0.0-rc2</api-sdk-java.version>
 
         <sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -31,7 +31,7 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
                                                .currentPeriod().get();
 
         //transform API data to web-readable data
-        BalanceSheet balanceSheet = transformer.getBalanceSheet();
+        BalanceSheet balanceSheet = transformer.getBalanceSheet(currentPeriod);
 
         return balanceSheet;
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
@@ -25,7 +25,7 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
-        CurrentPeriod currentPeriod = apiClient.transaction(transactionId)
+        CurrentPeriodApi currentPeriod = apiClient.transaction(transactionId)
                                                .companyAccount(companyAccountsId)
                                                .smallFull()
                                                .currentPeriod().get();

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformer.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull;
 
-import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 
 public interface BalanceSheetTransformer {
 
-    BalanceSheet getBalanceSheet(CurrentPeriod currentPeriod);
+    BalanceSheet getBalanceSheet(CurrentPeriodApi currentPeriod);
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformer.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull;
 
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 
 public interface BalanceSheetTransformer {
 
-    BalanceSheet getBalanceSheet();
+    BalanceSheet getBalanceSheet(CurrentPeriod currentPeriod);
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/BalanceSheetTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/BalanceSheetTransformerImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.model.smallfull.CalledUpShareCapitalNotPaid;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTransformer;
@@ -8,10 +9,16 @@ import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTran
 @Component
 public class BalanceSheetTransformerImpl implements BalanceSheetTransformer {
 
-    public BalanceSheet getBalanceSheet() {
+    public BalanceSheet getBalanceSheet(CurrentPeriod currentPeriod) {
+
+        uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheet apiCurrentPeriodBalanceSheet = currentPeriod.getBalanceSheet();
 
         BalanceSheet balanceSheet = new BalanceSheet();
-        balanceSheet.setCalledUpShareCapitalNotPaid(new CalledUpShareCapitalNotPaid());
+
+        CalledUpShareCapitalNotPaid calledUpShareCapitalNotPaid = new CalledUpShareCapitalNotPaid();
+        calledUpShareCapitalNotPaid.setCurrentAmount(apiCurrentPeriodBalanceSheet.getCalledUpShareCapitalNotPaid());
+
+        balanceSheet.setCalledUpShareCapitalNotPaid(calledUpShareCapitalNotPaid);
 
         return balanceSheet;
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/BalanceSheetTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/BalanceSheetTransformerImpl.java
@@ -1,7 +1,8 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
+import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.model.smallfull.CalledUpShareCapitalNotPaid;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTransformer;
@@ -9,14 +10,16 @@ import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTran
 @Component
 public class BalanceSheetTransformerImpl implements BalanceSheetTransformer {
 
-    public BalanceSheet getBalanceSheet(CurrentPeriod currentPeriod) {
+    @Override
+    public BalanceSheet getBalanceSheet(CurrentPeriodApi currentPeriod) {
 
-        uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheet apiCurrentPeriodBalanceSheet = currentPeriod.getBalanceSheet();
+        BalanceSheetApi currentPeriodBalanceSheetApi = currentPeriod.getBalanceSheetApi();
 
         BalanceSheet balanceSheet = new BalanceSheet();
 
         CalledUpShareCapitalNotPaid calledUpShareCapitalNotPaid = new CalledUpShareCapitalNotPaid();
-        calledUpShareCapitalNotPaid.setCurrentAmount(apiCurrentPeriodBalanceSheet.getCalledUpShareCapitalNotPaid());
+        calledUpShareCapitalNotPaid.setCurrentAmount(
+                currentPeriodBalanceSheetApi.getCalledUpShareCapitalNotPaid());
 
         balanceSheet.setCalledUpShareCapitalNotPaid(calledUpShareCapitalNotPaid);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
@@ -75,9 +75,11 @@ public class BalanceSheetServiceImplTests {
     @DisplayName("Get Balance Sheet - Success Path")
     void getBalanceSheetSuccess() throws ApiErrorResponseException {
 
-        when(currentPeriodResourceHandler.get()).thenReturn(new CurrentPeriod());
+        CurrentPeriod currentPeriod = new CurrentPeriod();
 
-        when(transformer.getBalanceSheet()).thenReturn(new BalanceSheet());
+        when(currentPeriodResourceHandler.get()).thenReturn(currentPeriod);
+
+        when(transformer.getBalanceSheet(currentPeriod)).thenReturn(new BalanceSheet());
 
         BalanceSheet balanceSheet = balanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
@@ -14,7 +14,7 @@ import uk.gov.companieshouse.api.handler.transaction.TransactionResourceHandler;
 import uk.gov.companieshouse.api.handler.transaction.companyaccount.CompanyAccountResourceHandler;
 import uk.gov.companieshouse.api.handler.transaction.companyaccount.smallfull.SmallFullResourceHandler;
 import uk.gov.companieshouse.api.handler.transaction.companyaccount.smallfull.subresource.CurrentPeriodResourceHandler;
-import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
@@ -75,7 +75,7 @@ public class BalanceSheetServiceImplTests {
     @DisplayName("Get Balance Sheet - Success Path")
     void getBalanceSheetSuccess() throws ApiErrorResponseException {
 
-        CurrentPeriod currentPeriod = new CurrentPeriod();
+        CurrentPeriodApi currentPeriod = new CurrentPeriodApi();
 
         when(currentPeriodResourceHandler.get()).thenReturn(currentPeriod);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformerTests.java
@@ -1,21 +1,44 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.impl.BalanceSheetTransformerImpl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BalanceSheetTransformerTests {
 
+    private Integer CALLED_UP_SHARE_CAPITAL = 1;
+
     private BalanceSheetTransformer transformer = new BalanceSheetTransformerImpl();
 
-    @Test
-    void getBalanceSheetSuccess() {
+    private CurrentPeriod currentPeriod;
 
-        BalanceSheet balanceSheet = transformer.getBalanceSheet();
+    @BeforeEach
+    private void init() {
+
+        uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheet apiCurrentPeriodBalanceSheet
+                = new uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheet();
+
+        apiCurrentPeriodBalanceSheet.setCalledUpShareCapitalNotPaid(CALLED_UP_SHARE_CAPITAL);
+
+        currentPeriod = new CurrentPeriod();
+
+        currentPeriod.setBalanceSheet(apiCurrentPeriodBalanceSheet);
+    }
+
+    @Test
+    @DisplayName("Get Balance Sheet - Assert Called Up Share Capital is Correct")
+    void getBalanceSheetCalledUpShareCapital() {
+
+        BalanceSheet balanceSheet = transformer.getBalanceSheet(currentPeriod);
 
         assertNotNull(balanceSheet);
         assertNotNull(balanceSheet.getCalledUpShareCapitalNotPaid());
+        assertEquals(CALLED_UP_SHARE_CAPITAL, balanceSheet.getCalledUpShareCapitalNotPaid().getCurrentAmount());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformerTests.java
@@ -3,7 +3,8 @@ package uk.gov.companieshouse.web.accounts.transformer.smallfull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriod;
+import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
+import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.impl.BalanceSheetTransformerImpl;
 
@@ -16,19 +17,18 @@ public class BalanceSheetTransformerTests {
 
     private BalanceSheetTransformer transformer = new BalanceSheetTransformerImpl();
 
-    private CurrentPeriod currentPeriod;
+    private CurrentPeriodApi currentPeriod;
 
     @BeforeEach
     private void init() {
 
-        uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheet apiCurrentPeriodBalanceSheet
-                = new uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheet();
+        BalanceSheetApi currentPeriodBalanceSheetApi = new BalanceSheetApi();
 
-        apiCurrentPeriodBalanceSheet.setCalledUpShareCapitalNotPaid(CALLED_UP_SHARE_CAPITAL);
+        currentPeriodBalanceSheetApi.setCalledUpShareCapitalNotPaid(CALLED_UP_SHARE_CAPITAL);
 
-        currentPeriod = new CurrentPeriod();
+        currentPeriod = new CurrentPeriodApi();
 
-        currentPeriod.setBalanceSheet(apiCurrentPeriodBalanceSheet);
+        currentPeriod.setBalanceSheetApi(currentPeriodBalanceSheetApi);
     }
 
     @Test


### PR DESCRIPTION
Add current period as a parameter in the `getBalanceSheet` method of the balance sheet transformer.

Note: this PR is set up against https://github.com/companieshouse/company-accounts.web.ch.gov.uk/pull/26

Required for SFA-592