### PR TITLE
Log Controller Errors with Request Id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 
-        <structured-logging.version>1.4.0-rc2</structured-logging.version>
+        <structured-logging.version>1.5.0-rc1</structured-logging.version>
 
         <web-security-java.version>1.1.0-rc1</web-security-java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 
-        <structured-logging.version>1.5.0-rc1</structured-logging.version>
+        <structured-logging.version>1.5.0-rc2</structured-logging.version>
 
         <web-security-java.version>1.1.0-rc1</web-security-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,13 +29,14 @@ public class ApprovalController extends BaseController {
     @PostMapping
     public String postApproval(@PathVariable String companyNumber,
                                @PathVariable String transactionId,
-                               @PathVariable String companyAccountsId) {
+                               @PathVariable String companyAccountsId,
+                               HttpServletRequest request) {
 
         try {
             transactionService.closeTransaction(transactionId);
         } catch (ApiErrorResponseException e) {
             // TODO: handle ApiErrorResponseExceptions (SFA-594)
-            LOGGER.error(e);
+            LOGGER.errorRequest(request, "Failed to close transaction");
         }
 
         // TODO: Further implementation when navigation built

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -36,7 +36,7 @@ public class ApprovalController extends BaseController {
             transactionService.closeTransaction(transactionId);
         } catch (ApiErrorResponseException e) {
             // TODO: handle ApiErrorResponseExceptions (SFA-594)
-            LOGGER.errorRequest(request, "Failed to close transaction");
+            LOGGER.errorRequest(request, "Failed to close transaction", e);
         }
 
         // TODO: Further implementation when navigation built

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -30,13 +31,14 @@ public class BalanceSheetController extends BaseController {
     @GetMapping
     public String getBalanceSheet(@PathVariable String transactionId,
                                   @PathVariable String companyAccountsId,
-                                  Model model) {
+                                  Model model,
+                                  HttpServletRequest request) {
 
         try {
             model.addAttribute("balanceSheet", balanceSheetService.getBalanceSheet(transactionId, companyAccountsId));
         } catch (ApiErrorResponseException e) {
             // TODO: handle ApiErrorResponseExceptions (SFA-594)
-            LOGGER.error(e);
+            LOGGER.errorRequest(request, "Failed to fetch balance sheet");
             model.addAttribute("balanceSheet", new BalanceSheet());
         }
 
@@ -48,7 +50,8 @@ public class BalanceSheetController extends BaseController {
                                    @PathVariable String transactionId,
                                    @PathVariable String companyAccountsId,
                                    @ModelAttribute("balanceSheet") @Valid BalanceSheet balanceSheet,
-                                   BindingResult bindingResult) {
+                                   BindingResult bindingResult,
+                                   HttpServletRequest request) {
 
         if (bindingResult.hasErrors()) {
             return SMALL_FULL_BALANCE_SHEET;
@@ -57,7 +60,7 @@ public class BalanceSheetController extends BaseController {
         try {
             balanceSheetService.postBalanceSheet(transactionId, companyAccountsId, balanceSheet);
         } catch (ApiErrorResponseException e) {
-            LOGGER.error(e);
+            LOGGER.errorRequest(request, "Failed to post balance sheet");
             return SMALL_FULL_BALANCE_SHEET;
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -60,7 +60,7 @@ public class BalanceSheetController extends BaseController {
         try {
             balanceSheetService.postBalanceSheet(transactionId, companyAccountsId, balanceSheet);
         } catch (ApiErrorResponseException e) {
-            LOGGER.errorRequest(request, "Failed to post balance sheet");
+            LOGGER.errorRequest(request, "Failed to post balance sheet", e);
             return SMALL_FULL_BALANCE_SHEET;
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -38,7 +38,7 @@ public class BalanceSheetController extends BaseController {
             model.addAttribute("balanceSheet", balanceSheetService.getBalanceSheet(transactionId, companyAccountsId));
         } catch (ApiErrorResponseException e) {
             // TODO: handle ApiErrorResponseExceptions (SFA-594)
-            LOGGER.errorRequest(request, "Failed to fetch balance sheet");
+            LOGGER.errorRequest(request, "Failed to fetch balance sheet", e);
             model.addAttribute("balanceSheet", new BalanceSheet());
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
 import com.google.api.client.util.DateTime;
+import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,7 +40,8 @@ public class StepsToCompleteController extends BaseController {
     }
 
     @PostMapping
-    public String postStepsToComplete(@PathVariable String companyNumber) {
+    public String postStepsToComplete(@PathVariable String companyNumber,
+                                      HttpServletRequest request) {
 
         try {
             String transactionId = transactionService.createTransaction(companyNumber);
@@ -53,7 +55,7 @@ public class StepsToCompleteController extends BaseController {
 
         } catch (ApiErrorResponseException e) {
             // TODO: handle ApiErrorResponseExceptions (SFA-594)
-            LOGGER.error(e);
+            LOGGER.errorRequest(request, "Failed to post steps to complete confirmation");
             return "error";
         }
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -55,7 +55,7 @@ public class StepsToCompleteController extends BaseController {
 
         } catch (ApiErrorResponseException e) {
             // TODO: handle ApiErrorResponseExceptions (SFA-594)
-            LOGGER.errorRequest(request, "Failed to post steps to complete confirmation");
+            LOGGER.errorRequest(request, "Failed to post steps to complete confirmation", e);
             return "error";
         }
     }


### PR DESCRIPTION
Use `errorRequest` to log errors in each controller so logs include the requestId

Resolves SFA-597