### PR TITLE
Set a meaningful transaction description

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
@@ -21,8 +21,7 @@ public class TransactionServiceImpl implements TransactionService {
         Transaction transaction = new Transaction();
         transaction.setCompanyNumber(companyNumber);
 
-        // TODO: Set this to something appropriate
-        transaction.setDescription("");
+        transaction.setDescription("Small Full Accounts");
 
         ApiClient apiClient = apiClientService.getApiClient();
 


### PR DESCRIPTION
The mandatory description field should be set in order to highlight the intent of the transaction, as per the transaction API specification. This description is shown on the 'Your filings' page within CHS.

Ideally, this should be an API enumeration constant, in a similar manner to the implementation for the 'Change of registered office address' filing seen here: https://github.com/companieshouse/api-enumerations/blob/develop/constants.yml#L185 and here: https://github.com/companieshouse/ch.gov.uk/blob/develop/lib/ChGovUk/Transaction.pm#L111

After discussions with Chris Smith, we have agreed to embed the description string in the service for the time-being, as is also done in the `abridged.accounts.web.ch.gov.uk` service.