### PR TITLE
Make MissingAnnotationException extend RuntimeException

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/MissingAnnotationException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/MissingAnnotationException.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.web.accounts.exception;
 
-public class MissingAnnotationException extends Exception {
+public class MissingAnnotationException extends RuntimeException {
 
     public MissingAnnotationException(String message) {
         super(message);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/util/Navigator.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/util/Navigator.java
@@ -14,7 +14,7 @@ public class Navigator {
     // Private constructor to prevent instantiation
     private Navigator() {}
 
-    public static String getNextControllerRedirect(Class clazz, String... pathVars) throws MissingAnnotationException {
+    public static String getNextControllerRedirect(Class clazz, String... pathVars) {
         Annotation nextControllerAnnotation = AnnotationUtils.findAnnotation(clazz, NextController.class);
         if (nextControllerAnnotation == null) {
             throw new MissingAnnotationException("Missing @NextController annotation on class " + clazz.toString());
@@ -38,7 +38,7 @@ public class Navigator {
         return UrlBasedViewResolver.REDIRECT_URL_PREFIX + new UriTemplate(mappings[0]).expand(pathVars);
     }
 
-    public static String getPreviousControllerPath(Class clazz, String... pathVars) throws MissingAnnotationException {
+    public static String getPreviousControllerPath(Class clazz, String... pathVars) {
         Annotation previousControllerAnnotation = AnnotationUtils.findAnnotation(clazz, PreviousController.class);
         if (previousControllerAnnotation == null) {
             return "";


### PR DESCRIPTION
Make `MissingAnnotationException` extend `RuntimeException` so that there's no need to explicitly try-catch in controller methods.

Required for SFA-573