### PR TITLE
Add javadoc comment to clarify intention of interface

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/api/ApiClientService.java
@@ -2,6 +2,11 @@ package uk.gov.companieshouse.web.accounts.api;
 
 import uk.gov.companieshouse.api.ApiClient;
 
+/**
+ * The {@code ApiClientService} interface provides an abstraction that can be
+ * used when testing {@code SessionHandler} static methods, without imposing
+ * the use of a test framework that supports mocking of static methods.
+ */
 public interface ApiClientService {
 
     ApiClient getApiClient();


### PR DESCRIPTION
The `ApiClientService` interface was introduced to permit testing of methods that rely on the static `getApiClient()` method provided by the `sdk-manager-java` dependency. This change adds a `Javadoc` comment to make this clear.