### PR TITLE
Create new api client for each operation to avoid path duplication

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
@@ -45,14 +45,10 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     public void closeTransaction(String transactionId) throws ServiceException {
 
-        ApiClient apiClient = apiClientService.getApiClient();
-
-        Transaction transaction;
-
         try {
-            transaction = apiClient.transaction(transactionId).get();
+            Transaction transaction = apiClientService.getApiClient().transaction(transactionId).get();
             transaction.setStatus(TransactionStatus.CLOSED);
-            apiClient.transaction(transactionId).update(transaction);
+            apiClientService.getApiClient().transaction(transactionId).update(transaction);
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException(e);


### PR DESCRIPTION
Reusing the same `ApiClient` for both the `get()` and `update()` operations was leading to duplicate paths in the URI (e.g. `/transactions/{id}/transactions/{id}`). This change ensures that the correct URI is used and that the transaction is closed successfully.