### PR TITLE
Add exception handling and update unit tests

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
 
 @Controller
@@ -34,9 +34,10 @@ public class ApprovalController extends BaseController {
 
         try {
             transactionService.closeTransaction(transactionId);
-        } catch (ApiErrorResponseException e) {
-            // TODO: handle ApiErrorResponseExceptions (SFA-594)
+        } catch (ServiceException e) {
+
             LOGGER.errorRequest(request, "Failed to close transaction");
+            return "error";
         }
 
         // TODO: Further implementation when navigation built

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -11,9 +11,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.util.Navigator;
@@ -36,10 +36,10 @@ public class BalanceSheetController extends BaseController {
 
         try {
             model.addAttribute("balanceSheet", balanceSheetService.getBalanceSheet(transactionId, companyAccountsId));
-        } catch (ApiErrorResponseException e) {
-            // TODO: handle ApiErrorResponseExceptions (SFA-594)
+        } catch (ServiceException e) {
+
             LOGGER.errorRequest(request, "Failed to fetch balance sheet");
-            model.addAttribute("balanceSheet", new BalanceSheet());
+            return "error";
         }
 
         return SMALL_FULL_BALANCE_SHEET;
@@ -59,9 +59,10 @@ public class BalanceSheetController extends BaseController {
 
         try {
             balanceSheetService.postBalanceSheet(transactionId, companyAccountsId, balanceSheet);
-        } catch (ApiErrorResponseException e) {
+        } catch (ServiceException e) {
+
             LOGGER.errorRequest(request, "Failed to post balance sheet");
-            return SMALL_FULL_BALANCE_SHEET;
+            return "error";
         }
 
         return Navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -8,10 +8,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccountsService;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
@@ -50,11 +50,10 @@ public class StepsToCompleteController extends BaseController {
             DateTime periodEndOn = companyProfile.getAccounts().getNextAccounts().getPeriodEndOn();
 
             String companyAccountsId = companyAccountsService.createCompanyAccounts(transactionId, periodEndOn);
-
             return Navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
 
-        } catch (ApiErrorResponseException e) {
-            // TODO: handle ApiErrorResponseExceptions (SFA-594)
+        } catch (ServiceException e) {
+
             LOGGER.errorRequest(request, "Failed to post steps to complete confirmation");
             return "error";
         }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/ServiceException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/ServiceException.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.web.accounts.exception;
+
+/**
+ * The class {@code ServiceException} is a form of {@code Exception}
+ * that should be used at the service layer to abstract lower level
+ * exceptions from being propagated up the call stack.
+ */
+public class ServiceException extends Exception {
+
+    /**
+     * Constructs a new {@code ServiceException} with the specified
+     * cause.
+     *
+     * @param cause the cause
+     */
+    public ServiceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/CompanyService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/CompanyService.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.web.accounts.service.company;
 
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
 public interface CompanyService {
 
-    CompanyProfileApi getCompanyProfile(String companyNumber) throws ApiErrorResponseException;
+    CompanyProfileApi getCompanyProfile(String companyNumber) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
@@ -6,6 +6,7 @@ import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 
 @Service
@@ -15,10 +16,19 @@ public class CompanyServiceImpl implements CompanyService {
     ApiClientService apiClientService;
 
     @Override
-    public CompanyProfileApi getCompanyProfile(String companyNumber) throws ApiErrorResponseException {
+    public CompanyProfileApi getCompanyProfile(String companyNumber) throws ServiceException {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
-        return apiClient.company(companyNumber).get();
+        CompanyProfileApi companyProfileApi;
+
+        try {
+            companyProfileApi = apiClient.company(companyNumber).get();
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException(e);
+        }
+
+        return companyProfileApi;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
@@ -1,9 +1,9 @@
 package uk.gov.companieshouse.web.accounts.service.companyaccounts;
 
 import com.google.api.client.util.DateTime;
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
 public interface CompanyAccountsService {
 
-    String createCompanyAccounts(String transactionId, DateTime periodEndOn) throws ApiErrorResponseException;
+    String createCompanyAccounts(String transactionId, DateTime periodEndOn) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccountsService;
 
 @Service
@@ -20,14 +21,20 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
     private static final Pattern COMPANY_ACCOUNTS_ID_MATCHER = Pattern.compile("/company-accounts/(.*)");
 
     @Override
-    public String createCompanyAccounts(String transactionId, DateTime periodEndOn) throws ApiErrorResponseException {
+    public String createCompanyAccounts(String transactionId, DateTime periodEndOn) throws ServiceException {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
         CompanyAccountsApi companyAccounts = new CompanyAccountsApi();
         companyAccounts.setPeriodEndOn(periodEndOn);
 
-        companyAccounts = apiClient.transaction(transactionId).companyAccounts().create(companyAccounts);
+        try {
+            companyAccounts = apiClient.transaction(transactionId).companyAccounts().create(companyAccounts);
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException(e);
+        }
+
         String selfLink = companyAccounts.getLinks().get("self");
 
         Matcher matcher = COMPANY_ACCOUNTS_ID_MATCHER.matcher(selfLink);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/BalanceSheetService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/BalanceSheetService.java
@@ -1,14 +1,13 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull;
 
-
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 
 public interface BalanceSheetService {
 
     BalanceSheet getBalanceSheet(String transactionId, String companyAccountsId)
-            throws ApiErrorResponseException;
+            throws ServiceException;
 
     void postBalanceSheet(String transactionId, String companyAccountsId, BalanceSheet balanceSheet)
-            throws ApiErrorResponseException;
+            throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -1,11 +1,13 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.BalanceSheetTransformer;
@@ -21,14 +23,26 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
 
     @Override
     public BalanceSheet getBalanceSheet(String transactionId, String companyAccountsId)
-            throws ApiErrorResponseException {
+            throws ServiceException {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
-        CurrentPeriodApi currentPeriod = apiClient.transaction(transactionId)
-                                               .companyAccount(companyAccountsId)
-                                               .smallFull()
-                                               .currentPeriod().get();
+
+        CurrentPeriodApi currentPeriod;
+
+        try {
+            currentPeriod = apiClient.transaction(transactionId)
+                .companyAccount(companyAccountsId)
+                .smallFull()
+                .currentPeriod().get();
+        } catch (ApiErrorResponseException e) {
+
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND.value()) {
+                return new BalanceSheet();
+            }
+
+            throw new ServiceException(e);
+        }
 
         //transform API data to web-readable data
         BalanceSheet balanceSheet = transformer.getBalanceSheet(currentPeriod);
@@ -38,15 +52,20 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
 
     @Override
     public void postBalanceSheet(String transactionId, String companyAccountsId, BalanceSheet balanceSheet)
-            throws ApiErrorResponseException {
+            throws ServiceException {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
         CurrentPeriodApi currentPeriod = transformer.getCurrentPeriod(balanceSheet);
 
-        apiClient.transaction(transactionId)
+        try {
+            apiClient.transaction(transactionId)
                 .companyAccount(companyAccountsId)
                 .smallFull()
                 .currentPeriod().create(currentPeriod);
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException(e);
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
@@ -1,11 +1,10 @@
 package uk.gov.companieshouse.web.accounts.service.transaction;
 
-import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
 public interface TransactionService {
 
-    String createTransaction(String companyNumber) throws ApiErrorResponseException;
+    String createTransaction(String companyNumber) throws ServiceException;
 
-    void closeTransaction(String transactionId) throws ApiErrorResponseException;
+    void closeTransaction(String transactionId) throws ServiceException;
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -10,9 +10,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -43,6 +48,8 @@ public class ApprovalControllerTests {
                                                 "/company-accounts/" + COMPANY_ACCOUNTS_ID +
                                                 "/small-full/approval";
 
+    private static final String ERROR_VIEW = "error";
+
     @BeforeEach
     private void setup() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(approvalController).build();
@@ -65,5 +72,17 @@ public class ApprovalControllerTests {
         this.mockMvc.perform(post(APPROVAL_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(APPROVAL_VIEW));
+    }
+
+    @Test
+    @DisplayName("Post approval failure path")
+    void postRequestFailure() throws Exception {
+
+        doThrow(ServiceException.class)
+                .when(transactionService).closeTransaction(anyString());
+
+        this.mockMvc.perform(post(APPROVAL_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 
@@ -97,7 +98,7 @@ public class BalanceSheetControllerTests {
     @DisplayName("Post balance sheet throws ApiErrorResponseException")
     void postRequestThrowsApiErrorResponseException() throws Exception {
 
-        doThrow(ApiErrorResponseException.class)
+        doThrow(ServiceException.class)
                 .when(balanceSheetService).postBalanceSheet(anyString(), anyString(), any(BalanceSheet.class));
 
         this.mockMvc.perform(post(BALANCE_SHEET_PATH))

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -63,6 +63,8 @@ public class BalanceSheetControllerTests {
 
     private static final String BALANCE_SHEET_VIEW = "smallfull/balanceSheet";
 
+    private static final String ERROR_VIEW = "error";
+
     @BeforeEach
     private void setup() {
 
@@ -95,16 +97,15 @@ public class BalanceSheetControllerTests {
     }
 
     @Test
-    @DisplayName("Post balance sheet throws ApiErrorResponseException")
-    void postRequestThrowsApiErrorResponseException() throws Exception {
+    @DisplayName("Post balance sheet failure path")
+    void postRequestFailure() throws Exception {
 
         doThrow(ServiceException.class)
                 .when(balanceSheetService).postBalanceSheet(anyString(), anyString(), any(BalanceSheet.class));
 
         this.mockMvc.perform(post(BALANCE_SHEET_PATH))
                 .andExpect(status().isOk())
-                .andExpect(view().name(BALANCE_SHEET_VIEW))
-                .andExpect(model().attributeExists(BALANCE_SHEET_MODEL_ATTR));
+                .andExpect(view().name(ERROR_VIEW));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.company.CompanyResourceHandler;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,7 +48,7 @@ public class CompanyServiceImplTests {
 
     @Test
     @DisplayName("Get Company Profile - Success Path")
-    void getCompanyProfileSuccess() throws ApiErrorResponseException {
+    void getCompanyProfileSuccess() throws ServiceException, ApiErrorResponseException {
 
         when(companyResourceHandler.get()).thenReturn(new CompanyProfileApi());
 
@@ -62,7 +63,7 @@ public class CompanyServiceImplTests {
 
         when(companyResourceHandler.get()).thenThrow(ApiErrorResponseException.class);
 
-        assertThrows(ApiErrorResponseException.class, () ->
+        assertThrows(ServiceException.class, () ->
                 companyService.getCompanyProfile(COMPANY_NUMBER));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImplTests.java
@@ -23,6 +23,7 @@ import uk.gov.companieshouse.api.handler.transaction.TransactionResourceHandler;
 import uk.gov.companieshouse.api.handler.transaction.companyaccount.CompanyAccountsResourceHandler;
 import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccountsService;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,7 +62,7 @@ public class CompanyAccountsServiceImplTests {
 
     @Test
     @DisplayName("Create Company Accounts - Success Path")
-    void createCompanyAccountSuccess() throws ApiErrorResponseException {
+    void createCompanyAccountSuccess() throws ServiceException, ApiErrorResponseException {
 
         DateTime periodEndOn = new DateTime(new Date());
 
@@ -87,7 +88,7 @@ public class CompanyAccountsServiceImplTests {
         when(companyAccountsResourceHandler.create(any(CompanyAccountsApi.class)))
                 .thenThrow(ApiErrorResponseException.class);
 
-        assertThrows(ApiErrorResponseException.class, () ->
+        assertThrows(ServiceException.class, () ->
                 companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImplTests.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,7 +59,7 @@ public class TransactionServiceImplTests {
     
     @Test
     @DisplayName("Create Transaction - Success Path")
-    void createTransactionSuccess() throws ApiErrorResponseException {
+    void createTransactionSuccess() throws ServiceException, ApiErrorResponseException {
 
         when(apiClient.transactions()).thenReturn(transactionsResourceHandler);
 
@@ -80,12 +81,12 @@ public class TransactionServiceImplTests {
 
         when(transactionsResourceHandler.create(any(Transaction.class))).thenThrow(ApiErrorResponseException.class);
 
-        assertThrows(ApiErrorResponseException.class, () -> transactionService.createTransaction(COMPANY_NUMBER));
+        assertThrows(ServiceException.class, () -> transactionService.createTransaction(COMPANY_NUMBER));
     }
 
     @Test
     @DisplayName("Close Transaction - Success Path")
-    void closeTransactionSuccess() throws ApiErrorResponseException {
+    void closeTransactionSuccess() throws ServiceException, ApiErrorResponseException {
 
         when(apiClient.transaction(TRANSACTION_ID)).thenReturn(transactionResourceHandler);
 
@@ -111,7 +112,7 @@ public class TransactionServiceImplTests {
 
         when(transactionResourceHandler.get()).thenThrow(ApiErrorResponseException.class);
 
-        assertThrows(ApiErrorResponseException.class, () -> transactionService.closeTransaction(TRANSACTION_ID));
+        assertThrows(ServiceException.class, () -> transactionService.closeTransaction(TRANSACTION_ID));
     }
 
     @Test
@@ -129,6 +130,6 @@ public class TransactionServiceImplTests {
 
         doThrow(ApiErrorResponseException.class).when(transactionResourceHandler).update(transaction);
 
-        assertThrows(ApiErrorResponseException.class, () -> transactionService.closeTransaction(TRANSACTION_ID));
+        assertThrows(ServiceException.class, () -> transactionService.closeTransaction(TRANSACTION_ID));
     }
 }


### PR DESCRIPTION
Add suitable exception handling—wrapping lower level service-layer exceptions in a new `ServiceException` checked exception—and update unit tests with failure paths for error page returned to user agent.

Resolves: SFA-594