### PR TITLE
Add Hidden Form Input for Balance Sheet Headers

### DIFF
--- a/src/main/resources/templates/smallfull/balanceSheet.html
+++ b/src/main/resources/templates/smallfull/balanceSheet.html
@@ -33,6 +33,8 @@
                         <div class="column-quarter" style="text-align: center">
                             <h2 class="heading-small">
                                 <span id="currentPeriodHeading" th:text='*{balanceSheetHeadings.currentPeriodHeading}'></span>
+                                <!-- Hidden input for form binding -->
+                                <input th:field="*{balanceSheetHeadings.currentPeriodHeading}" type="hidden">
                             </h2>
                         </div>
                     </div>


### PR DESCRIPTION
Add hidden form input for balance sheet headers. Form binding currently previously failed so that if any binding result errors occurred, the balance sheet headers wouldn't be persisted.