### PR TITLE
Resolve Sonar Code Smells

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
@@ -4,7 +4,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.web.accounts.CompanyAccountsWebApplication;
 
-public class BaseController {
+public abstract class BaseController {
 
     protected static final Logger LOGGER = LoggerFactory
             .getLogger(CompanyAccountsWebApplication.APPLICATION_NAME_SPACE);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -21,15 +21,14 @@ public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
 
-        if (request.getMethod().equalsIgnoreCase("GET")) {
-            if (modelAndView != null) {
-                Map<String, Object> sessionData = SessionHandler.getSessionDataFromContext();
-                Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
-                if (signInInfo != null) {
-                    Map<String, Object> userProfile = (Map<String, Object>) signInInfo
-                            .get(USER_PROFILE_KEY);
-                    modelAndView.addObject(USER_EMAIL, userProfile.get(EMAIL_KEY));
-                }
+        if (request.getMethod().equalsIgnoreCase("GET") && modelAndView != null) {
+
+            Map<String, Object> sessionData = SessionHandler.getSessionDataFromContext();
+            Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
+            if (signInInfo != null) {
+                Map<String, Object> userProfile = (Map<String, Object>) signInInfo
+                        .get(USER_PROFILE_KEY);
+                modelAndView.addObject(USER_EMAIL, userProfile.get(EMAIL_KEY));
             }
         }
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/CalledUpShareCapitalNotPaid.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/CalledUpShareCapitalNotPaid.java
@@ -2,7 +2,6 @@ package uk.gov.companieshouse.web.accounts.model.smallfull;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.validator.constraints.Range;
 
 @Getter
 @Setter

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -30,10 +30,7 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
                                                .smallFull()
                                                .currentPeriod().get();
 
-        //transform API data to web-readable data
-        BalanceSheet balanceSheet = transformer.getBalanceSheet(currentPeriod);
-
-        return balanceSheet;
+        return transformer.getBalanceSheet(currentPeriod);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.web.accounts.service.transaction;
 
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 
 public interface TransactionService {
 


### PR DESCRIPTION
- Make `BaseController` abstract to prevent instantiation.
- Simplify logic in `UserDetailsInterceptor`.
- Remove unused imports.
- Return the transformer expression in `BalanceSheetServiceImpl`, removing the need for a temporary variable assignment.