### PR TITLE
Update web-security-java dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 
-        <web-security-java.version>1.0.0-rc1</web-security-java.version>
+        <web-security-java.version>1.1.0-rc1</web-security-java.version>
 
         <junit-jupiter-engine.version>5.2.0</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>2.18.0</mockito-junit-jupiter.version>


### PR DESCRIPTION
This change ensures that consistent dependency versions of `java-session-handler` are used by both `company-accounts.web.ch.gov.uk` and `web-security-java`.