### PR TITLE
Add unit test for user details interceptor and interface to support test

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -9,7 +9,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
-import uk.gov.companieshouse.session.handler.SessionHandler;
 import uk.gov.companieshouse.web.accounts.session.SessionService;
 
 @Component

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -3,11 +3,14 @@ package uk.gov.companieshouse.web.accounts.interceptor;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import uk.gov.companieshouse.session.handler.SessionHandler;
+import uk.gov.companieshouse.web.accounts.session.SessionService;
 
 @Component
 public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
@@ -18,12 +21,15 @@ public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
     private static final String USER_PROFILE_KEY = "user_profile";
     private static final String EMAIL_KEY = "email";
 
+    @Autowired
+    SessionService sessionService;
+
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
 
         if (request.getMethod().equalsIgnoreCase("GET") && modelAndView != null) {
 
-            Map<String, Object> sessionData = SessionHandler.getSessionDataFromContext();
+            Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
             Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);
             if (signInInfo != null) {
                 Map<String, Object> userProfile = (Map<String, Object>) signInInfo

--- a/src/main/java/uk/gov/companieshouse/web/accounts/session/SessionService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/session/SessionService.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.web.accounts.session;
+
+import java.util.Map;
+
+/**
+ * The {@code SessionService} interface provides an abstraction that can be
+ * used when testing {@code SessionHandler} static methods, without imposing
+ * the use of a test framework that supports mocking of static methods.
+ */
+public interface SessionService {
+
+    /**
+     * Returns a map comprising data retrieved from the current session.
+     *
+     * @return a map of session data
+     */
+    Map<String, Object> getSessionDataFromContext();
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/session/impl/SessionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/session/impl/SessionServiceImpl.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.web.accounts.session.impl;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.session.handler.SessionHandler;
+import uk.gov.companieshouse.web.accounts.session.SessionService;
+
+import java.util.Map;
+
+@Component
+public class SessionServiceImpl implements SessionService {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<String, Object> getSessionDataFromContext() {
+        return SessionHandler.getSessionDataFromContext();
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/session/impl/SessionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/session/impl/SessionServiceImpl.java
@@ -14,6 +14,7 @@ public class SessionServiceImpl implements SessionService {
      */
     @Override
     public Map<String, Object> getSessionDataFromContext() {
+
         return SessionHandler.getSessionDataFromContext();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
@@ -19,7 +19,10 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 public class UserDetailsInterceptorTests {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
@@ -52,7 +52,7 @@ public class UserDetailsInterceptorTests {
 
     @Test
     @DisplayName("Tests the interceptor adds the user email to the model")
-    public void postHandleForGetRequestSuccess() throws Exception {
+    void postHandleForGetRequestSuccess() throws Exception {
 
         Map<String, Object> userProfile = new HashMap<>();
         userProfile.put(EMAIL_KEY, TEST_EMAIL_ADDRESS);
@@ -73,7 +73,7 @@ public class UserDetailsInterceptorTests {
 
     @Test
     @DisplayName("Tests the interceptor does not add the user email to the model for POST requests")
-    public void postHandleForPostRequestIgnored() throws Exception {
+    void postHandleForPostRequestIgnored() throws Exception {
 
         when(httpServletRequest.getMethod()).thenReturn(HttpMethod.POST.toString());
 
@@ -84,7 +84,7 @@ public class UserDetailsInterceptorTests {
 
     @Test
     @DisplayName("Tests the interceptor does not add the user email to the model if no sign in info is available")
-    public void postHandleForGetRequestWithoutSignInInfoIgnored() throws Exception {
+    void postHandleForGetRequestWithoutSignInInfoIgnored() throws Exception {
 
         Map<String, Object> sessionData = new HashMap<>();
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
@@ -1,0 +1,75 @@
+package uk.gov.companieshouse.web.accounts.interceptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.ModelAndView;
+import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.session.SessionService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserDetailsInterceptorTests {
+
+    private static final String USER_EMAIL = "userEmail";
+
+    private static final String SIGN_IN_KEY = "signin_info";
+    private static final String USER_PROFILE_KEY = "user_profile";
+    private static final String EMAIL_KEY = "email";
+
+    private static final String TEST_EMAIL_ADDRESS = "test_email_address";
+
+    @Mock
+    private HttpServletRequest httpServletRequest;
+
+    @Mock
+    private HttpServletResponse httpServletResponse;
+
+    @Mock
+    private HttpSession session;
+
+    @Mock
+    private ModelAndView modelAndView;
+
+    @Mock
+    private SessionService sessionService;
+
+    @InjectMocks
+    private UserDetailsInterceptor userDetailsInterceptor;
+
+    @Test
+    @DisplayName("Tests the interceptor adds the user email to the model")
+    public void postHandle() throws Exception {
+
+        Map<String, Object> userProfile = new HashMap<>();
+        userProfile.put(EMAIL_KEY, TEST_EMAIL_ADDRESS);
+
+        Map<String, Object> signInInfo = new HashMap<>();
+        signInInfo.put(USER_PROFILE_KEY, userProfile);
+
+        Map<String, Object> sessionData = new HashMap<>();
+        sessionData.put(SIGN_IN_KEY, signInInfo);
+
+        when(sessionService.getSessionDataFromContext()).thenReturn(sessionData);
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.GET.toString());
+
+        userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
+
+        verify(modelAndView, times(1)).addObject(USER_EMAIL, TEST_EMAIL_ADDRESS);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
@@ -19,7 +19,6 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
-import uk.gov.companieshouse.web.accounts.session.SessionService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -33,9 +32,6 @@ public class CompanyServiceImplTests {
 
     @Mock
     private CompanyResourceHandler companyResourceHandler;
-
-    @Mock
-    private SessionService sessionService;
 
     @InjectMocks
     private CompanyService companyService = new CompanyServiceImpl();

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
+import uk.gov.companieshouse.web.accounts.session.SessionService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -32,6 +33,9 @@ public class CompanyServiceImplTests {
 
     @Mock
     private CompanyResourceHandler companyResourceHandler;
+
+    @Mock
+    private SessionService sessionService;
 
     @InjectMocks
     private CompanyService companyService = new CompanyServiceImpl();


### PR DESCRIPTION
This change introduces a unit test for the `UserDetailsInterceptor` class, to improve code coverage, as well as a convenience interface that simplifies testing. The interface is necessary since a static method—`getSessionDataFromContext()`—is being used, and to avoid imposing the use of a test framework for mocking static methods.