### PR TITLE
Update service to support creation of small full accounts and unit test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>2.0.1-rc2</api-sdk-java.version>
+        <api-sdk-java.version>2.0.1-rc3</api-sdk-java.version>
 
         <sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -50,6 +50,9 @@ public class StepsToCompleteController extends BaseController {
             DateTime periodEndOn = companyProfile.getAccounts().getNextAccounts().getPeriodEndOn();
 
             String companyAccountsId = companyAccountsService.createCompanyAccounts(transactionId, periodEndOn);
+
+            companyAccountsService.createSmallFullAccounts(transactionId, companyAccountsId);
+
             return Navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
 
         } catch (ServiceException e) {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
@@ -6,4 +6,6 @@ import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 public interface CompanyAccountsService {
 
     String createCompanyAccounts(String transactionId, DateTime periodEndOn) throws ServiceException;
+
+    void createSmallFullAccounts(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
@@ -42,4 +42,17 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
 
         return matcher.group(1);
     }
+
+    @Override
+    public void createSmallFullAccounts(String transactionId, String companyAccountsId) throws ServiceException {
+
+        ApiClient apiClient = apiClientService.getApiClient();
+
+        try {
+            apiClient.transaction(transactionId).companyAccount(companyAccountsId).smallFull().create();
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException(e);
+        }
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
@@ -141,10 +141,9 @@ public class StepsToCompleteControllerTests {
                 .andExpect(view().name(ERROR_VIEW));
     }
 
-
     @Test
-    @DisplayName("Post steps to complete failure path for company accounts service")
-    void postRequestCompanyAccountsServiceFailure() throws Exception {
+    @DisplayName("Post steps to complete failure path for create company accounts resource")
+    void postRequestCompanyAccountsServiceCreateCompanyAccountsFailure() throws Exception {
 
         when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
 
@@ -169,4 +168,32 @@ public class StepsToCompleteControllerTests {
                 .andExpect(view().name(ERROR_VIEW));
     }
 
+    @Test
+    @DisplayName("Post steps to complete failure path for create small full accounts resource")
+    void postRequestCompanyAccountsServiceCreateSmallFullAccountsFailure() throws Exception {
+
+        when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
+
+        DateTime periodEndOn = new DateTime(new Date());
+
+        NextAccountsApi nextAccounts = new NextAccountsApi();
+        nextAccounts.setPeriodEndOn(periodEndOn);
+
+        CompanyAccountApi companyAccount = new CompanyAccountApi();
+        companyAccount.setNextAccounts(nextAccounts);
+
+        CompanyProfileApi companyProfile = new CompanyProfileApi();
+        companyProfile.setAccounts(companyAccount);
+
+        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
+
+        when(companyAccountsService.createCompanyAccounts(anyString(), any(DateTime.class))).thenReturn("company_accounts_id");
+
+        doThrow(ServiceException.class)
+                .when(companyAccountsService).createSmallFullAccounts(anyString(), anyString());
+
+        this.mockMvc.perform(post(STEPS_TO_COMPLETE_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,6 +105,8 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn)).thenReturn(COMPANY_ACCOUNTS_ID);
 
+        doNothing().when(companyAccountsService).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
         this.mockMvc.perform(post(STEPS_TO_COMPLETE_PATH))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + BALANCE_SHEET_PATH));
@@ -113,6 +116,8 @@ public class StepsToCompleteControllerTests {
         verify(companyService, times(1)).getCompanyProfile(COMPANY_NUMBER);
 
         verify(companyAccountsService, times(1)).createCompanyAccounts(TRANSACTION_ID, periodEndOn);
+
+        verify(companyAccountsService, times(1)).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
     }
 
     @Test


### PR DESCRIPTION
This pull-request introduces the following changes:

* Update `api-sdk-java` dependency version with new `create()` method for small full accounts
* Add service method to support creating small full accounts resource
* Update controller to create small full accounts resource
* Add unit test to cover failure to create resource and update success test to verify new service method is called
