### PR TITLE
Fix UserDetailsInterceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -26,9 +26,8 @@ public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
 
-        if ((request.getMethod().equalsIgnoreCase("GET") ||
-             request.getMethod().equalsIgnoreCase("POST") && !modelAndView.getViewName().startsWith("redirect:"))
-                && modelAndView != null) {
+        if (modelAndView != null && (request.getMethod().equalsIgnoreCase("GET") ||
+             request.getMethod().equalsIgnoreCase("POST") && !modelAndView.getViewName().startsWith("redirect:"))) {
 
             Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
             Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -26,7 +26,9 @@ public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
 
-        if (request.getMethod().equalsIgnoreCase("GET") && modelAndView != null) {
+        if ((request.getMethod().equalsIgnoreCase("GET") ||
+             request.getMethod().equalsIgnoreCase("POST") && !modelAndView.getViewName().startsWith("redirect:"))
+                && modelAndView != null) {
 
             Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
             Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.session.SessionService;
 
 @Component
@@ -27,7 +28,8 @@ public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
 
         if (modelAndView != null && (request.getMethod().equalsIgnoreCase("GET") ||
-             request.getMethod().equalsIgnoreCase("POST") && !modelAndView.getViewName().startsWith("redirect:"))) {
+             request.getMethod().equalsIgnoreCase("POST") &&
+                     !modelAndView.getViewName().startsWith(UrlBasedViewResolver.REDIRECT_URL_PREFIX))) {
 
             Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
             Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptor.java
@@ -28,8 +28,8 @@ public class UserDetailsInterceptor extends HandlerInterceptorAdapter {
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, @Nullable ModelAndView modelAndView) throws Exception {
 
         if (modelAndView != null && (request.getMethod().equalsIgnoreCase("GET") ||
-             request.getMethod().equalsIgnoreCase("POST") &&
-                     !modelAndView.getViewName().startsWith(UrlBasedViewResolver.REDIRECT_URL_PREFIX))) {
+                (request.getMethod().equalsIgnoreCase("POST") &&
+                     !modelAndView.getViewName().startsWith(UrlBasedViewResolver.REDIRECT_URL_PREFIX)))) {
 
             Map<String, Object> sessionData = sessionService.getSessionDataFromContext();
             Map<String, Object> signInInfo = (Map<String, Object>) sessionData.get(SIGN_IN_KEY);

--- a/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/interceptor/UserDetailsInterceptorTests.java
@@ -54,7 +54,7 @@ public class UserDetailsInterceptorTests {
     private UserDetailsInterceptor userDetailsInterceptor;
 
     @Test
-    @DisplayName("Tests the interceptor adds the user email to the model")
+    @DisplayName("Tests the interceptor adds the user email to the model for GET requests")
     void postHandleForGetRequestSuccess() throws Exception {
 
         Map<String, Object> userProfile = new HashMap<>();
@@ -75,10 +75,33 @@ public class UserDetailsInterceptorTests {
     }
 
     @Test
+    @DisplayName("Tests the interceptor adds the user email to the model for POST requests which don't redirect")
+    void postHandleForPostRequestError() throws Exception {
+
+        Map<String, Object> userProfile = new HashMap<>();
+        userProfile.put(EMAIL_KEY, TEST_EMAIL_ADDRESS);
+
+        Map<String, Object> signInInfo = new HashMap<>();
+        signInInfo.put(USER_PROFILE_KEY, userProfile);
+
+        Map<String, Object> sessionData = new HashMap<>();
+        sessionData.put(SIGN_IN_KEY, signInInfo);
+
+        when(sessionService.getSessionDataFromContext()).thenReturn(sessionData);
+        when(httpServletRequest.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(modelAndView.getViewName()).thenReturn("error");
+
+        userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
+
+        verify(modelAndView, times(1)).addObject(USER_EMAIL, TEST_EMAIL_ADDRESS);
+    }
+
+    @Test
     @DisplayName("Tests the interceptor does not add the user email to the model for POST requests")
     void postHandleForPostRequestIgnored() throws Exception {
 
         when(httpServletRequest.getMethod()).thenReturn(HttpMethod.POST.toString());
+        when(modelAndView.getViewName()).thenReturn("redirect:abc");
 
         userDetailsInterceptor.postHandle(httpServletRequest, httpServletResponse, new Object(), modelAndView);
 


### PR DESCRIPTION
Execute user details interceptor for POST requests which don't redirect so that user email is displayed on the error page.