### PR TITLE
Use static css for accounts web app styling

### DIFF
--- a/src/main/resources/static/application.css
+++ b/src/main/resources/static/application.css
@@ -1,0 +1,7158 @@
+@charset "UTF-8";
+.govuk-link, a {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
+@font-face {
+  font-family: "nta";
+  src: url("/assets/fonts/light-2c037cf7e1-v1.eot");
+  src: url("/assets/fonts/light-2c037cf7e1-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/light-f38ad40456-v1.woff2") format("woff2"), url("/assets/fonts/light-458f8ea81c-v1.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+  font-display: fallback;
+}
+
+@font-face {
+  font-family: "nta";
+  src: url("/assets/fonts/bold-fb2676462a-v1.eot");
+  src: url("/assets/fonts/bold-fb2676462a-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/bold-a2452cb66f-v1.woff2") format("woff2"), url("/assets/fonts/bold-f38c792ac2-v1.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+  font-display: fallback;
+}
+
+@font-face {
+  font-family: "ntatabularnumbers";
+  src: url("/assets/fonts/light-tabular-498ea8ffe2-v1.eot");
+  src: url("/assets/fonts/light-tabular-498ea8ffe2-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/light-tabular-851b10ccdd-v1.woff2") format("woff2"), url("/assets/fonts/light-tabular-62cc6f0a28-v1.woff") format("woff");
+  font-weight: normal;
+  font-style: normal;
+  font-display: fallback;
+}
+
+@font-face {
+  font-family: "ntatabularnumbers";
+  src: url("/assets/fonts/bold-tabular-357fdfbcc3-v1.eot");
+  src: url("/assets/fonts/bold-tabular-357fdfbcc3-v1.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/bold-tabular-b89238d840-v1.woff2") format("woff2"), url("/assets/fonts/bold-tabular-784c21afb8-v1.woff") format("woff");
+  font-weight: bold;
+  font-style: normal;
+  font-display: fallback;
+}
+
+@media print {
+  .govuk-link, a {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-link:focus, a:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-link:link, a:link {
+  color: #005ea5;
+}
+
+.govuk-link:visited, a:visited {
+  color: #4c2c92;
+}
+
+.govuk-link:hover, a:hover {
+  color: #2b8cc4;
+}
+
+.govuk-link:active, a:active {
+  color: #2b8cc4;
+}
+
+@media print {
+  .govuk-link[href^="/"]::after, a[href^="/"]::after, .govuk-link[href^="http://"]::after, a[href^="http://"]::after, .govuk-link[href^="https://"]::after, a[href^="https://"]::after {
+    content: " (" attr(href) ")";
+    font-size: 90%;
+    word-wrap: break-word;
+  }
+}
+
+.govuk-link--muted:link, .govuk-link--muted:visited, .govuk-link--muted:hover, .govuk-link--muted:active {
+  color: #6f777b;
+}
+
+.govuk-link--muted:focus {
+  color: #0b0c0c;
+}
+
+.govuk-link--muted:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-link--muted:link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-link--text-colour:link, .govuk-link--text-colour:visited, .govuk-link--text-colour:hover, .govuk-link--text-colour:active, .govuk-link--text-colour:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-link--text-colour:link, .govuk-link--text-colour:visited, .govuk-link--text-colour:hover, .govuk-link--text-colour:active, .govuk-link--text-colour:focus {
+    color: #000000;
+  }
+}
+
+.govuk-link--text-colour:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-link--text-colour:link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-link--no-visited-state:visited {
+  color: #005ea5;
+}
+
+.govuk-list {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  margin-top: 0;
+  margin-bottom: 15px;
+  padding-left: 0;
+  list-style-type: none;
+}
+
+@media print {
+  .govuk-list {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-list {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-list {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-list {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-list {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-list .govuk-list {
+  margin-top: 10px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-list > li {
+    margin-bottom: 5px;
+  }
+}
+
+.govuk-list a:link {
+  color: #005ea5;
+}
+
+.govuk-list a:visited {
+  color: #4c2c92;
+}
+
+.govuk-list a:hover {
+  color: #2b8cc4;
+}
+
+.govuk-list a:active {
+  color: #2b8cc4;
+}
+
+.govuk-list--bullet {
+  padding-left: 20px;
+  list-style-type: disc;
+}
+
+.govuk-list--number {
+  padding-left: 20px;
+  list-style-type: decimal;
+}
+
+.govuk-template {
+  background-color: #dee0e2;
+}
+
+.govuk-template__body {
+  margin: 0;
+  background-color: #ffffff;
+}
+
+.govuk-heading-xl {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1.09375;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 30px;
+}
+
+@media print {
+  .govuk-heading-xl {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-heading-xl {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-xl {
+    font-size: 48px;
+    line-height: 1.04167;
+  }
+}
+
+@media print {
+  .govuk-heading-xl {
+    font-size: 32pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-xl {
+    margin-bottom: 50px;
+  }
+}
+
+.govuk-heading-l {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.04167;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+@media print {
+  .govuk-heading-l {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-heading-l {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-l {
+    font-size: 36px;
+    line-height: 1.11111;
+  }
+}
+
+@media print {
+  .govuk-heading-l {
+    font-size: 24pt;
+    line-height: 1.05;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-l {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-heading-m {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.11111;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-heading-m {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-heading-m {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-m {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-heading-m {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-m {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-heading-s {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-heading-s {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-heading-s {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-s {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-heading-s {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-heading-s {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-caption-xl {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.11111;
+  display: block;
+  margin-bottom: 5px;
+  color: #6f777b;
+}
+
+@media print {
+  .govuk-caption-xl {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-caption-xl {
+    font-size: 27px;
+    line-height: 1.11111;
+  }
+}
+
+@media print {
+  .govuk-caption-xl {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-caption-l {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.11111;
+  display: block;
+  margin-bottom: 5px;
+  color: #6f777b;
+}
+
+@media print {
+  .govuk-caption-l {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-caption-l {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-caption-l {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-caption-l {
+    margin-bottom: 0;
+  }
+}
+
+.govuk-caption-m {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+  color: #6f777b;
+}
+
+@media print {
+  .govuk-caption-m {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-caption-m {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-caption-m {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-body-l, .govuk-body-lead {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.11111;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+@media print {
+  .govuk-body-l, .govuk-body-lead {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-body-l, .govuk-body-lead {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-l, .govuk-body-lead {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-body-l, .govuk-body-lead {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-l, .govuk-body-lead {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-body-m, .govuk-body, p {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-body-m, .govuk-body, p {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-body-m, .govuk-body, p {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-m, .govuk-body, p {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-body-m, .govuk-body, p {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-m, .govuk-body, p {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-body-s {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-body-s {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-body-s {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-s {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-body-s {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-s {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-body-xs {
+  color: #0b0c0c;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 1.25;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-body-xs {
+    color: #000000;
+  }
+}
+
+@media print {
+  .govuk-body-xs {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-xs {
+    font-size: 14px;
+    line-height: 1.42857;
+  }
+}
+
+@media print {
+  .govuk-body-xs {
+    font-size: 12pt;
+    line-height: 1.2;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-xs {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-body-l + .govuk-heading-l, .govuk-body-lead + .govuk-heading-l {
+  padding-top: 5px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-l + .govuk-heading-l, .govuk-body-lead + .govuk-heading-l {
+    padding-top: 10px;
+  }
+}
+
+.govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l, p + .govuk-heading-l,
+.govuk-body-s + .govuk-heading-l,
+.govuk-list + .govuk-heading-l {
+  padding-top: 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l, p + .govuk-heading-l,
+  .govuk-body-s + .govuk-heading-l,
+  .govuk-list + .govuk-heading-l {
+    padding-top: 20px;
+  }
+}
+
+.govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m, p + .govuk-heading-m,
+.govuk-body-s + .govuk-heading-m,
+.govuk-list + .govuk-heading-m,
+.govuk-body-m + .govuk-heading-s,
+.govuk-body + .govuk-heading-s,
+p + .govuk-heading-s,
+.govuk-body-s + .govuk-heading-s,
+.govuk-list + .govuk-heading-s {
+  padding-top: 5px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m, p + .govuk-heading-m,
+  .govuk-body-s + .govuk-heading-m,
+  .govuk-list + .govuk-heading-m,
+  .govuk-body-m + .govuk-heading-s,
+  .govuk-body + .govuk-heading-s,
+  p + .govuk-heading-s,
+  .govuk-body-s + .govuk-heading-s,
+  .govuk-list + .govuk-heading-s {
+    padding-top: 10px;
+  }
+}
+
+.govuk-section-break {
+  margin: 0;
+  border: 0;
+  height: 0;
+}
+
+.govuk-section-break--xl {
+  margin-top: 30px;
+  margin-bottom: 30px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-section-break--xl {
+    margin-top: 50px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-section-break--xl {
+    margin-bottom: 50px;
+  }
+}
+
+.govuk-section-break--l {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-section-break--l {
+    margin-top: 30px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-section-break--l {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-section-break--m {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-section-break--m {
+    margin-top: 20px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-section-break--m {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-section-break--visible {
+  border-bottom: 1px solid #bfc1c3;
+}
+
+.govuk-form-group {
+  margin-bottom: 20px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-form-group {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-form-group .govuk-form-group:last-of-type {
+  margin-bottom: 0;
+}
+
+.govuk-form-group--error {
+  padding-left: 15px;
+  border-left: 5px solid #b10e1e;
+}
+
+.govuk-form-group--error .govuk-form-group {
+  padding: 0;
+  border: 0;
+}
+
+.govuk-grid-row {
+  margin-right: -15px;
+  margin-left: -15px;
+}
+
+.govuk-grid-row:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.govuk-grid-column-one-quarter {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-grid-column-one-quarter {
+    width: 25%;
+    float: left;
+  }
+}
+
+.govuk-grid-column-one-third {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-grid-column-one-third {
+    width: 33.3333%;
+    float: left;
+  }
+}
+
+.govuk-grid-column-one-half {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-grid-column-one-half {
+    width: 50%;
+    float: left;
+  }
+}
+
+.govuk-grid-column-two-thirds {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-grid-column-two-thirds {
+    width: 66.6666%;
+    float: left;
+  }
+}
+
+.govuk-grid-column-three-quarters {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-grid-column-three-quarters {
+    width: 75%;
+    float: left;
+  }
+}
+
+.govuk-grid-column-full {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-grid-column-full {
+    width: 100%;
+    float: left;
+  }
+}
+
+.govuk-main-wrapper {
+  padding-top: 20px;
+  padding-bottom: 20px;
+  display: block;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-main-wrapper {
+    padding-top: 30px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-main-wrapper {
+    padding-bottom: 30px;
+  }
+}
+
+.govuk-main-wrapper--l {
+  padding-top: 30px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-main-wrapper--l {
+    padding-top: 50px;
+  }
+}
+
+.govuk-width-container {
+  max-width: 960px;
+  margin: 0 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-width-container {
+    margin: 0 30px;
+  }
+}
+
+@media (min-width: 1020px) {
+  .govuk-width-container {
+    margin: 0 auto;
+  }
+}
+
+.govuk-back-link {
+  font-size: 14px;
+  line-height: 1.14286;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: inline-block;
+  position: relative;
+  margin-top: 15px;
+  margin-bottom: 15px;
+  padding-left: 14px;
+  border-bottom: 1px solid #0b0c0c;
+  text-decoration: none;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-back-link {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-back-link {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+@media print {
+  .govuk-back-link {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-back-link:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-back-link:link, .govuk-back-link:visited, .govuk-back-link:hover, .govuk-back-link:active, .govuk-back-link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-back-link:link, .govuk-back-link:visited, .govuk-back-link:hover, .govuk-back-link:active, .govuk-back-link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-back-link:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-back-link:link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-back-link:before {
+  display: block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  -webkit-clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+  clip-path: polygon(0% 50%, 100% 100%, 100% 0%);
+  border-width: 5px 6px 5px 0;
+  border-right-color: inherit;
+  content: "";
+  position: absolute;
+  top: -1px;
+  bottom: 1px;
+  left: 0;
+  margin: auto;
+}
+
+.govuk-back-link:before {
+  top: -1px;
+  bottom: 1px;
+}
+
+.govuk-breadcrumbs {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  color: #0b0c0c;
+  margin-top: 15px;
+  margin-bottom: 10px;
+}
+
+@media print {
+  .govuk-breadcrumbs {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-breadcrumbs {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-breadcrumbs {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+@media print {
+  .govuk-breadcrumbs {
+    color: #000000;
+  }
+}
+
+.govuk-breadcrumbs__list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.govuk-breadcrumbs__list:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.govuk-breadcrumbs__list-item {
+  display: inline-block;
+  position: relative;
+  margin-bottom: 5px;
+  margin-left: 10px;
+  padding-left: 15.655px;
+  float: left;
+}
+
+.govuk-breadcrumbs__list-item:before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -1px;
+  bottom: 1px;
+  left: -3.31px;
+  width: 7px;
+  height: 7px;
+  margin: auto 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+  border: solid;
+  border-width: 1px 1px 0 0;
+  border-color: #6f777b;
+}
+
+.govuk-breadcrumbs__list-item:first-child {
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.govuk-breadcrumbs__list-item:first-child:before {
+  content: none;
+  display: none;
+}
+
+.govuk-breadcrumbs__link {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@media print {
+  .govuk-breadcrumbs__link {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-breadcrumbs__link:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-breadcrumbs__link:link, .govuk-breadcrumbs__link:visited, .govuk-breadcrumbs__link:hover, .govuk-breadcrumbs__link:active, .govuk-breadcrumbs__link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-breadcrumbs__link:link, .govuk-breadcrumbs__link:visited, .govuk-breadcrumbs__link:hover, .govuk-breadcrumbs__link:active, .govuk-breadcrumbs__link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-breadcrumbs__link:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-breadcrumbs__link:link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-button {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.1875;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  margin-bottom: 22px;
+  padding: 7px 10px;
+  border: 2px solid transparent;
+  border-radius: 0;
+  color: #ffffff;
+  background-color: #00823b;
+  -webkit-box-shadow: 0 2px 0 #003618;
+  box-shadow: 0 2px 0 #003618;
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none;
+}
+
+@media print {
+  .govuk-button {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-button {
+    font-size: 19px;
+    line-height: 1;
+  }
+}
+
+@media print {
+  .govuk-button {
+    font-size: 14pt;
+    line-height: 19px;
+  }
+}
+
+.govuk-button:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-button {
+    margin-bottom: 32px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-button {
+    width: auto;
+  }
+}
+
+.govuk-button:link, .govuk-button:visited, .govuk-button:active, .govuk-button:hover {
+  color: #ffffff;
+  text-decoration: none;
+}
+
+.govuk-button:link:focus {
+  color: #ffffff;
+}
+
+.govuk-button::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.govuk-button:hover, .govuk-button:focus {
+  background-color: #00692f;
+}
+
+.govuk-button:active {
+  top: 2px;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+
+.govuk-button::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -4px;
+  left: -2px;
+  background: transparent;
+}
+
+.govuk-button:active::before {
+  top: -4px;
+}
+
+.govuk-button--disabled,
+.govuk-button[disabled="disabled"],
+.govuk-button[disabled] {
+  opacity: 0.5;
+  background: #00823b;
+}
+
+.govuk-button--disabled:hover,
+.govuk-button[disabled="disabled"]:hover,
+.govuk-button[disabled]:hover {
+  background-color: #00823b;
+  cursor: default;
+}
+
+.govuk-button--disabled:focus,
+.govuk-button[disabled="disabled"]:focus,
+.govuk-button[disabled]:focus {
+  outline: none;
+}
+
+.govuk-button--disabled:active,
+.govuk-button[disabled="disabled"]:active,
+.govuk-button[disabled]:active {
+  top: 0;
+  -webkit-box-shadow: 0 2px 0 #003618;
+  box-shadow: 0 2px 0 #003618;
+}
+
+.govuk-button--start {
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1;
+  min-height: auto;
+  padding-top: 8px;
+  padding-right: 40px;
+  padding-bottom: 8px;
+  padding-left: 15px;
+  background-image: url("/assets/images/icon-pointer.png");
+  background-repeat: no-repeat;
+  background-position: 100% 50%;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-button--start {
+    font-size: 24px;
+    line-height: 1;
+  }
+}
+
+@media print {
+  .govuk-button--start {
+    font-size: 18pt;
+    line-height: 1;
+  }
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+  .govuk-button--start {
+    background-image: url("/assets/images/icon-pointer-2x.png");
+    background-size: 30px 19px;
+  }
+}
+
+.govuk-button {
+  padding-top: 9px;
+  padding-bottom: 6px;
+}
+
+.govuk-button--start {
+  padding-top: 9px;
+  padding-bottom: 6px;
+}
+
+.govuk-error-message {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+  margin-bottom: 15px;
+  clear: both;
+  color: #b10e1e;
+}
+
+@media print {
+  .govuk-error-message {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-message {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-error-message {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.govuk-fieldset:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.govuk-fieldset__legend {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  display: table;
+  max-width: 100%;
+  margin-bottom: 10px;
+  padding: 0;
+  overflow: hidden;
+  white-space: normal;
+}
+
+@media print {
+  .govuk-fieldset__legend {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-fieldset__legend {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-fieldset__legend {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-fieldset__legend {
+    color: #000000;
+  }
+}
+
+.govuk-fieldset__legend--xl {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1.09375;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-fieldset__legend--xl {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-fieldset__legend--xl {
+    font-size: 48px;
+    line-height: 1.04167;
+  }
+}
+
+@media print {
+  .govuk-fieldset__legend--xl {
+    font-size: 32pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-fieldset__legend--l {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.04167;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-fieldset__legend--l {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-fieldset__legend--l {
+    font-size: 36px;
+    line-height: 1.11111;
+  }
+}
+
+@media print {
+  .govuk-fieldset__legend--l {
+    font-size: 24pt;
+    line-height: 1.05;
+  }
+}
+
+.govuk-fieldset__legend--m {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.11111;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-fieldset__legend--m {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-fieldset__legend--m {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-fieldset__legend--m {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-fieldset__legend--s {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+@media print {
+  .govuk-fieldset__legend--s {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-fieldset__legend--s {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-fieldset__legend--s {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-fieldset__heading {
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+.govuk-hint {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+  margin-bottom: 15px;
+  color: #6f777b;
+}
+
+@media print {
+  .govuk-hint {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-hint {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-hint {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
+  margin-bottom: 10px;
+}
+
+.govuk-fieldset__legend:not(.govuk-fieldset__legend--m):not(.govuk-fieldset__legend--l):not(.govuk-fieldset__legend--xl) + .govuk-hint {
+  margin-bottom: 10px;
+}
+
+.govuk-fieldset__legend + .govuk-hint,
+.govuk-fieldset__legend + .govuk-hint {
+  margin-top: -5px;
+}
+
+.govuk-label {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  display: block;
+  margin-bottom: 5px;
+}
+
+@media print {
+  .govuk-label {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-label {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-label {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-label {
+    color: #000000;
+  }
+}
+
+.govuk-label--xl {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1.09375;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-label--xl {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-label--xl {
+    font-size: 48px;
+    line-height: 1.04167;
+  }
+}
+
+@media print {
+  .govuk-label--xl {
+    font-size: 32pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-label--l {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.04167;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-label--l {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-label--l {
+    font-size: 36px;
+    line-height: 1.11111;
+  }
+}
+
+@media print {
+  .govuk-label--l {
+    font-size: 24pt;
+    line-height: 1.05;
+  }
+}
+
+.govuk-label--m {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.11111;
+  margin-bottom: 10px;
+}
+
+@media print {
+  .govuk-label--m {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-label--m {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-label--m {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-label--s {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+@media print {
+  .govuk-label--s {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-label--s {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-label--s {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-label-wrapper {
+  margin: 0;
+}
+
+.govuk-checkboxes__item {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+  position: relative;
+  min-height: 40px;
+  margin-bottom: 10px;
+  padding: 0 0 0 40px;
+  clear: left;
+}
+
+@media print {
+  .govuk-checkboxes__item {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-checkboxes__item {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-checkboxes__item {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-checkboxes__item:last-child,
+.govuk-checkboxes__item:last-of-type {
+  margin-bottom: 0;
+}
+
+.govuk-checkboxes__input {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  margin: 0;
+  opacity: 0;
+}
+
+.govuk-checkboxes__label {
+  display: inline-block;
+  margin-bottom: 0;
+  padding: 8px 15px 5px;
+  cursor: pointer;
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+}
+
+.govuk-checkboxes__hint {
+  display: block;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.govuk-checkboxes__input + .govuk-checkboxes__label::before {
+  content: "";
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  border: 2px solid currentColor;
+  background: transparent;
+}
+
+.govuk-checkboxes__input + .govuk-checkboxes__label::after {
+  content: "";
+  position: absolute;
+  top: 11px;
+  left: 9px;
+  width: 18px;
+  height: 7px;
+  -webkit-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  border: solid;
+  border-width: 0 0 5px 5px;
+  border-top-color: transparent;
+  opacity: 0;
+  background: transparent;
+}
+
+.govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  outline: 3px solid transparent;
+  outline-offset: 3px;
+  -webkit-box-shadow: 0 0 0 3px #ffbf47;
+  box-shadow: 0 0 0 3px #ffbf47;
+}
+
+.govuk-checkboxes__input:checked + .govuk-checkboxes__label::after {
+  opacity: 1;
+}
+
+.govuk-checkboxes__input:disabled,
+.govuk-checkboxes__input:disabled + .govuk-checkboxes__label {
+  cursor: default;
+}
+
+.govuk-checkboxes__input:disabled + .govuk-checkboxes__label {
+  opacity: .5;
+}
+
+.govuk-checkboxes__conditional {
+  margin-bottom: 15px;
+  margin-left: 18px;
+  padding-left: 33px;
+  border-left: 4px solid #bfc1c3;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-checkboxes__conditional {
+    margin-bottom: 20px;
+  }
+}
+
+.js-enabled .govuk-checkboxes__conditional--hidden {
+  display: none;
+}
+
+.govuk-checkboxes__conditional > :last-child {
+  margin-bottom: 0;
+}
+
+.govuk-input {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  height: 40px;
+  margin-top: 0;
+  padding: 5px;
+  border: 2px solid #0b0c0c;
+  border-radius: 0;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+@media print {
+  .govuk-input {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-input {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-input {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-input:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+.govuk-input::-webkit-outer-spin-button,
+.govuk-input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+
+.govuk-input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.govuk-input--error {
+  border: 4px solid #b10e1e;
+}
+
+.govuk-input--width-30 {
+  max-width: 59ex;
+}
+
+.govuk-input--width-20 {
+  max-width: 41ex;
+}
+
+.govuk-input--width-10 {
+  max-width: 23ex;
+}
+
+.govuk-input--width-5 {
+  max-width: 10.8ex;
+}
+
+.govuk-input--width-4 {
+  max-width: 9ex;
+}
+
+.govuk-input--width-3 {
+  max-width: 7.2ex;
+}
+
+.govuk-input--width-2 {
+  max-width: 5.4ex;
+}
+
+.govuk-date-input {
+  font-size: 0;
+}
+
+.govuk-date-input:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.govuk-date-input__item {
+  display: inline-block;
+  margin-right: 20px;
+  margin-bottom: 0;
+}
+
+.govuk-date-input__label {
+  display: block;
+}
+
+.govuk-date-input__input {
+  margin-bottom: 0;
+}
+
+.govuk-details {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  margin-bottom: 20px;
+  display: block;
+}
+
+@media print {
+  .govuk-details {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-details {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-details {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-details {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-details {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-details__summary {
+  display: inline-block;
+  position: relative;
+  margin-bottom: 5px;
+  padding-left: 25px;
+  color: #005ea5;
+  cursor: pointer;
+}
+
+.govuk-details__summary-text {
+  text-decoration: underline;
+}
+
+.govuk-details__summary:hover {
+  color: #2b8cc4;
+}
+
+.govuk-details__summary:focus {
+  outline: 4px solid #ffbf47;
+  outline-offset: -1px;
+  background: #ffbf47;
+}
+
+.govuk-details__summary::-webkit-details-marker {
+  display: none;
+}
+
+.govuk-details__summary:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  display: block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  -webkit-clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+  clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+  border-width: 7px 0 7px 12.124px;
+  border-left-color: inherit;
+}
+
+.govuk-details[open] > .govuk-details__summary:before {
+  display: block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  -webkit-clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+  clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+  border-width: 12.124px 7px 0 7px;
+  border-top-color: inherit;
+}
+
+.govuk-details__text {
+  padding: 15px;
+  padding-left: 20px;
+  border-left: 5px solid #bfc1c3;
+}
+
+.govuk-details__text p {
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+.govuk-details__text > :last-child {
+  margin-bottom: 0;
+}
+
+.govuk-error-summary {
+  color: #0b0c0c;
+  padding: 15px;
+  margin-bottom: 30px;
+  border: 4px solid #b10e1e;
+}
+
+@media print {
+  .govuk-error-summary {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary {
+    padding: 20px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary {
+    margin-bottom: 50px;
+  }
+}
+
+.govuk-error-summary:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary {
+    border: 5px solid #b10e1e;
+  }
+}
+
+.govuk-error-summary__title {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.11111;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media print {
+  .govuk-error-summary__title {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary__title {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-error-summary__title {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary__title {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-error-summary__body {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+@media print {
+  .govuk-error-summary__body {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary__body {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-error-summary__body {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-error-summary__body p {
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-error-summary__body p {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-error-summary__list {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.govuk-error-summary__list a {
+  font-weight: 700;
+}
+
+.govuk-error-summary__list a:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-error-summary__list a:link, .govuk-error-summary__list a:visited, .govuk-error-summary__list a:hover, .govuk-error-summary__list a:active, .govuk-error-summary__list a:focus {
+  color: #b10e1e;
+  text-decoration: underline;
+}
+
+.govuk-error-summary__list a:link:focus {
+  color: #b10e1e;
+}
+
+.govuk-file-upload {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-file-upload {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-file-upload {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-file-upload {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-file-upload {
+    color: #000000;
+  }
+}
+
+.govuk-file-upload:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+.govuk-file-upload--error {
+  border: 4px solid #b10e1e;
+}
+
+.govuk-footer {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  padding-top: 25px;
+  padding-bottom: 15px;
+  border-top: 1px solid #a1acb2;
+  color: #454a4c;
+  background: #dee0e2;
+}
+
+@media print {
+  .govuk-footer {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-footer {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-footer {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-footer {
+    padding-top: 40px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-footer {
+    padding-bottom: 25px;
+  }
+}
+
+.govuk-footer__link:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-footer__link:link, .govuk-footer__link:visited {
+  color: #454a4c;
+}
+
+.govuk-footer__link:hover, .govuk-footer__link:active {
+  color: #171819;
+}
+
+.govuk-footer__link:focus {
+  color: #0b0c0c;
+}
+
+.govuk-footer__link:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-footer__link:link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-footer__section-break {
+  margin: 0;
+  margin-bottom: 30px;
+  border: 0;
+  border-bottom: 1px solid #bfc1c3;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-footer__section-break {
+    margin-bottom: 50px;
+  }
+}
+
+.govuk-footer__meta {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: -15px;
+  margin-left: -15px;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-align: end;
+  -ms-flex-align: end;
+  align-items: flex-end;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.govuk-footer__meta-item {
+  margin-right: 15px;
+  margin-bottom: 25px;
+  margin-left: 15px;
+}
+
+.govuk-footer__meta-item--grow {
+  -webkit-box-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+@media (max-width: 40.0525em) {
+  .govuk-footer__meta-item--grow {
+    -ms-flex-preferred-size: 320px;
+    flex-basis: 320px;
+  }
+}
+
+.govuk-footer__licence-logo {
+  display: inline-block;
+  margin-right: 10px;
+  vertical-align: top;
+}
+
+@media (max-width: 48.0525em) {
+  .govuk-footer__licence-logo {
+    margin-bottom: 15px;
+  }
+}
+
+.govuk-footer__licence-description {
+  display: inline-block;
+}
+
+.govuk-footer__copyright-logo {
+  display: inline-block;
+  min-width: 125px;
+  padding-top: 112px;
+  background-image: url("/assets/images/govuk-crest.png");
+  background-repeat: no-repeat;
+  background-position: 50% 0%;
+  background-size: 125px 102px;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min--moz-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2), only screen and (min-resolution: 192dpi), only screen and (min-resolution: 2dppx) {
+  .govuk-footer__copyright-logo {
+    background-image: url("/assets/images/govuk-crest-2x.png");
+  }
+}
+
+.govuk-footer__inline-list {
+  margin-top: 0;
+  margin-bottom: 15px;
+  padding: 0;
+}
+
+.govuk-footer__inline-list-item {
+  display: inline-block;
+  margin-right: 15px;
+  margin-bottom: 5px;
+}
+
+.govuk-footer__heading {
+  margin-bottom: 25px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #bfc1c3;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-footer__heading {
+    margin-bottom: 40px;
+  }
+}
+
+@media (max-width: 40.0525em) {
+  .govuk-footer__heading {
+    padding-bottom: 10px;
+  }
+}
+
+.govuk-footer__navigation {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: -15px;
+  margin-left: -15px;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+.govuk-footer__section {
+  display: inline-block;
+  margin-right: 15px;
+  margin-bottom: 30px;
+  margin-left: 15px;
+  vertical-align: top;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+}
+
+@media (max-width: 48.0525em) {
+  .govuk-footer__section {
+    -ms-flex-preferred-size: 200px;
+    flex-basis: 200px;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .govuk-footer__section:first-child {
+    -webkit-box-flex: 2;
+    -ms-flex-positive: 2;
+    flex-grow: 2;
+  }
+}
+
+.govuk-footer__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  -webkit-column-gap: 30px;
+  column-gap: 30px;
+}
+
+@media (min-width: 48.0625em) {
+  .govuk-footer__list--columns-2 {
+    -webkit-column-count: 2;
+    column-count: 2;
+  }
+  .govuk-footer__list--columns-3 {
+    -webkit-column-count: 3;
+    column-count: 3;
+  }
+}
+
+.govuk-footer__list-item {
+  margin-bottom: 15px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-footer__list-item {
+    margin-bottom: 20px;
+  }
+}
+
+.govuk-footer__list-item:last-child {
+  margin-bottom: 0;
+}
+
+.govuk-header {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  border-bottom: 10px solid #ffffff;
+  color: #ffffff;
+  background: #0b0c0c;
+}
+
+@media print {
+  .govuk-header {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-header {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.govuk-header__container--full-width {
+  padding: 0 15px;
+  border-color: #005ea5;
+}
+
+.govuk-header__container--full-width .govuk-header__menu-button {
+  right: 15px;
+}
+
+.govuk-header__container {
+  position: relative;
+  margin-bottom: -10px;
+  padding-top: 10px;
+  border-bottom: 10px solid #005ea5;
+}
+
+.govuk-header__container:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.govuk-header__logotype {
+  margin-right: 5px;
+}
+
+.govuk-header__logotype-crown {
+  margin-right: 1px;
+  fill: currentColor;
+  vertical-align: middle;
+}
+
+.govuk-header__logotype-crown-fallback-image {
+  width: 36px;
+  height: 32px;
+  border: 0;
+  vertical-align: middle;
+}
+
+.govuk-header__product-name {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.11111;
+}
+
+@media print {
+  .govuk-header__product-name {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__product-name {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-header__product-name {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-header__link {
+  text-decoration: none;
+}
+
+.govuk-header__link:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-header__link:link, .govuk-header__link:visited {
+  color: #ffffff;
+}
+
+.govuk-header__link:hover {
+  text-decoration: underline;
+}
+
+.govuk-header__link:focus {
+  color: #0b0c0c;
+}
+
+.govuk-header__link:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-header__link:link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-header__link--homepage {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  display: inline-block;
+  font-size: 30px;
+  line-height: 30px;
+}
+
+@media print {
+  .govuk-header__link--homepage {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-header__link--homepage:link, .govuk-header__link--homepage:visited {
+  text-decoration: none;
+}
+
+.govuk-header__link--homepage:hover, .govuk-header__link--homepage:active {
+  margin-bottom: -1px;
+  border-bottom: 1px solid;
+}
+
+.govuk-header__link--service-name {
+  display: inline-block;
+  margin-bottom: 10px;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.11111;
+}
+
+@media print {
+  .govuk-header__link--service-name {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__link--service-name {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-header__link--service-name {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-header__logo {
+  margin-bottom: 10px;
+  padding-right: 50px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__logo {
+    margin-bottom: 10px;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .govuk-header__logo {
+    width: 33.33%;
+    padding-right: 0;
+    float: left;
+    vertical-align: top;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .govuk-header__content {
+    width: 66.66%;
+    float: left;
+  }
+}
+
+.govuk-header__menu-button {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  display: none;
+  position: absolute;
+  top: 20px;
+  right: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: #ffffff;
+  background: none;
+}
+
+@media print {
+  .govuk-header__menu-button {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__menu-button {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-header__menu-button {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.govuk-header__menu-button:hover {
+  text-decoration: underline;
+}
+
+.govuk-header__menu-button::after {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  -webkit-clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+  clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+  border-width: 8.66px 5px 0 5px;
+  border-top-color: inherit;
+  content: "";
+  margin-left: 5px;
+}
+
+.govuk-header__menu-button:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__menu-button {
+    top: 15px;
+  }
+}
+
+.govuk-header__menu-button--open::after {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  -webkit-clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+  border-width: 0 5px 8.66px 5px;
+  border-bottom-color: inherit;
+}
+
+.govuk-header__navigation {
+  margin-bottom: 10px;
+  display: block;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__navigation {
+    margin-bottom: 10px;
+  }
+}
+
+.js-enabled .govuk-header__menu-button {
+  display: block;
+}
+
+@media (min-width: 48.0625em) {
+  .js-enabled .govuk-header__menu-button {
+    display: none;
+  }
+}
+
+.js-enabled .govuk-header__navigation {
+  display: none;
+}
+
+@media (min-width: 48.0625em) {
+  .js-enabled .govuk-header__navigation {
+    display: block;
+  }
+}
+
+.js-enabled .govuk-header__navigation--open {
+  display: block;
+}
+
+@media (min-width: 48.0625em) {
+  .govuk-header__navigation--end {
+    margin: 0;
+    padding: 5px 0;
+    text-align: right;
+  }
+}
+
+.govuk-header__navigation--no-service-name {
+  padding-top: 40px;
+}
+
+.govuk-header__navigation-item {
+  padding: 10px 0;
+  border-bottom: 1px solid #2e3133;
+}
+
+@media (min-width: 48.0625em) {
+  .govuk-header__navigation-item {
+    display: inline-block;
+    margin-right: 15px;
+    padding: 5px 0;
+    border: 0;
+  }
+}
+
+.govuk-header__navigation-item a {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.14286;
+  white-space: nowrap;
+}
+
+@media print {
+  .govuk-header__navigation-item a {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-header__navigation-item a {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-header__navigation-item a {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.govuk-header__navigation-item--active a:link, .govuk-header__navigation-item--active a:hover, .govuk-header__navigation-item--active a:visited {
+  color: #1d8feb;
+}
+
+.govuk-header__navigation-item:last-child {
+  margin-right: 0;
+}
+
+@media print {
+  .govuk-header {
+    border-bottom-width: 0;
+    color: #0b0c0c;
+    background: transparent;
+  }
+  .govuk-header__logotype-crown-fallback-image {
+    display: none;
+  }
+  .govuk-header__link:link, .govuk-header__link:visited {
+    color: #0b0c0c;
+  }
+  .govuk-header__link:after {
+    display: none;
+  }
+}
+
+.govuk-header__logotype-crown,
+.govuk-header__logotype-crown-fallback-image {
+  position: relative;
+  top: -4px;
+}
+
+.govuk-header {
+  padding-top: 3px;
+}
+
+.govuk-inset-text {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  padding: 15px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  clear: both;
+  border-left: 10px solid #bfc1c3;
+}
+
+@media print {
+  .govuk-inset-text {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-inset-text {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-inset-text {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-inset-text {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-inset-text {
+    margin-top: 30px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-inset-text {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-inset-text :first-child {
+  margin-top: 0;
+}
+
+.govuk-inset-text :only-child,
+.govuk-inset-text :last-child {
+  margin-bottom: 0;
+}
+
+.govuk-panel {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  margin-bottom: 15px;
+  padding: 35px;
+  border: 5px solid transparent;
+  text-align: center;
+}
+
+@media print {
+  .govuk-panel {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-panel {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-panel {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media (max-width: 40.0525em) {
+  .govuk-panel {
+    padding: 25px;
+  }
+}
+
+.govuk-panel--confirmation {
+  color: #ffffff;
+  background: #28a197;
+}
+
+.govuk-panel__title {
+  margin-top: 0;
+  margin-bottom: 30px;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 32px;
+  line-height: 1.09375;
+}
+
+@media print {
+  .govuk-panel__title {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-panel__title {
+    font-size: 48px;
+    line-height: 1.04167;
+  }
+}
+
+@media print {
+  .govuk-panel__title {
+    font-size: 32pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-panel__title:last-child {
+  margin-bottom: 0;
+}
+
+.govuk-panel__body {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 24px;
+  line-height: 1.04167;
+}
+
+@media print {
+  .govuk-panel__body {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-panel__body {
+    font-size: 36px;
+    line-height: 1.11111;
+  }
+}
+
+@media print {
+  .govuk-panel__body {
+    font-size: 24pt;
+    line-height: 1.05;
+  }
+}
+
+.govuk-tag {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 1.25;
+  display: inline-block;
+  padding: 4px 8px;
+  padding-bottom: 1px;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  color: #ffffff;
+  background-color: #005ea5;
+  letter-spacing: 1px;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+@media print {
+  .govuk-tag {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tag {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-tag {
+    font-size: 14pt;
+    line-height: 1.25;
+  }
+}
+
+.govuk-tag--inactive {
+  background-color: #6f777b;
+}
+
+.govuk-phase-banner {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #bfc1c3;
+}
+
+.govuk-phase-banner__content {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  color: #0b0c0c;
+  display: table;
+  margin: 0;
+}
+
+@media print {
+  .govuk-phase-banner__content {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-phase-banner__content {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-phase-banner__content {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+@media print {
+  .govuk-phase-banner__content {
+    color: #000000;
+  }
+}
+
+.govuk-phase-banner__content__tag {
+  margin-right: 10px;
+}
+
+.govuk-phase-banner__text {
+  display: table-cell;
+  vertical-align: baseline;
+}
+
+.govuk-tabs {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  margin-top: 5px;
+  margin-bottom: 20px;
+}
+
+@media print {
+  .govuk-tabs {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tabs {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-tabs {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-tabs {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tabs {
+    margin-top: 5px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tabs {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-tabs__title {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  margin-bottom: 5px;
+}
+
+@media print {
+  .govuk-tabs__title {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tabs__title {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-tabs__title {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-tabs__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (max-width: 40.0525em) {
+  .govuk-tabs__list {
+    margin-bottom: 20px;
+  }
+}
+
+@media (max-width: 40.0525em) and (min-width: 40.0625em) {
+  .govuk-tabs__list {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-tabs__list-item {
+  margin-left: 25px;
+}
+
+.govuk-tabs__list-item::before {
+  content: "— ";
+  margin-left: -25px;
+  padding-right: 5px;
+}
+
+.govuk-tabs__tab {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  display: inline-block;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+@media print {
+  .govuk-tabs__tab {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-tabs__tab:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-tabs__tab:link {
+  color: #005ea5;
+}
+
+.govuk-tabs__tab:visited {
+  color: #4c2c92;
+}
+
+.govuk-tabs__tab:hover {
+  color: #2b8cc4;
+}
+
+.govuk-tabs__tab:active {
+  color: #2b8cc4;
+}
+
+@media print {
+  .govuk-tabs__tab {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tabs__tab {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-tabs__tab {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-tabs__tab[aria-current="true"] {
+  color: #0b0c0c;
+  text-decoration: none;
+}
+
+.govuk-tabs__panel {
+  margin-bottom: 30px;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-tabs__panel {
+    margin-bottom: 50px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .js-enabled .govuk-tabs__list {
+    border-bottom: 1px solid #bfc1c3;
+  }
+  .js-enabled .govuk-tabs__list:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+  .js-enabled .govuk-tabs__list-item {
+    margin-left: 0;
+  }
+  .js-enabled .govuk-tabs__list-item::before {
+    content: none;
+  }
+  .js-enabled .govuk-tabs__title {
+    display: none;
+  }
+  .js-enabled .govuk-tabs__tab {
+    margin-right: 5px;
+    padding-right: 20px;
+    padding-left: 20px;
+    float: left;
+    color: #0b0c0c;
+    background-color: #f8f8f8;
+    text-align: center;
+    text-decoration: none;
+  }
+  .js-enabled .govuk-tabs__tab[aria-selected="true"] {
+    margin-top: -5px;
+    margin-bottom: -1px;
+    padding-top: 14px;
+    padding-right: 19px;
+    padding-bottom: 16px;
+    padding-left: 19px;
+    border: 1px solid #bfc1c3;
+    border-bottom: 0;
+    color: #0b0c0c;
+    background-color: #ffffff;
+  }
+  .js-enabled .govuk-tabs__tab[aria-selected="true"]:focus {
+    background-color: transparent;
+  }
+  .js-enabled .govuk-tabs__panel {
+    margin-bottom: 0;
+    padding-top: 30px;
+    padding-right: 20px;
+    padding-bottom: 30px;
+    padding-left: 20px;
+    border: 1px solid #bfc1c3;
+    border-top: 0;
+  }
+}
+
+@media (min-width: 40.0625em) and (min-width: 40.0625em) {
+  .js-enabled .govuk-tabs__panel {
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .js-enabled .govuk-tabs__panel--hidden {
+    display: none;
+  }
+  .js-enabled .govuk-tabs__panel > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+.govuk-radios__item {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+  position: relative;
+  min-height: 40px;
+  margin-bottom: 10px;
+  padding: 0 0 0 40px;
+  clear: left;
+}
+
+@media print {
+  .govuk-radios__item {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-radios__item {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-radios__item {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-radios__item:last-child,
+.govuk-radios__item:last-of-type {
+  margin-bottom: 0;
+}
+
+.govuk-radios__input {
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+  margin: 0;
+  opacity: 0;
+}
+
+.govuk-radios__label {
+  display: inline-block;
+  margin-bottom: 0;
+  padding: 8px 15px 5px;
+  cursor: pointer;
+  -ms-touch-action: manipulation;
+  touch-action: manipulation;
+}
+
+.govuk-radios__hint {
+  display: block;
+  padding-right: 15px;
+  padding-left: 15px;
+}
+
+.govuk-radios__input + .govuk-radios__label::before {
+  content: "";
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+  background: transparent;
+}
+
+.govuk-radios__input + .govuk-radios__label::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 0;
+  height: 0;
+  border: 10px solid currentColor;
+  border-radius: 50%;
+  opacity: 0;
+  background: currentColor;
+}
+
+.govuk-radios__input:focus + .govuk-radios__label::before {
+  outline: 3px solid transparent;
+  outline-offset: 3px;
+  -webkit-box-shadow: 0 0 0 4px #ffbf47;
+  box-shadow: 0 0 0 4px #ffbf47;
+}
+
+.govuk-radios__input:checked + .govuk-radios__label::after {
+  opacity: 1;
+}
+
+.govuk-radios__input:disabled,
+.govuk-radios__input:disabled + .govuk-radios__label {
+  cursor: default;
+}
+
+.govuk-radios__input:disabled + .govuk-radios__label {
+  opacity: .5;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-radios--inline:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
+  .govuk-radios--inline .govuk-radios__item {
+    margin-right: 20px;
+    float: left;
+    clear: none;
+  }
+}
+
+.govuk-radios__divider {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  width: 40px;
+  margin-bottom: 10px;
+  text-align: center;
+}
+
+@media print {
+  .govuk-radios__divider {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-radios__divider {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-radios__divider {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-radios__conditional {
+  margin-bottom: 15px;
+  margin-left: 18px;
+  padding-left: 33px;
+  border-left: 4px solid #bfc1c3;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-radios__conditional {
+    margin-bottom: 20px;
+  }
+}
+
+.js-enabled .govuk-radios__conditional--hidden {
+  display: none;
+}
+
+.govuk-radios__conditional > :last-child {
+  margin-bottom: 0;
+}
+
+.govuk-select {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+  height: 40px;
+  padding: 5px;
+  border: 2px solid #0b0c0c;
+}
+
+@media print {
+  .govuk-select {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-select {
+    font-size: 19px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-select {
+    font-size: 14pt;
+    line-height: 1.25;
+  }
+}
+
+.govuk-select:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+.govuk-select option:active,
+.govuk-select option:checked,
+.govuk-select:focus::-ms-value {
+  color: #ffffff;
+  background-color: #005ea5;
+}
+
+.govuk-select--error {
+  border: 4px solid #b10e1e;
+}
+
+.govuk-skip-link {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-size: 14px;
+  line-height: 1.14286;
+  display: block;
+  padding: 10px 15px;
+}
+
+.govuk-skip-link:active, .govuk-skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  -webkit-clip-path: none;
+  clip-path: none;
+  white-space: inherit;
+}
+
+@media print {
+  .govuk-skip-link {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-skip-link:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+  background-color: #ffbf47;
+}
+
+.govuk-skip-link:link, .govuk-skip-link:visited, .govuk-skip-link:hover, .govuk-skip-link:active, .govuk-skip-link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-skip-link:link, .govuk-skip-link:visited, .govuk-skip-link:hover, .govuk-skip-link:active, .govuk-skip-link:focus {
+    color: #000000;
+  }
+}
+
+.govuk-skip-link:link:focus {
+  color: #0b0c0c;
+}
+
+@media print {
+  .govuk-skip-link:link:focus {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-skip-link {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-skip-link {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.govuk-table {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  width: 100%;
+  margin-bottom: 20px;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+@media print {
+  .govuk-table {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-table {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-table {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-table {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-table {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-table__header {
+  font-weight: 700;
+  padding: 10px 20px 10px 0;
+  border-bottom: 1px solid #bfc1c3;
+  text-align: left;
+}
+
+.govuk-table__cell {
+  padding: 10px 20px 10px 0;
+  border-bottom: 1px solid #bfc1c3;
+  text-align: left;
+}
+
+.govuk-table__cell--numeric {
+  font-family: "ntatabularnumbers", "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+}
+
+@media print {
+  .govuk-table__cell--numeric {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-table__header--numeric,
+.govuk-table__cell--numeric {
+  text-align: right;
+}
+
+.govuk-table__header:last-child,
+.govuk-table__cell:last-child {
+  padding-right: 0;
+}
+
+.govuk-table__caption {
+  font-weight: 700;
+  display: table-caption;
+  text-align: left;
+}
+
+.govuk-textarea {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  display: block;
+  width: 100%;
+  margin-bottom: 20px;
+  padding: 5px;
+  border: 2px solid #0b0c0c;
+  border-radius: 0;
+  -webkit-appearance: none;
+}
+
+@media print {
+  .govuk-textarea {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-textarea {
+    font-size: 19px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .govuk-textarea {
+    font-size: 14pt;
+    line-height: 1.25;
+  }
+}
+
+.govuk-textarea:focus {
+  outline: 3px solid #ffbf47;
+  outline-offset: 0;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-textarea {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-textarea--error {
+  border: 4px solid #b10e1e;
+}
+
+.govuk-warning-text {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  color: #0b0c0c;
+  position: relative;
+  margin-bottom: 20px;
+  padding: 10px 0;
+}
+
+@media print {
+  .govuk-warning-text {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-warning-text {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .govuk-warning-text {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media print {
+  .govuk-warning-text {
+    color: #000000;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-warning-text {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-warning-text__assistive {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+
+.govuk-warning-text__icon {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  display: inline-block;
+  position: absolute;
+  top: 50%;
+  left: 0;
+  min-width: 32px;
+  min-height: 29px;
+  margin-top: -20px;
+  padding-top: 3px;
+  border: 3px solid #0b0c0c;
+  border-radius: 50%;
+  color: #ffffff;
+  background: #0b0c0c;
+  font-size: 1.6em;
+  line-height: 29px;
+  text-align: center;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media print {
+  .govuk-warning-text__icon {
+    font-family: sans-serif;
+  }
+}
+
+.govuk-warning-text__text {
+  display: block;
+  margin-left: -15px;
+  padding-left: 65px;
+}
+
+.govuk-clearfix:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.govuk-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  border: 0;
+  white-space: nowrap;
+}
+
+.govuk-visually-hidden-focussable {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.govuk-visually-hidden-focussable:active, .govuk-visually-hidden-focussable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  -webkit-clip-path: none;
+  clip-path: none;
+  white-space: inherit;
+}
+
+.govuk-visually-hidden-focusable {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.govuk-visually-hidden-focusable:active, .govuk-visually-hidden-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: inherit;
+  overflow: visible;
+  clip: auto;
+  -webkit-clip-path: none;
+  clip-path: none;
+  white-space: inherit;
+}
+
+.govuk-\!-display-inline {
+  display: inline !important;
+}
+
+.govuk-\!-display-inline-block {
+  display: inline-block !important;
+}
+
+.govuk-\!-display-block {
+  display: block !important;
+}
+
+.govuk-\!-margin-0 {
+  margin: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-0 {
+    margin: 0 !important;
+  }
+}
+
+.govuk-\!-margin-top-0 {
+  margin-top: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-0 {
+    margin-top: 0 !important;
+  }
+}
+
+.govuk-\!-margin-right-0 {
+  margin-right: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-0 {
+    margin-right: 0 !important;
+  }
+}
+
+.govuk-\!-margin-bottom-0 {
+  margin-bottom: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-0 {
+    margin-bottom: 0 !important;
+  }
+}
+
+.govuk-\!-margin-left-0 {
+  margin-left: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-0 {
+    margin-left: 0 !important;
+  }
+}
+
+.govuk-\!-margin-1 {
+  margin: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-1 {
+    margin: 5px !important;
+  }
+}
+
+.govuk-\!-margin-top-1 {
+  margin-top: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-1 {
+    margin-top: 5px !important;
+  }
+}
+
+.govuk-\!-margin-right-1 {
+  margin-right: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-1 {
+    margin-right: 5px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-1 {
+  margin-bottom: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-1 {
+    margin-bottom: 5px !important;
+  }
+}
+
+.govuk-\!-margin-left-1 {
+  margin-left: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-1 {
+    margin-left: 5px !important;
+  }
+}
+
+.govuk-\!-margin-2 {
+  margin: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-2 {
+    margin: 10px !important;
+  }
+}
+
+.govuk-\!-margin-top-2 {
+  margin-top: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-2 {
+    margin-top: 10px !important;
+  }
+}
+
+.govuk-\!-margin-right-2 {
+  margin-right: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-2 {
+    margin-right: 10px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-2 {
+  margin-bottom: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-2 {
+    margin-bottom: 10px !important;
+  }
+}
+
+.govuk-\!-margin-left-2 {
+  margin-left: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-2 {
+    margin-left: 10px !important;
+  }
+}
+
+.govuk-\!-margin-3 {
+  margin: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-3 {
+    margin: 15px !important;
+  }
+}
+
+.govuk-\!-margin-top-3 {
+  margin-top: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-3 {
+    margin-top: 15px !important;
+  }
+}
+
+.govuk-\!-margin-right-3 {
+  margin-right: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-3 {
+    margin-right: 15px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-3 {
+  margin-bottom: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-3 {
+    margin-bottom: 15px !important;
+  }
+}
+
+.govuk-\!-margin-left-3 {
+  margin-left: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-3 {
+    margin-left: 15px !important;
+  }
+}
+
+.govuk-\!-margin-4 {
+  margin: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-4 {
+    margin: 20px !important;
+  }
+}
+
+.govuk-\!-margin-top-4 {
+  margin-top: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-4 {
+    margin-top: 20px !important;
+  }
+}
+
+.govuk-\!-margin-right-4 {
+  margin-right: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-4 {
+    margin-right: 20px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-4 {
+  margin-bottom: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-4 {
+    margin-bottom: 20px !important;
+  }
+}
+
+.govuk-\!-margin-left-4 {
+  margin-left: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-4 {
+    margin-left: 20px !important;
+  }
+}
+
+.govuk-\!-margin-5 {
+  margin: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-5 {
+    margin: 25px !important;
+  }
+}
+
+.govuk-\!-margin-top-5 {
+  margin-top: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-5 {
+    margin-top: 25px !important;
+  }
+}
+
+.govuk-\!-margin-right-5 {
+  margin-right: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-5 {
+    margin-right: 25px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-5 {
+  margin-bottom: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-5 {
+    margin-bottom: 25px !important;
+  }
+}
+
+.govuk-\!-margin-left-5 {
+  margin-left: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-5 {
+    margin-left: 25px !important;
+  }
+}
+
+.govuk-\!-margin-6 {
+  margin: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-6 {
+    margin: 30px !important;
+  }
+}
+
+.govuk-\!-margin-top-6 {
+  margin-top: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-6 {
+    margin-top: 30px !important;
+  }
+}
+
+.govuk-\!-margin-right-6 {
+  margin-right: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-6 {
+    margin-right: 30px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-6 {
+  margin-bottom: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-6 {
+    margin-bottom: 30px !important;
+  }
+}
+
+.govuk-\!-margin-left-6 {
+  margin-left: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-6 {
+    margin-left: 30px !important;
+  }
+}
+
+.govuk-\!-margin-7 {
+  margin: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-7 {
+    margin: 40px !important;
+  }
+}
+
+.govuk-\!-margin-top-7 {
+  margin-top: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-7 {
+    margin-top: 40px !important;
+  }
+}
+
+.govuk-\!-margin-right-7 {
+  margin-right: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-7 {
+    margin-right: 40px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-7 {
+  margin-bottom: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-7 {
+    margin-bottom: 40px !important;
+  }
+}
+
+.govuk-\!-margin-left-7 {
+  margin-left: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-7 {
+    margin-left: 40px !important;
+  }
+}
+
+.govuk-\!-margin-8 {
+  margin: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-8 {
+    margin: 50px !important;
+  }
+}
+
+.govuk-\!-margin-top-8 {
+  margin-top: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-8 {
+    margin-top: 50px !important;
+  }
+}
+
+.govuk-\!-margin-right-8 {
+  margin-right: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-8 {
+    margin-right: 50px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-8 {
+  margin-bottom: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-8 {
+    margin-bottom: 50px !important;
+  }
+}
+
+.govuk-\!-margin-left-8 {
+  margin-left: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-8 {
+    margin-left: 50px !important;
+  }
+}
+
+.govuk-\!-margin-9 {
+  margin: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-9 {
+    margin: 60px !important;
+  }
+}
+
+.govuk-\!-margin-top-9 {
+  margin-top: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-top-9 {
+    margin-top: 60px !important;
+  }
+}
+
+.govuk-\!-margin-right-9 {
+  margin-right: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-right-9 {
+    margin-right: 60px !important;
+  }
+}
+
+.govuk-\!-margin-bottom-9 {
+  margin-bottom: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-bottom-9 {
+    margin-bottom: 60px !important;
+  }
+}
+
+.govuk-\!-margin-left-9 {
+  margin-left: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-margin-left-9 {
+    margin-left: 60px !important;
+  }
+}
+
+.govuk-\!-padding-0 {
+  padding: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-0 {
+    padding: 0 !important;
+  }
+}
+
+.govuk-\!-padding-top-0 {
+  padding-top: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-0 {
+    padding-top: 0 !important;
+  }
+}
+
+.govuk-\!-padding-right-0 {
+  padding-right: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-0 {
+    padding-right: 0 !important;
+  }
+}
+
+.govuk-\!-padding-bottom-0 {
+  padding-bottom: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-0 {
+    padding-bottom: 0 !important;
+  }
+}
+
+.govuk-\!-padding-left-0 {
+  padding-left: 0 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-0 {
+    padding-left: 0 !important;
+  }
+}
+
+.govuk-\!-padding-1 {
+  padding: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-1 {
+    padding: 5px !important;
+  }
+}
+
+.govuk-\!-padding-top-1 {
+  padding-top: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-1 {
+    padding-top: 5px !important;
+  }
+}
+
+.govuk-\!-padding-right-1 {
+  padding-right: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-1 {
+    padding-right: 5px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-1 {
+  padding-bottom: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-1 {
+    padding-bottom: 5px !important;
+  }
+}
+
+.govuk-\!-padding-left-1 {
+  padding-left: 5px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-1 {
+    padding-left: 5px !important;
+  }
+}
+
+.govuk-\!-padding-2 {
+  padding: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-2 {
+    padding: 10px !important;
+  }
+}
+
+.govuk-\!-padding-top-2 {
+  padding-top: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-2 {
+    padding-top: 10px !important;
+  }
+}
+
+.govuk-\!-padding-right-2 {
+  padding-right: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-2 {
+    padding-right: 10px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-2 {
+  padding-bottom: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-2 {
+    padding-bottom: 10px !important;
+  }
+}
+
+.govuk-\!-padding-left-2 {
+  padding-left: 10px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-2 {
+    padding-left: 10px !important;
+  }
+}
+
+.govuk-\!-padding-3 {
+  padding: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-3 {
+    padding: 15px !important;
+  }
+}
+
+.govuk-\!-padding-top-3 {
+  padding-top: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-3 {
+    padding-top: 15px !important;
+  }
+}
+
+.govuk-\!-padding-right-3 {
+  padding-right: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-3 {
+    padding-right: 15px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-3 {
+  padding-bottom: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-3 {
+    padding-bottom: 15px !important;
+  }
+}
+
+.govuk-\!-padding-left-3 {
+  padding-left: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-3 {
+    padding-left: 15px !important;
+  }
+}
+
+.govuk-\!-padding-4 {
+  padding: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-4 {
+    padding: 20px !important;
+  }
+}
+
+.govuk-\!-padding-top-4 {
+  padding-top: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-4 {
+    padding-top: 20px !important;
+  }
+}
+
+.govuk-\!-padding-right-4 {
+  padding-right: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-4 {
+    padding-right: 20px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-4 {
+  padding-bottom: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-4 {
+    padding-bottom: 20px !important;
+  }
+}
+
+.govuk-\!-padding-left-4 {
+  padding-left: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-4 {
+    padding-left: 20px !important;
+  }
+}
+
+.govuk-\!-padding-5 {
+  padding: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-5 {
+    padding: 25px !important;
+  }
+}
+
+.govuk-\!-padding-top-5 {
+  padding-top: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-5 {
+    padding-top: 25px !important;
+  }
+}
+
+.govuk-\!-padding-right-5 {
+  padding-right: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-5 {
+    padding-right: 25px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-5 {
+  padding-bottom: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-5 {
+    padding-bottom: 25px !important;
+  }
+}
+
+.govuk-\!-padding-left-5 {
+  padding-left: 15px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-5 {
+    padding-left: 25px !important;
+  }
+}
+
+.govuk-\!-padding-6 {
+  padding: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-6 {
+    padding: 30px !important;
+  }
+}
+
+.govuk-\!-padding-top-6 {
+  padding-top: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-6 {
+    padding-top: 30px !important;
+  }
+}
+
+.govuk-\!-padding-right-6 {
+  padding-right: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-6 {
+    padding-right: 30px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-6 {
+  padding-bottom: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-6 {
+    padding-bottom: 30px !important;
+  }
+}
+
+.govuk-\!-padding-left-6 {
+  padding-left: 20px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-6 {
+    padding-left: 30px !important;
+  }
+}
+
+.govuk-\!-padding-7 {
+  padding: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-7 {
+    padding: 40px !important;
+  }
+}
+
+.govuk-\!-padding-top-7 {
+  padding-top: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-7 {
+    padding-top: 40px !important;
+  }
+}
+
+.govuk-\!-padding-right-7 {
+  padding-right: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-7 {
+    padding-right: 40px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-7 {
+  padding-bottom: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-7 {
+    padding-bottom: 40px !important;
+  }
+}
+
+.govuk-\!-padding-left-7 {
+  padding-left: 25px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-7 {
+    padding-left: 40px !important;
+  }
+}
+
+.govuk-\!-padding-8 {
+  padding: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-8 {
+    padding: 50px !important;
+  }
+}
+
+.govuk-\!-padding-top-8 {
+  padding-top: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-8 {
+    padding-top: 50px !important;
+  }
+}
+
+.govuk-\!-padding-right-8 {
+  padding-right: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-8 {
+    padding-right: 50px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-8 {
+  padding-bottom: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-8 {
+    padding-bottom: 50px !important;
+  }
+}
+
+.govuk-\!-padding-left-8 {
+  padding-left: 30px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-8 {
+    padding-left: 50px !important;
+  }
+}
+
+.govuk-\!-padding-9 {
+  padding: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-9 {
+    padding: 60px !important;
+  }
+}
+
+.govuk-\!-padding-top-9 {
+  padding-top: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-top-9 {
+    padding-top: 60px !important;
+  }
+}
+
+.govuk-\!-padding-right-9 {
+  padding-right: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-right-9 {
+    padding-right: 60px !important;
+  }
+}
+
+.govuk-\!-padding-bottom-9 {
+  padding-bottom: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-bottom-9 {
+    padding-bottom: 60px !important;
+  }
+}
+
+.govuk-\!-padding-left-9 {
+  padding-left: 40px !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-padding-left-9 {
+    padding-left: 60px !important;
+  }
+}
+
+.govuk-\!-font-size-80 {
+  font-size: 53px !important;
+  line-height: 1.03774 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-80 {
+    font-size: 80px !important;
+    line-height: 1 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-80 {
+    font-size: 53pt !important;
+    line-height: 1.1 !important;
+  }
+}
+
+.govuk-\!-font-size-48 {
+  font-size: 32px !important;
+  line-height: 1.09375 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-48 {
+    font-size: 48px !important;
+    line-height: 1.04167 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-48 {
+    font-size: 32pt !important;
+    line-height: 1.15 !important;
+  }
+}
+
+.govuk-\!-font-size-36 {
+  font-size: 24px !important;
+  line-height: 1.04167 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-36 {
+    font-size: 36px !important;
+    line-height: 1.11111 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-36 {
+    font-size: 24pt !important;
+    line-height: 1.05 !important;
+  }
+}
+
+.govuk-\!-font-size-27 {
+  font-size: 18px !important;
+  line-height: 1.11111 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-27 {
+    font-size: 27px !important;
+    line-height: 1.11111 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-27 {
+    font-size: 18pt !important;
+    line-height: 1.15 !important;
+  }
+}
+
+.govuk-\!-font-size-24 {
+  font-size: 18px !important;
+  line-height: 1.11111 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-24 {
+    font-size: 24px !important;
+    line-height: 1.25 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-24 {
+    font-size: 18pt !important;
+    line-height: 1.15 !important;
+  }
+}
+
+.govuk-\!-font-size-19 {
+  font-size: 16px !important;
+  line-height: 1.25 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-19 {
+    font-size: 19px !important;
+    line-height: 1.31579 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-19 {
+    font-size: 14pt !important;
+    line-height: 1.15 !important;
+  }
+}
+
+.govuk-\!-font-size-16 {
+  font-size: 14px !important;
+  line-height: 1.14286 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-16 {
+    font-size: 16px !important;
+    line-height: 1.25 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-16 {
+    font-size: 14pt !important;
+    line-height: 1.2 !important;
+  }
+}
+
+.govuk-\!-font-size-14 {
+  font-size: 12px !important;
+  line-height: 1.25 !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-font-size-14 {
+    font-size: 14px !important;
+    line-height: 1.42857 !important;
+  }
+}
+
+@media print {
+  .govuk-\!-font-size-14 {
+    font-size: 12pt !important;
+    line-height: 1.2 !important;
+  }
+}
+
+.govuk-\!-font-weight-regular {
+  font-weight: 400 !important;
+}
+
+.govuk-\!-font-weight-bold {
+  font-weight: 700 !important;
+}
+
+.govuk-\!-width-three-quarters {
+  width: 100% !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-width-three-quarters {
+    width: 75% !important;
+  }
+}
+
+.govuk-\!-width-two-thirds {
+  width: 100% !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-width-two-thirds {
+    width: 66.66% !important;
+  }
+}
+
+.govuk-\!-width-one-half {
+  width: 100% !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-width-one-half {
+    width: 50% !important;
+  }
+}
+
+.govuk-\!-width-one-third {
+  width: 100% !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-width-one-third {
+    width: 33.33% !important;
+  }
+}
+
+.govuk-\!-width-one-quarter {
+  width: 100% !important;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-\!-width-one-quarter {
+    width: 25% !important;
+  }
+}
+
+.app-check-your-answers {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+@media print {
+  .app-check-your-answers {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .app-check-your-answers {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .app-check-your-answers {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers {
+    display: table;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers--short {
+    width: 100%;
+  }
+  .app-check-your-answers--short .app-check-your-answers__question {
+    width: 30%;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers--long {
+    width: 100%;
+  }
+  .app-check-your-answers--long .app-check-your-answers__question {
+    width: 50%;
+  }
+}
+
+.app-check-your-answers__contents {
+  position: relative;
+  border-bottom: 1px solid #bfc1c3;
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers__contents {
+    display: table-row;
+    border-bottom-width: 0;
+  }
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers__contents:first-child .app-check-your-answers__question,
+  .app-check-your-answers__contents:first-child .app-check-your-answers__answer,
+  .app-check-your-answers__contents:first-child .app-check-your-answers__change {
+    padding-top: 0;
+  }
+}
+
+.app-check-your-answers__question,
+.app-check-your-answers__answer,
+.app-check-your-answers__change {
+  display: block;
+  margin: 0;
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers__question,
+  .app-check-your-answers__answer,
+  .app-check-your-answers__change {
+    display: table-cell;
+    border-bottom: 1px solid #bfc1c3;
+    padding: 0.63158em 1.05263em 0.47368em 0;
+  }
+}
+
+.app-check-your-answers__question {
+  font-weight: bold;
+  margin: 0.63158em 4em 0.21053em 0;
+}
+
+.app-check-your-answers__answer {
+  padding-bottom: 0.47368em;
+}
+
+.app-check-your-answers__change {
+  text-align: right;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+@media (min-width: 48.0625em) {
+  .app-check-your-answers__change {
+    position: static;
+    padding-right: 0;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .app-column-minimum {
+    min-width: 600px;
+  }
+}
+
+.app-task-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 30px;
+}
+
+@media (min-width: 40.0625em) {
+  .app-task-list {
+    margin-top: 60px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 1.11111;
+  margin: 0;
+  padding-bottom: 5px;
+}
+
+@media print {
+  .app-task-list__section {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .app-task-list__section {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .app-task-list__section {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+  padding-right: 5px;
+}
+
+@media (min-width: 40.0625em) {
+  .app-task-list__section-number {
+    min-width: 35px;
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 30px;
+}
+
+@media (min-width: 40.0625em) {
+  .app-task-list__items {
+    margin-bottom: 60px;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .app-task-list__items {
+    padding-left: 35px;
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid #bfc1c3;
+  padding-top: 10px;
+  padding-bottom: 10px;
+}
+
+.app-task-list__item:after {
+  content: "";
+  display: block;
+  clear: both;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid #bfc1c3;
+}
+
+.app-task-list__task-name {
+  width: 33.3%;
+  float: left;
+}
+
+.app-task-list__task-completed {
+  float: right;
+}
+
+.app-related-items {
+  border-top: 10px solid #005ea5;
+  padding-top: 10px;
+}
+
+.app-related-items .govuk-list > li {
+  margin-bottom: 10px;
+}
+
+.two-column-accounts form-control {
+  text-align: right;
+}
+
+.two-column-accounts .govuk-form-group {
+  margin-bottom: -20px;
+}
+
+.two-column-accounts #accounts-header {
+  display: none;
+  /*Hide from mobiles*/
+}
+
+.two-column-accounts #accounts-header .left {
+  text-align: left;
+}
+
+@media (min-width: 48.0625em) {
+  .two-column-accounts #accounts-header {
+    display: block;
+    text-align: center;
+    margin: 2em 0;
+  }
+}
+
+.two-column-accounts #accounts-header .govuk-heading-m {
+  margin: 0;
+}
+
+.two-column-accounts .error {
+  border: none;
+  padding-left: 0;
+}
+
+.two-column-accounts .error input {
+  border: 4px solid #b10e1e;
+}
+
+.two-column-accounts .read-only {
+  border-color: #bfc1c3;
+}
+
+.two-column-accounts .mobile-only-label {
+  position: relative;
+  overflow: visible;
+  /*Visible on mobiles*/
+}
+
+@media (min-width: 48.0625em) {
+  .two-column-accounts .mobile-only-label {
+    position: absolute;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    /*Hidden on desktop, but can be read by screenreaders*/
+  }
+}
+
+.two-column-accounts .cya-desktop-only {
+  display: none;
+}
+
+@media (min-width: 48.0625em) {
+  .two-column-accounts .cya-desktop-only {
+    display: table-row;
+  }
+}
+
+.two-column-accounts .accounts-total .govuk-input {
+  border-left: 0;
+  border-right: 0;
+  font-weight: 700;
+}
+
+.two-column-accounts .accounts-total details {
+  font-weight: 700;
+}
+
+.two-column-accounts .accounts-total .no-help {
+  margin-left: 1em;
+}
+
+@media (min-width: 20em) {
+  .two-column-accounts .accounts-total .no-help {
+    /*Visible on mobiles*/
+    margin-left: 0;
+    display: block;
+    font-family: "nta", Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 1.25;
+    font-weight: 700;
+    margin-bottom: 0.5em;
+  }
+}
+
+@media print and (min-width: 20em) {
+  .two-column-accounts .accounts-total .no-help {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 20em) and (min-width: 40.0625em) {
+  .two-column-accounts .accounts-total .no-help {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print and (min-width: 20em) {
+  .two-column-accounts .accounts-total .no-help {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.two-column-accounts .accounts-row-spacer {
+  margin-top: 2em;
+}
+
+.two-column-accounts .form-control {
+  width: 100%;
+}
+
+.two-column-accounts .govuk-heading-s {
+  margin: 0;
+}
+
+.two-column-accounts .currency-included-within-inputs input[type="number"] {
+  display: block;
+  width: 100%;
+  clear: both;
+  margin-bottom: 2.2em;
+  position: static;
+}
+
+@media (min-width: 48.0625em) {
+  .two-column-accounts .currency-included-within-inputs input[type="number"] {
+    margin-bottom: 0.5em;
+  }
+}
+
+.two-column-accounts .currency-included-within-inputs .govuk-grid-column-one-half {
+  display: none;
+}
+
+@media (min-width: 48.0625em) {
+  .two-column-accounts .currency-included-within-inputs .govuk-grid-column-one-half {
+    display: inherit;
+  }
+  .two-column-accounts input[type="number"] {
+    text-align: right;
+  }
+  .two-column-accounts .currency-type {
+    position: relative;
+    left: 10px;
+    font-weight: bold;
+  }
+  .two-column-accounts .currency-included-within-inputs input[type="number"] {
+    position: relative !important;
+    top: -60px;
+    left: -10px;
+    background: none;
+  }
+  .two-column-accounts .currency-included-within-inputs .mobile-only-label {
+    display: inline-block;
+    width: 100%;
+    clear: both;
+    margin-bottom: 10px;
+    position: static;
+  }
+  .two-column-accounts .currency-included-within-inputs .currency-type {
+    display: inline;
+    width: 100%;
+    clear: both;
+    margin-bottom: 10px;
+    position: static;
+  }
+}
+
+.two-column-accounts table.check-your-answers thead th {
+  padding: 2em 0 1em;
+}
+
+.two-column-accounts table.check-your-answers thead th h2.govuk-heading-m,
+.two-column-accounts table.check-your-answers thead th h2.govuk-heading-s {
+  margin: 0;
+}
+
+.two-column-accounts table.check-your-answers th.check-your-answers-section {
+  width: 75%;
+}
+
+.two-column-accounts table.check-your-answers td.note-completed {
+  width: 5%;
+  padding-top: 0.2em;
+  padding-bottom: 0;
+}
+
+.two-column-accounts table.check-your-answers tr.total td {
+  font-weight: 700;
+}
+
+.two-column-accounts table.check-your-answers td.numeric {
+  font-family: inherit;
+  font-size: inherit;
+  padding-right: 0;
+}
+
+.two-column-accounts table.check-your-answers td.notes,
+.two-column-accounts table.check-your-answers th.notes {
+  width: 15%;
+}
+
+.two-column-accounts table.check-your-answers td.complete,
+.two-column-accounts table.check-your-answers th.complete {
+  width: 4%;
+}
+
+.two-column-accounts table.check-your-answers tr.to-be-completed td,
+.two-column-accounts table.check-your-answers tr.to-be-completed th {
+  color: #6f777b;
+}
+
+.two-column-accounts table.check-your-answers .accounts-success {
+  color: #00823b;
+  display: block;
+  margin: 0 auto;
+  font-size: 1em;
+}
+
+.two-column-accounts table.check-your-answers .accounts-update {
+  color: #ffbf47;
+  display: block;
+  margin: 0 auto;
+  font-size: 1.8em;
+}
+
+.two-column-accounts table.check-your-answers .review-reveal {
+  padding: 0.5em 0 0.2em 1em;
+}
+
+.two-column-accounts table.check-your-answers .review-reveal .column-one-half p {
+  text-align: left;
+}
+
+.two-column-accounts table.check-your-answers .review-reveal .column-one-quarter p {
+  text-align: right;
+}
+
+.two-column-accounts table.check-your-answers .review-reveal .column-sixth p {
+  text-align: right;
+}
+
+.two-column-accounts table.check-your-answers .review-reveal .column-fifth p {
+  text-align: right;
+}
+
+@media (min-width: 20em) {
+  .review-reveal .column-one-half {
+    width: 45%;
+    display: inline-block;
+  }
+  .review-reveal .column-one-third {
+    width: 31%;
+    display: inline-block;
+  }
+  .review-reveal .column-one-quarter {
+    width: 22%;
+    display: inline-block;
+  }
+}
+
+table.check-your-answers-notes td.change-answer {
+  font-weight: normal;
+  width: 35%;
+}
+
+@media (min-width: 20em) {
+  table.check-your-answers-notes td.change-answer a {
+    margin-bottom: 0.5em;
+    float: right;
+  }
+}
+
+table.check-your-answers-notes td.name {
+  width: 20%;
+}
+
+#content-delete-warning {
+  margin-top: 0;
+}
+
+#delete-summary {
+  padding-bottom: 0;
+  margin-top: 0.5em;
+  display: block;
+}
+
+#delete-summary p {
+  color: #b10e1e;
+}
+
+#delete-summary .button {
+  background-color: #b10e1e;
+  margin-bottom: 1em;
+}
+
+#delete-summary .button:hover {
+  background-color: #8e0513;
+}
+
+#delete-summary .no-delete {
+  color: #005ea5;
+  background-color: transparent;
+  box-shadow: none;
+  text-decoration: underline;
+}
+
+#delete-summary .no-delete:hover {
+  background-color: transparent;
+  box-shadow: none;
+  color: #2b8cc4;
+}
+
+@media (min-width: 20em) {
+  #delete-summary .button {
+    margin-top: 0.5em;
+    margin-left: 0 !important;
+  }
+}
+
+.your-filings table#rf_table {
+  margin-top: 1em;
+}
+
+.your-filings table#rf_table tr td {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+}
+
+@media print {
+  .your-filings table#rf_table tr td {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .your-filings table#rf_table tr td {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .your-filings table#rf_table tr td {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.your-filings table#rf_table tr td strong.status {
+  font-weight: 700;
+  font-size: 1.2em;
+}
+
+.your-filings table#rf_table tr td a {
+  display: inline-block;
+  font-size: 1.1em;
+}
+
+.your-filings table#rf_table tr th {
+  font-weight: normal;
+}
+
+.your-filings table#rf_table tr th.description {
+  width: 69%;
+}
+
+.your-filings table#rf_table tr th.status {
+  width: 18%;
+  text-align: left;
+}
+
+.your-filings table#rf_table tr th.actions {
+  width: 15%;
+  text-align: left;
+}
+
+.your-filings table#rf_table tr td.rejected-type {
+  padding-right: 4em;
+}
+
+.your-filings table#rf_table tr .notice {
+  margin-left: -3em;
+}
+
+.your-filings table#rf_table tr .rejected {
+  color: #b10e1e;
+  margin-left: -3.1em;
+}
+
+.your-filings table#rf_table tr .rejected .icon-important {
+  background-image: url("/public/images/icon-important-red.png");
+}
+
+.your-filings .one-filing {
+  margin-bottom: 2em;
+  background-color: #f8f8f8;
+  padding: 1em;
+  clear: both;
+}
+
+.your-filings .one-filing .govuk-heading-m {
+  margin-top: 0;
+}
+
+.your-filings .one-filing .govuk-heading-m span {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+  display: block;
+}
+
+@media print {
+  .your-filings .one-filing .govuk-heading-m span {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .your-filings .one-filing .govuk-heading-m span {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .your-filings .one-filing .govuk-heading-m span {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.your-filings .one-filing.rejected .notice {
+  color: #b10e1e;
+}
+
+.your-filings .one-filing.rejected .notice .icon-important {
+  background-image: url("/public/images/icon-important-red.png");
+}
+
+.your-filings .govuk-grid-row strong {
+  display: block;
+}
+
+.your-filings .govuk-grid-row strong a:first-of-type {
+  padding-right: 1em;
+}
+
+.your-filings .govuk-grid-row .bold-medium {
+  font-weight: normal;
+  margin-bottom: 1em;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.25;
+}
+
+@media print {
+  .your-filings .govuk-grid-row .bold-medium {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .your-filings .govuk-grid-row .bold-medium {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}
+
+@media print {
+  .your-filings .govuk-grid-row .bold-medium {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.your-filings .govuk-grid-row .bold-medium span {
+  display: block;
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.11111;
+  font-weight: 700;
+}
+
+@media print {
+  .your-filings .govuk-grid-row .bold-medium span {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .your-filings .govuk-grid-row .bold-medium span {
+    font-size: 24px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .your-filings .govuk-grid-row .bold-medium span {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+.your-filings .no-table .column-description {
+  width: 33%;
+}
+
+.your-filings .no-table .column-reference {
+  width: 33%;
+}
+
+.your-filings .no-table .column-status {
+  width: 17%;
+}
+
+.your-filings .no-table .column-actions {
+  width: 17%;
+}
+
+.your-filings .no-table .column-actions strong {
+  font-weight: normal;
+  font-size: 0.9em;
+}
+
+.your-filings .no-table .column-actions strong a:first-of-type {
+  padding-right: 0;
+}
+
+.your-filings a.admin-link {
+  font-size: 16px !important;
+  color: #ffffff;
+  background-color: #005ea5;
+  text-decoration: none;
+  padding: 2px 8px;
+  display: inline-block;
+  margin: 0.5em 0.5em 0 0;
+}
+
+.your-filings a.admin-link:focus, .your-filings a.admin-link:hover {
+  background-color: #2b8cc4;
+}
+
+a.button::before {
+  width: auto;
+}
+
+.form-group .inline-multiple label {
+  margin-bottom: 0.5em;
+}
+
+p.company-details {
+  font-size: 0.9em;
+}
+
+.group-textarea details {
+  margin: -.5em 0 0.5em;
+}
+
+.group-textarea details summary {
+  font-weight: normal;
+}
+
+h1 .circle,
+h2 .circle,
+h3 .circle {
+  font-size: 21px;
+  margin-right: 5px;
+  position: relative;
+  top: -.5em;
+}
+
+.subheading {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  color: #6f777b;
+  display: block;
+}
+
+@media print {
+  .subheading {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .subheading {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .subheading {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.circle-subheading {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 1.11111;
+  color: #6f777b;
+  display: block;
+}
+
+@media print {
+  .circle-subheading {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .circle-subheading {
+    font-size: 27px;
+    line-height: 1.11111;
+  }
+}
+
+@media print {
+  .circle-subheading {
+    font-size: 18pt;
+    line-height: 1.15;
+  }
+}
+
+@media (min-width: 20em) {
+  /*Adjust layout of heading styles on mobiles*/
+  .text .govuk-heading-xl .circle-subheading {
+    margin: 0.5em 0 0;
+  }
+}
+
+.warning-with-triangle {
+  top: 25px;
+  position: relative;
+  background-color: #fff4e0;
+  border: 3px solid #ffbf47;
+  width: auto;
+  height: auto;
+  padding: 0.5em;
+  margin-bottom: 1.5em;
+}
+
+.warning-with-triangle p {
+  margin: 0;
+}
+
+.warning-with-triangle:after,
+.warning-with-triangle:before {
+  bottom: 100%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.warning-with-triangle:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-bottom-color: #fff4e0;
+  border-width: 19px;
+  left: 80%;
+  margin-left: -19px;
+}
+
+.warning-with-triangle:before {
+  border-color: rgba(113, 158, 206, 0);
+  border-bottom-color: #ffbf47;
+  border-width: 23px;
+  left: 80%;
+  margin-left: -23px;
+}
+
+.warning-note {
+  background-color: #005ea5;
+  padding: 0 0.3em;
+  margin-left: 0.5em;
+  color: #ffffff;
+}
+
+.warning-note.warning-note-large {
+  padding: 0.7em;
+  margin-left: 0;
+  margin-bottom: 1em;
+}
+
+h1 span.circle {
+  position: relative;
+  top: -.5em;
+}
+
+.example-icon-list span.circle {
+  position: relative;
+  top: -.2em;
+}
+
+.icon-important {
+  background-image: url("/public/images/icon-important.png");
+}
+
+.icon-file-download {
+  background-image: url("/public/images/icon-file-download.png");
+}
+
+#accounts-start-page .govuk-hint {
+  margin: 0 0 1em 2em;
+}
+
+#accounts-start-page li span {
+  margin-right: 0.9em;
+  margin-bottom: 1em;
+}
+
+.left-indent {
+  margin-left: 2.8em;
+}
+
+.left-indent textarea.form-control {
+  width: 100%;
+}
+
+@media (min-width: 20em) {
+  .left-indent {
+    margin-left: 0 !important;
+  }
+}
+
+#autosave-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  background-color: #6f777b;
+  color: govuk-page-colour;
+  width: 100%;
+  padding: 0.5em 0 0.8em;
+  height: 1em;
+}
+
+#autosave-container div {
+  text-align: center;
+}
+
+h1 .panel {
+  font-size: 0.5em;
+  margin: 1em 0;
+}
+
+th .panel {
+  font-size: 0.6em;
+  margin: 1em 0;
+}
+
+.panel .grid-row {
+  margin-bottom: 15px;
+}
+
+@media (max-width: 640px) {
+  h1 .panel {
+    font-size: 0.5em;
+  }
+  th .panel {
+    font-size: 0.7em;
+  }
+}
+
+#save-modal {
+  border: 2px solid #bfc1c3;
+  background-color: #dee0e2;
+  padding: 1em;
+  display: block;
+  margin: 0 auto 2em;
+}
+
+#save-modal h2 {
+  margin-top: 0;
+}
+
+#save-modal .button {
+  margin: 0 1em 0 0;
+}
+
+@media (max-width: 640px) {
+  #save-modal .button:first-of-type {
+    margin-bottom: 1em;
+  }
+}
+
+.notification-counter {
+  top: -6px;
+  right: -1px;
+  position: relative;
+  background-color: #ffbf47;
+  color: #0b0c0c;
+  padding: 2px 7px 0;
+  border-radius: 15px;
+}
+
+#filing-alert {
+  background: #ffbf47;
+  color: #0b0c0c;
+  display: inline-block;
+  float: right;
+  position: relative;
+  top: 0.2em;
+  right: 14em;
+  width: auto;
+  padding: 0.2em 0.4em;
+  text-align: center;
+}
+
+#filing-alert:before {
+  border-top: 15px solid #ffbf47;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;
+  content: "";
+  height: 0;
+  left: 48%;
+  position: absolute;
+  bottom: -15px;
+  width: 0;
+}
+
+#acc-ref-date-form-group label {
+  margin-bottom: 0.5em;
+}
+
+.embedded-PDF {
+  height: 160vh;
+  border-bottom: 1em solid #3C3C3C;
+  margin: 1em 0;
+}
+
+.margin-top-0 {
+  margin-top: 0;
+}
+
+.payment-summary-small {
+  background-color: #f8f8f8;
+  border: 10px solid #bfc1c3;
+  padding: 1em 1em 0;
+  margin-top: 2em;
+}
+
+.sticky {
+  position: -webkit-sticky !important;
+  position: sticky !important;
+  top: 0;
+}
+
+.card-images {
+  position: relative;
+}
+
+.card-images img {
+  height: 35px;
+}
+
+.card-images .original-accepted {
+  margin-bottom: 0;
+  margin-top: 10px;
+  max-width: 340px;
+  position: relative;
+  z-index: 1;
+}
+
+img.card-image {
+  margin-left: 8px;
+  margin-top: -5px;
+  max-height: 38px;
+  padding-top: 2px;
+  vertical-align: middle;
+}
+
+.column-one-sixth,
+.column-sixth {
+  box-sizing: border-box;
+  padding: 0 8px;
+}
+
+.column-one-sixth,
+.column-sixth {
+  width: 100%;
+}
+
+@media (min-width: 48.0625em) {
+  .column-one-sixth,
+  .column-sixth {
+    width: 12.5%;
+    float: left;
+  }
+}
+
+.column-fifth,
+.column-one-fifth {
+  box-sizing: border-box;
+  padding: 0 15px;
+}
+
+.column-fifth,
+.column-one-fifth {
+  width: 100%;
+}
+
+@media (min-width: 48.0625em) {
+  .column-fifth,
+  .column-one-fifth {
+    width: 18%;
+    float: left;
+  }
+}
+
+.important-message {
+  background-color: #005ea5;
+  color: #ffffff;
+  padding: 0.9em 0.9em 0.1em;
+}
+
+.important-message a {
+  color: #ffffff;
+}
+
+.important-message a:focus,
+.important-message a:hover {
+  color: #2b8cc4;
+}
+
+.cics-task-list li.task-list-item:first-of-type {
+  border-top: none;
+}
+
+.cics-task-list span.task-list-section-number {
+  width: 35px;
+}
+
+.cics-task-list strong.task-completed {
+  float: right;
+}
+
+.circle-step-white {
+  height: 1.4em;
+  width: 1.4em;
+  background-color: #ffffff;
+  color: #0b0c0c;
+  border-radius: 50%;
+  display: inline-block;
+  padding: 0.5em;
+  text-align: center;
+  font-weight: bold;
+  margin: -0.4em 0.5em 0 0;
+}
+
+.circle-step-black {
+  height: 1.4em;
+  width: 1.4em;
+  background-color: #0b0c0c;
+  color: #ffffff;
+  border-radius: 50%;
+  display: inline-block;
+  padding: 0.5em;
+  text-align: center;
+  font-weight: bold;
+  margin: -0.4em 0.5em 1em 0;
+}
+
+.interruption-card {
+  padding: 2em 3em;
+  background: #005ea5 url("/public/images/file-accounts-and-cic-report-transparent.png") no-repeat 95% 60%;
+}
+
+.interruption-card.interruption-card-paper {
+  background: #005ea5 url("/public/images/file-paper.png") no-repeat 90% 100%;
+}
+
+@media (max-width: 40.0525em) {
+  .interruption-card {
+    background-image: none !important;
+  }
+}
+
+.interruption-card.interruption-card-cic-only {
+  background: #005ea5 url("/public/images/file-cic-report-transparent.png") no-repeat 90% 30%;
+}
+
+@media (max-width: 40.0525em) {
+  .interruption-card {
+    background-image: none !important;
+  }
+}
+
+.interruption-card.interruption-card-accounts-only {
+  background: #005ea5 url("/public/images/file-accounts-transparent.png") no-repeat 90% 30%;
+}
+
+@media (max-width: 40.0525em) {
+  .interruption-card {
+    background-image: none !important;
+  }
+}
+
+.interruption-card .govuk-button {
+  background-color: #ffffff;
+  color: #0b0c0c;
+}
+
+.interruption-card .govuk-button:hover {
+  background-color: #dee0e2;
+}
+
+.interruption-card h1 {
+  color: #ffffff;
+}
+
+.interruption-card h2 {
+  display: inline;
+  color: #ffffff;
+}
+
+.interruption-card ul {
+  width: 75%;
+  padding: 2em 0 0;
+}
+
+@media (min-width: 20em) {
+  .interruption-card ul {
+    width: 100%;
+    margin-top: 0.5em;
+  }
+}
+
+.interruption-card ul li h2 {
+  padding-bottom: 2em;
+  display: inline-block;
+  width: 85%;
+  margin: 0 0 0 0.2em;
+}
+
+@media (min-width: 20em) {
+  .interruption-card ul li h2 {
+    width: 80%;
+  }
+}
+
+.interruption-card ul li span {
+  vertical-align: top;
+}
+
+.interruption-card a:link,
+.interruption-card a:visited {
+  color: #ffffff !important;
+}
+
+.interruption-card .button {
+  background-color: #ffffff;
+  color: #005ea5;
+  font-weight: 700;
+}
+
+.interruption-card .button:focus, .interruption-card .button:hover {
+  background-color: #dee0e2;
+  color: #005ea5;
+}
+
+.interruption-card .circle-white {
+  background-color: #ffffff;
+  color: #0b0c0c;
+  margin-right: 0.5em;
+  position: relative;
+  top: -.3em;
+}
+
+.float-right {
+  float: right;
+}
+
+#company-number {
+  margin-top: -3em;
+}
+
+#action-buttons {
+  margin: 1.5em 0 3em;
+}
+
+#action-buttons a {
+  margin-right: .5em;
+}
+
+#action-buttons a#manage-company-authentication {
+  margin-top: .7em;
+  display: inline-block;
+}
+
+@media (max-width: 640px) {
+  #company-number {
+    margin-top: -1em !important;
+  }
+  #action-buttons {
+    margin-bottom: 0;
+  }
+  #action-buttons a {
+    margin-bottom: 0;
+  }
+  #action-buttons a#manage-company-authentication {
+    text-align: center;
+    display: block;
+  }
+  #search .searchfield input,
+  #profile .searchfield input {
+    width: 75%;
+  }
+  #search a:link,
+  #profile a:link {
+    float: right;
+  }
+}
+
+#global-header a#logo {
+  background-image: url("/public/images/royal-coat-of-arms-white.png");
+  background-position: 10px top;
+  background-size: 47px 42px;
+  padding: 8px 0 2px 62px;
+  width: 400px;
+}
+
+#global-header a#proposition-name {
+  padding-left: 1em;
+  position: relative;
+  top: 0.35em;
+}
+
+.normal {
+  font-weight: normal;
+}
+
+ul#navigation {
+  border-bottom: 1px solid #bfc1c3;
+  font-size: 0.9em;
+  margin: 0 0 1em;
+  padding: 0.8em 0;
+  text-align: right;
+}
+
+ul#navigation li {
+  display: inline;
+  padding: 0 0 0 1.5em;
+  font-family: "nta", Arial;
+  font-size: 16px;
+}
+
+.center {
+  text-align: center;
+}
+
+.search-bar-active {
+  background: #dee0e2 none repeat scroll 0 0;
+  padding: 0.4em 0.4em 0;
+  margin-bottom: 20px;
+}
+
+.js-search-focus {
+  font-size: 19px;
+  font-weight: 400;
+  height: 52px;
+  line-height: 1.31579;
+  margin: 0;
+  padding: 0 0 0 10px;
+  text-transform: none;
+  width: 93%;
+}
+
+.govuk-button-search {
+  background-color: #005ea5;
+  background-image: url("/public/images/search-button.png");
+  background-position: -12.5% 50%;
+  background-repeat: no-repeat;
+  border-radius: 0;
+  color: #ffffff;
+  height: 52px;
+  overflow: hidden;
+  text-indent: -5000px;
+  width: 54px;
+  z-index: 4;
+  margin-bottom: 5px;
+}
+
+.govuk-button-search:focus, .govuk-button-search:hover {
+  background-color: #2b8cc4;
+}
+
+sup.label {
+  color: #912b88;
+  display: inline-block;
+  font-size: 0.8em;
+  font-weight: 700;
+}
+
+ul.search-tabs {
+  border-bottom: 1px solid #bfc1c3;
+  margin-bottom: 30px;
+  overflow: auto;
+  padding: 0;
+}
+
+ul.search-tabs li {
+  float: left;
+  list-style-type: none;
+  margin: 0 20px 0 0;
+  padding: 0 8px 10px;
+}
+
+ul.search-tabs li.active {
+  border-bottom: 2px solid #005ea5;
+}
+
+ul.search-tabs li a {
+  text-decoration: none;
+}
+
+ul.search-tabs li a:focus, ul.search-tabs li a:hover, ul.search-tabs li a:visited {
+  color: #005ea5;
+}
+
+main.search .results-list p {
+  font-size: 16px;
+  line-height: 1.25;
+  margin: 0;
+  padding: 0;
+  text-transform: none;
+}
+
+main.search .results-list p.meta {
+  color: #6f777b;
+  font-size: 16px;
+  padding: 0 0 3px;
+  word-wrap: break-word;
+}
+
+main.search .results-list li {
+  padding: 0 0 25px;
+}
+
+main.search .results-list h3 {
+  padding: 0;
+  margin: 0;
+}
+
+main.search .results-list h3 a {
+  color: #005ea5;
+  font-size: 20px;
+  font-weight: normal;
+  text-decoration: none;
+}
+
+main.search .results-list h3 a:focus, main.search .results-list h3 a:hover, main.search .results-list h3 a:visited {
+  color: #2b8cc4;
+  text-decoration: underline;
+}
+
+ul.pager {
+  padding-top: 2em;
+}
+
+ul.pager li {
+  display: inline;
+  float: left;
+  margin: 0;
+  padding: 0 1.4em 0 0;
+}
+
+.data,
+b,
+strong {
+  font-weight: bold;
+  margin: 0;
+}
+
+.view {
+  display: none;
+}
+
+.view.active {
+  display: block;
+}
+
+.profile dl {
+  margin-bottom: 20px;
+}
+
+.section-tabs::after {
+  clear: both;
+  content: '';
+  display: block;
+}
+
+.section-tabs {
+  border-bottom: 1px solid #bfc1c3;
+  margin: 1.5em 0;
+}
+
+@media (max-width: 640px) {
+  .section-tabs {
+    border-bottom: medium none;
+    margin: 30px 0;
+  }
+}
+
+.section-tabs ul {
+  margin: 0;
+  padding: 0;
+  position: relative;
+  top: 1px;
+}
+
+.section-tabs ul li {
+  display: inline;
+  float: left;
+  list-style: outside none none;
+  margin: 0;
+  padding: 0;
+}
+
+.section-tabs ul li h1 {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .section-tabs ul li {
+    display: block;
+    float: none;
+  }
+}
+
+.section-tabs ul a {
+  -moz-border-bottom-colors: none;
+  -moz-border-left-colors: none;
+  -moz-border-right-colors: none;
+  -moz-border-top-colors: none;
+  background: #dee0e2 none repeat scroll 0 0;
+  border-color: #dee0e2 #dee0e2 -moz-use-text-color;
+  border-image: none;
+  border-style: solid solid none;
+  border-width: 1px 1px medium;
+  display: block;
+  font-size: 19px;
+  font-weight: bold;
+  line-height: 1.31579;
+  margin: 5px 5px 6px 0;
+  overflow: hidden;
+  padding: 5px 0;
+  text-decoration: none;
+  text-transform: none;
+}
+
+.section-tabs ul a:visited {
+  color: #005ea5;
+}
+
+.section-tabs ul a:hover {
+  color: #2b8cc4;
+}
+
+@media (max-width: 640px) {
+  .section-tabs ul a {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+.section-tabs ul a:focus .label,
+.section-tabs ul a:hover .label {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .section-tabs ul a {
+    border-bottom: 1px solid #bfc1c3;
+    font-size: 16px;
+    font-weight: normal;
+    line-height: 1.25;
+    margin: 5px 0 0;
+    padding: 5px 0 5px 5px;
+    text-decoration: underline;
+    text-transform: none;
+    width: calc(100% - 10px);
+  }
+}
+
+@media (max-width: 640px) and (max-width: 640px) {
+  .section-tabs ul a {
+    font-size: 14px;
+    line-height: 1.14286;
+  }
+}
+
+@media (min-width: 641px) {
+  .section-tabs ul a {
+    padding: 11px 14px 9px 9px;
+  }
+}
+
+.section-tabs ul li.active a {
+  background: #ffffff none repeat scroll 0 0;
+  border-color: #bfc1c3;
+  margin: 0 5px 0 0;
+  padding: 10px 9px;
+}
+
+@media (max-width: 640px) {
+  .section-tabs ul li.active a {
+    border-bottom: 1px solid #bfc1c3;
+    font-weight: bold;
+    margin: 5px 0 0;
+    padding: 5px 0 5px 5px;
+    text-decoration: none;
+    width: calc(100% - 10px);
+  }
+}
+
+@media (min-width: 641px) {
+  .section-tabs ul li.active a {
+    padding: 16px 19px 15px 14px;
+  }
+}
+
+.section-tabs ul li.active a:focus {
+  outline: medium none;
+}
+
+.section-tabs ul li.active a .label {
+  text-decoration: none;
+}
+
+.section-tabs ul.two-tabs li {
+  width: 50%;
+}
+
+@media (min-width: 769px) {
+  .section-tabs ul.two-tabs li {
+    min-width: 33.333%;
+    width: auto;
+  }
+}
+
+.section-tabs.plain-tabs .tab-navigation ul li a {
+  background-color: #ffffff;
+  border: medium none;
+  font-weight: normal;
+  text-decoration: underline;
+}
+
+.section-tabs.plain-tabs .tab-navigation ul li.active a {
+  -moz-border-bottom-colors: none;
+  -moz-border-left-colors: none;
+  -moz-border-right-colors: none;
+  -moz-border-top-colors: none;
+  border-color: #dee0e2 #dee0e2 -moz-use-text-color;
+  border-image: none;
+  border-style: solid solid none;
+  border-width: 1px 1px medium;
+}
+
+.company-header {
+  margin-top: 2em;
+}
+
+#accounts-start-page li span {
+  margin-right: 0.9em;
+  margin-bottom: 1em;
+}
+
+ol.example-icon-list i {
+  margin-right: 0.5em;
+  position: relative;
+  top: 0.2em;
+}
+
+.get-started .destination {
+  display: block;
+  font-size: 16px;
+  font-size-adjust: 0.5;
+  font-weight: 400;
+  line-height: 1.25;
+  margin-top: 0.2em;
+  max-width: 13em;
+  text-transform: none;
+}
+
+.chs-email ul {
+  font-family: "nta", Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.14286;
+  padding-top: 1em;
+}
+
+@media print {
+  .chs-email ul {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .chs-email ul {
+    font-size: 16px;
+    line-height: 1.25;
+  }
+}
+
+@media print {
+  .chs-email ul {
+    font-size: 14pt;
+    line-height: 1.2;
+  }
+}
+
+.chs-email ul li {
+  padding-bottom: 1em;
+}
+
+.chs-email table {
+  background-color: #f8f8f8;
+  margin: 2em 0;
+}
+
+.chs-email table th {
+  background-color: #dee0e2;
+  padding: 7em 1em;
+}
+
+.chs-email table td {
+  padding: 0.7em 1em;
+}
+
+.action-button-list li {
+  padding-bottom: 0.7em;
+}
+
+.destination {
+  font-size: 16px;
+  display: block;
+  padding-top: 0.5em;
+  max-width: 13em;
+}
+
+.hidden {
+  display: none;
+  visibility: hidden;
+}
+
+.uppercase {
+  text-transform: uppercase;
+}
+
+/*# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiYXBwbGljYXRpb24uY3NzIiwic291cmNlcyI6WyJhcHBsaWNhdGlvbi5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2FsbC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3NldHRpbmdzL19hbGwuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9zZXR0aW5ncy9fYXNzZXRzLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvc2V0dGluZ3MvX2NvbXBhdGliaWxpdHkuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9zZXR0aW5ncy9fZ2xvYmFsLXN0eWxlcy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3NldHRpbmdzL19pZTguc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9zZXR0aW5ncy9fbWVkaWEtcXVlcmllcy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3NldHRpbmdzL19jb2xvdXJzLXBhbGV0dGUuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9zZXR0aW5ncy9fY29sb3Vycy1vcmdhbmlzYXRpb25zLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvc2V0dGluZ3MvX2NvbG91cnMtYXBwbGllZC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2hlbHBlcnMvX2NvbG91ci5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3NldHRpbmdzL19zcGFjaW5nLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvc2V0dGluZ3MvX21lYXN1cmVtZW50cy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3NldHRpbmdzL190eXBvZ3JhcGh5LWZvbnQtZmFtaWxpZXMuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9zZXR0aW5ncy9fdHlwb2dyYXBoeS1mb250LnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvc2V0dGluZ3MvX3R5cG9ncmFwaHktcmVzcG9uc2l2ZS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3Rvb2xzL19hbGwuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC90b29scy9fY29tcGF0aWJpbGl0eS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3Rvb2xzL19leHBvcnRzLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvdG9vbHMvX2ZvbnQtdXJsLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvdG9vbHMvX2llOC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3Rvb2xzL19pZmYuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC90b29scy9faW1hZ2UtdXJsLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvdG9vbHMvX3B4LXRvLWVtLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvdG9vbHMvX3B4LXRvLXJlbS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2hlbHBlcnMvX2FsbC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2hlbHBlcnMvX2NsZWFyZml4LnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvaGVscGVycy9fZGV2aWNlLXBpeGVscy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2hlbHBlcnMvX2ZvY3VzYWJsZS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2hlbHBlcnMvX2ZvbnQtZmFjZXMuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9oZWxwZXJzL19ncmlkLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvaGVscGVycy9fbGlua3Muc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9oZWxwZXJzL19tZWRpYS1xdWVyaWVzLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvdmVuZG9yL19zYXNzLW1xLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvaGVscGVycy9fc2hhcGUtYXJyb3cuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9oZWxwZXJzL19zcGFjaW5nLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvaGVscGVycy9fdHlwb2dyYXBoeS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2hlbHBlcnMvX3Zpc3VhbGx5LWhpZGRlbi5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvcmUvX2FsbC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvcmUvX2xpbmtzLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29yZS9fbGlzdHMuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb3JlL190ZW1wbGF0ZS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvcmUvX3R5cG9ncmFwaHkuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb3JlL19zZWN0aW9uLWJyZWFrLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29yZS9fZ2xvYmFsLXN0eWxlcy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL29iamVjdHMvX2FsbC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL29iamVjdHMvX2Zvcm0tZ3JvdXAuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9vYmplY3RzL19ncmlkLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvb2JqZWN0cy9fbWFpbi13cmFwcGVyLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvb2JqZWN0cy9fd2lkdGgtY29udGFpbmVyLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9fYWxsLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9iYWNrLWxpbmsvX2JhY2stbGluay5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvYnJlYWRjcnVtYnMvX2JyZWFkY3J1bWJzLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9idXR0b24vX2J1dHRvbi5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvY2hlY2tib3hlcy9fY2hlY2tib3hlcy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvZXJyb3ItbWVzc2FnZS9fZXJyb3ItbWVzc2FnZS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvZmllbGRzZXQvX2ZpZWxkc2V0LnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9oaW50L19oaW50LnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9sYWJlbC9fbGFiZWwuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL2RhdGUtaW5wdXQvX2RhdGUtaW5wdXQuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL2lucHV0L19pbnB1dC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvZGV0YWlscy9fZGV0YWlscy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvZXJyb3Itc3VtbWFyeS9fZXJyb3Itc3VtbWFyeS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvZmlsZS11cGxvYWQvX2ZpbGUtdXBsb2FkLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9mb290ZXIvX2Zvb3Rlci5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvaGVhZGVyL19oZWFkZXIuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL2luc2V0LXRleHQvX2luc2V0LXRleHQuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL3BhbmVsL19wYW5lbC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvcGhhc2UtYmFubmVyL19waGFzZS1iYW5uZXIuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL3RhZy9fdGFnLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy90YWJzL190YWJzLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy9yYWRpb3MvX3JhZGlvcy5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvc2VsZWN0L19zZWxlY3Quc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL3NraXAtbGluay9fc2tpcC1saW5rLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvY29tcG9uZW50cy90YWJsZS9fdGFibGUuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9jb21wb25lbnRzL3RleHRhcmVhL190ZXh0YXJlYS5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL2NvbXBvbmVudHMvd2FybmluZy10ZXh0L193YXJuaW5nLXRleHQuc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC91dGlsaXRpZXMvX2FsbC5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL3V0aWxpdGllcy9fY2xlYXJmaXguc2NzcyIsIi4uLy4uLy4uL25vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC91dGlsaXRpZXMvX3Zpc3VhbGx5LWhpZGRlbi5zY3NzIiwiLi4vLi4vLi4vbm9kZV9tb2R1bGVzL2dvdnVrLWZyb250ZW5kL292ZXJyaWRlcy9fYWxsLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvb3ZlcnJpZGVzL19kaXNwbGF5LnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvb3ZlcnJpZGVzL19zcGFjaW5nLnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvb3ZlcnJpZGVzL190eXBvZ3JhcGh5LnNjc3MiLCIuLi8uLi8uLi9ub2RlX21vZHVsZXMvZ292dWstZnJvbnRlbmQvb3ZlcnJpZGVzL193aWR0aC5zY3NzIiwicGF0dGVybnMvX2NoZWNrLXlvdXItYW5zd2Vycy5zY3NzIiwicGF0dGVybnMvX3Rhc2stbGlzdC5zY3NzIiwicGF0dGVybnMvX3JlbGF0ZWQtaXRlbXMuc2NzcyIsIl9jaC1hY2NvdW50cy5zY3NzIiwiX2Nocy1wcm9maWxlLnNjc3MiLCJfY2hzLWhhY2tlZC1zdHlsZXMuc2NzcyJdLCJzb3VyY2VzQ29udGVudCI6WyIvLyBnbG9iYWwgc3R5bGVzIGZvciA8YT4gYW5kIDxwPiB0YWdzXG4kZ292dWstZ2xvYmFsLXN0eWxlczogdHJ1ZTsgLy8gSW1wb3J0IEdPVi5VSyBGcm9udGVuZFxuQGltcG9ydCBcIm5vZGVfbW9kdWxlcy9nb3Z1ay1mcm9udGVuZC9hbGxcIjsgLy8gUGF0dGVybnMgdGhhdCBhcmVuJ3QgaW4gRnJvbnRlbmRcbkBpbXBvcnQgXCJwYXR0ZXJucy9jaGVjay15b3VyLWFuc3dlcnNcIjtcbkBpbXBvcnQgXCJwYXR0ZXJucy90YXNrLWxpc3RcIjtcbkBpbXBvcnQgXCJwYXR0ZXJucy9yZWxhdGVkLWl0ZW1zXCI7IC8vIENvbXBvbmVudHMgdGhhdCBhcmVuJ3QgaW4gRnJvbnRlbmRcbi8vQGltcG9ydCBcImNvbXBvbmVudHMvY29va2llLWJhbm5lclwiO1xuLy8gQWRkIGV4dHJhIHN0eWxlcyBoZXJlLCBvciByZS1vcmdhbmlzZSB0aGUgU2FzcyBmaWxlcyBpbiB3aGljaGV2ZXIgd2F5IG1ha2VzIG1vc3Qgc2Vuc2UgdG8geW91XG5AaW1wb3J0IFwiY2gtYWNjb3VudHNcIjtcbkBpbXBvcnQgXCJjaHMtcHJvZmlsZVwiO1xuQGltcG9ydCBcImNocy1oYWNrZWQtc3R5bGVzXCI7IC8vQGltcG9ydCBcImNoLWFjY291bnRzLXByaW50XCI7IiwiQGltcG9ydCBcInNldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcInRvb2xzL2FsbFwiO1xuQGltcG9ydCBcImhlbHBlcnMvYWxsXCI7XG5cbkBpbXBvcnQgXCJjb3JlL2FsbFwiO1xuQGltcG9ydCBcIm9iamVjdHMvYWxsXCI7XG5cbkBpbXBvcnQgXCJjb21wb25lbnRzL2FsbFwiO1xuXG5AaW1wb3J0IFwidXRpbGl0aWVzL2FsbFwiO1xuQGltcG9ydCBcIm92ZXJyaWRlcy9hbGxcIjtcbiIsIi8vIFRoZSBvcmRlciB3ZSBpbXBvcnQgc2V0dGluZ3MgaW4gaXMgaW1wb3J0YW50LCBhcyBzb21lIHNldHRpbmdzIGZpbGVzIHJlbHkgb25cbi8vIG90aGVyc1xuXG5AaW1wb3J0IFwiYXNzZXRzXCI7XG5cbkBpbXBvcnQgXCJjb21wYXRpYmlsaXR5XCI7XG5AaW1wb3J0IFwiZ2xvYmFsLXN0eWxlc1wiO1xuQGltcG9ydCBcImllOFwiO1xuXG5AaW1wb3J0IFwibWVkaWEtcXVlcmllc1wiO1xuXG5AaW1wb3J0IFwiY29sb3Vycy1wYWxldHRlXCI7XG5AaW1wb3J0IFwiY29sb3Vycy1vcmdhbmlzYXRpb25zXCI7XG5AaW1wb3J0IFwiY29sb3Vycy1hcHBsaWVkXCI7XG5cbkBpbXBvcnQgXCJzcGFjaW5nXCI7XG5AaW1wb3J0IFwibWVhc3VyZW1lbnRzXCI7XG5cbkBpbXBvcnQgXCJ0eXBvZ3JhcGh5LWZvbnQtZmFtaWxpZXNcIjtcbkBpbXBvcnQgXCJ0eXBvZ3JhcGh5LWZvbnRcIjtcbkBpbXBvcnQgXCJ0eXBvZ3JhcGh5LXJlc3BvbnNpdmVcIjtcbiIsIi8vLy9cbi8vLyBAZ3JvdXAgc2V0dGluZ3MvYXNzZXRzXG4vLy8vXG5cbi8vLyBQYXRoIHRvIHRoZSBhc3NldHMgZGlyZWN0b3J5LCB3aXRoIHRyYWlsaW5nIHNsYXNoLlxuLy8vXG4vLy8gVGhpcyBpcyB0aGUgZGlyZWN0b3J5IHdoZXJlIHRoZSBpbWFnZXMgYW5kIGZvbnRzIHN1YmRpcmVjdG9yaWVzIGxpdmUuIFlvdVxuLy8vIHdpbGwgbmVlZCB0byBtYWtlIHRoaXMgZGlyZWN0b3J5IGF2YWlsYWJsZSB2aWEgeW91ciBhcHBsaWNhdGlvbiDigJMgc2VlIHRoZVxuLy8vIFJFQURNRSBmb3IgZGV0YWlscy5cbi8vL1xuLy8vIEB0eXBlIFN0cmluZ1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1hc3NldHMtcGF0aDogXCIvYXNzZXRzL1wiICFkZWZhdWx0O1xuXG4vLy8gUGF0aCB0byB0aGUgaW1hZ2VzIGZvbGRlciwgd2l0aCB0cmFpbGluZyBzbGFzaC5cbi8vL1xuLy8vIEB0eXBlIFN0cmluZ1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1pbWFnZXMtcGF0aDogXCIjeyRnb3Z1ay1hc3NldHMtcGF0aH1pbWFnZXMvXCIgIWRlZmF1bHQ7XG5cbi8vLyBQYXRoIHRvIHRoZSBmb250cyBmb2xkZXIsIHdpdGggdHJhaWxpbmcgc2xhc2guXG4vLy9cbi8vLyBAdHlwZSBTdHJpbmdcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstZm9udHMtcGF0aDogXCIjeyRnb3Z1ay1hc3NldHMtcGF0aH1mb250cy9cIiAhZGVmYXVsdDtcblxuLy8vIEN1c3RvbSBpbWFnZSBVUkwgZnVuY3Rpb25cbi8vL1xuLy8vIElmIHRoZSBidWlsdC1pbiBpbWFnZSBVUkwgaGVscGVyIGRvZXMgbm90IG1lZXQgeW91ciBuZWVkcywgeW91IGNhbiBzcGVjaWZ5XG4vLy8gdGhlIG5hbWUgb2YgYSBjdXN0b20gaGFuZGxlciDigJMgZWl0aGVyIGJ1aWx0IGluIG9yIGJ5IHdyaXRpbmcgeW91ciBvd25cbi8vLyBmdW5jdGlvbi5cbi8vL1xuLy8vIElmIHlvdSBhcmUgd3JpdGluZyB5b3VyIG93biBoYW5kbGVyLCBlbnN1cmUgdGhhdCBpdCByZXR1cm5zIGEgc3RyaW5nIHdyYXBwZWRcbi8vLyB3aXRoIGB1cmwoKWBcbi8vL1xuLy8vIEB0eXBlIFN0cmluZ1xuLy8vXG4vLy8gQGV4YW1wbGUgc2NzcyAtIFJhaWxzIGFzc2V0IGhhbmRsaW5nXG4vLy8gICAkZ292dWstaW1hZ2UtdXJsLWZ1bmN0aW9uOiAnaW1hZ2UtdXJsJztcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBDdXN0b20gYXNzZXQgaGFuZGxpbmdcbi8vL1xuLy8vICAgQGZ1bmN0aW9uIG15LXVybC1oYW5kbGVyKCRmaWxlbmFtZSkge1xuLy8vICAgICAvLyBTb21lIGN1c3RvbSBVUkwgaGFuZGxpbmdcbi8vLyAgICAgQHJldHVybiB1cmwoJ2V4YW1wbGUuanBnJyk7XG4vLy8gICB9XG4vLy9cbi8vLyAgICRnb3Z1ay1pbWFnZS11cmwtZnVuY3Rpb246ICdteS11cmwtaGFuZGxlcic7XG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstaW1hZ2UtdXJsLWZ1bmN0aW9uOiBmYWxzZSAhZGVmYXVsdDtcblxuLy8vIEN1c3RvbSBmb250IFVSTCBmdW5jdGlvblxuLy8vXG4vLy8gSWYgdGhlIGJ1aWx0LWluIGZvbnQgVVJMIGhlbHBlciBkb2VzIG5vdCBtZWV0IHlvdXIgbmVlZHMsIHlvdSBjYW4gc3BlY2lmeVxuLy8vIHRoZSBuYW1lIG9mIGEgY3VzdG9tIGhhbmRsZXIg4oCTIGVpdGhlciBidWlsdCBpbiBvciBieSB3cml0aW5nIHlvdXIgb3duXG4vLy8gZnVuY3Rpb24uXG4vLy9cbi8vLyBJZiB5b3UgYXJlIHdyaXRpbmcgeW91ciBvd24gaGFuZGxlciwgZW5zdXJlIHRoYXQgaXQgcmV0dXJucyBhIHN0cmluZyB3cmFwcGVkXG4vLy8gd2l0aCBgdXJsKClgXG4vLy9cbi8vLyBAdHlwZSBTdHJpbmdcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBSYWlscyBhc3NldCBoYW5kbGluZ1xuLy8vICAgJGdvdnVrLWZvbnQtdXJsLWZ1bmN0aW9uOiAnZm9udC11cmwnO1xuLy8vXG4vLy8gQGV4YW1wbGUgc2NzcyAtIEN1c3RvbSBhc3NldCBoYW5kbGluZ1xuLy8vXG4vLy8gICBAZnVuY3Rpb24gbXktdXJsLWhhbmRsZXIoJGZpbGVuYW1lKSB7XG4vLy8gICAgIC8vIFNvbWUgY3VzdG9tIFVSTCBoYW5kbGluZ1xuLy8vICAgICBAcmV0dXJuIHVybCgnZXhhbXBsZS53b2ZmJyk7XG4vLy8gICB9XG4vLy9cbi8vLyAgICRnb3Z1ay1mb250LXVybC1mdW5jdGlvbjogJ215LXVybC1oYW5kbGVyJztcbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1mb250LXVybC1mdW5jdGlvbjogZmFsc2UgIWRlZmF1bHQ7XG4iLCIvLy8vXG4vLy8gQ29tcGF0aWJpbGl0eSB3aXRoIGxlZ2FjeSByZXBvcyAoZ292dWtfZWxlbWVudHMsIGdvdnVrX2Zyb250ZW5kX3Rvb2traXQgYW5kXG4vLy8gZ292dWtfdGVtcGxhdGUpIHNldHRpbmdzXG4vLy9cbi8vLyBXZSBkZWZhdWx0IHRoZXNlIHNldHRpbmdzIHRvIGB0cnVlYCBzbyB0aGF0IGlmIHRoZXkgYXJlIG1pc3NlZCB3ZSBvcHQgZm9yIGFcbi8vLyBtaWxkIHBlcmZvcm1hbmNlIGhpdCBvdmVyIGEgcG90ZW50aWFsIGJyb2tlbiBleHBlcmllbmNlIGZvciB0aGUgZW5kLXVzZXIuXG4vLy9cbi8vLyBAZ3JvdXAgc2V0dGluZ3MvY29tcGF0aWJpbGl0eVxuLy8vL1xuXG5cbi8vLyBDb21wYXRpYmlsaXR5IE1vZGU6IGFscGhhZ292L2dvdnVrX2Zyb250ZW5kX3Rvb2xraXRcbi8vL1xuLy8vIFRydWUgaWYgdXNlZCBpbiBhIHByb2plY3QgdGhhdCBhbHNvIGluY2x1ZGVzIGFscGhhZ292L2dvdnVrX2Zyb250ZW5kX3Rvb2xraXQuXG4vLy9cbi8vLyBAdHlwZSBCb29sZWFuXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWNvbXBhdGliaWxpdHktZ292dWtmcm9udGVuZHRvb2xraXQ6IHRydWUgIWRlZmF1bHQ7XG5cbi8vLyBDb21wYXRpYmlsaXR5IE1vZGU6IGFscGhhZ292L2dvdnVrX3RlbXBsYXRlXG4vLy9cbi8vLyBUcnVlIGlmIHVzZWQgaW4gYSBwcm9qZWN0IHRoYXQgYWxzbyBpbmNsdWRlcyBhbHBoYWdvdi9nb3Z1a190ZW1wbGF0ZS5cbi8vL1xuLy8vIEB0eXBlIEJvb2xlYW5cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstY29tcGF0aWJpbGl0eS1nb3Z1a3RlbXBsYXRlOiB0cnVlICFkZWZhdWx0O1xuXG4vLy8gQ29tcGF0aWJpbGl0eSBNb2RlOiBhbHBoYWdvdi9nb3Z1a19lbGVtZW50c1xuLy8vXG4vLy8gVHJ1ZSBpZiB1c2VkIGluIGEgcHJvamVjdCB0aGF0IGFsc28gaW5jbHVkZXMgYWxwaGFnb3YvZ292dWtfZWxlbWVudHMuXG4vLy9cbi8vLyBAdHlwZSBCb29sZWFuXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWNvbXBhdGliaWxpdHktZ292dWtlbGVtZW50czogdHJ1ZSAhZGVmYXVsdDtcblxuLy8vIENvbXBhdGliaWxpdHkgUHJvZHVjdCBNYXBcbi8vL1xuLy8vIE1hcHMgcHJvZHVjdCBuYW1lcyB0byB0aGVpciBzZXR0aW5ncyB0aGF0IHdlIGNhbiB1c2UgdG8gbG9va3VwIHN0YXRlcyBmcm9tXG4vLy8gd2l0aGluIHRoZSBgQGdvdnVrLWNvbXBhdGliaWxpdHlgIG1peGluLlxuLy8vXG4vLy8gQHR5cGUgTWFwXG4vLy8gQGFjY2VzcyBwcml2YXRlXG5cbiRfZ292dWstY29tcGF0aWJpbGl0eTogKFxuICBnb3Z1a19mcm9udGVuZF90b29sa2l0OiAkZ292dWstY29tcGF0aWJpbGl0eS1nb3Z1a2Zyb250ZW5kdG9vbGtpdCxcbiAgZ292dWtfdGVtcGxhdGU6ICRnb3Z1ay1jb21wYXRpYmlsaXR5LWdvdnVrdGVtcGxhdGUsXG4gIGdvdnVrX2VsZW1lbnRzOiAkZ292dWstY29tcGF0aWJpbGl0eS1nb3Z1a2VsZW1lbnRzLFxuKTtcbiIsIi8vLy9cbi8vLyBAZ3JvdXAgc2V0dGluZ3MvZ2xvYmFsLXN0eWxlc1xuLy8vL1xuXG4vLy8gSW5jbHVkZSAnZ2xvYmFsJyBzdHlsZXNcbi8vL1xuLy8vIFdoZXRoZXIgdG8gc3R5bGUgcGFyYWdyYXBocyAoYDxwPmApIGFuZCBsaW5rcyAoYDxhPmApIHdpdGhvdXQgZXhwbGljaXRseVxuLy8vIGhhdmluZyB0byBhcHBseSB0aGUgYGdvdnVrLWJvZHlgIGFuZCBgZ292dWstbGlua2AgY2xhc3Nlcy5cbi8vL1xuLy8vIEB0eXBlIEJvb2xlYW5cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstZ2xvYmFsLXN0eWxlczogZmFsc2UgIWRlZmF1bHQ7XG4iLCIvLy8vXG4vLy8gQGdyb3VwIHNldHRpbmdzL2llOFxuLy8vL1xuXG4vLy8gV2hldGhlciB0aGUgc3R5bGVzaGVldCBiZWluZyBidWlsdCBpcyB0YXJnZXRpbmcgSW50ZXJuZXQgRXhwbG9yZXIgOC5cbi8vL1xuLy8vIEB0eXBlIEJvb2xlYW5cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstaXMtaWU4OiBmYWxzZSAhZGVmYXVsdDtcblxuLy8vIFRoZSBuYW1lIG9mIHRoZSBicmVha3BvaW50IHRvIHVzZSBhcyB0aGUgdGFyZ2V0IHdoZW4gcmFzdGVyaXppbmcgbWVkaWFcbi8vLyBxdWVyaWVzXG4vLy9cbi8vLyBAdHlwZSBTdHJpbmdcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstaWU4LWJyZWFrcG9pbnQ6IGRlc2t0b3AgIWRlZmF1bHQ7XG4iLCIvLy8vXG4vLy8gQGdyb3VwIHNldHRpbmdzL21lZGlhLXF1ZXJpZXNcbi8vLy9cblxuLy8vIEJyZWFrcG9pbnQgZGVmaW5pdGlvbnNcbi8vL1xuLy8vIEB0eXBlIE1hcFxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1icmVha3BvaW50czogKFxuICBtb2JpbGU6ICAzMjBweCxcbiAgdGFibGV0OiAgNjQxcHgsXG4gIGRlc2t0b3A6IDc2OXB4XG4pICFkZWZhdWx0O1xuXG4vLy8gU2hvdyBhY3RpdmUgYnJlYWtwb2ludCBpbiB0b3AtcmlnaHQgY29ybmVyLlxuLy8vXG4vLy8gT25seSB1c2UgdGhpcyBkdXJpbmcgbG9jYWwgZGV2ZWxvcG1lbnQuXG4vLy9cbi8vLyBAdHlwZSBCb29sZWFuXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLXNob3ctYnJlYWtwb2ludHM6IGZhbHNlICFkZWZhdWx0O1xuIiwiLy8vL1xuLy8vIEBncm91cCBzZXR0aW5ncy9jb2xvdXJzXG4vLy8vXG5cbi8vLyBDb2xvdXIgcGFsZXR0ZVxuLy8vXG4vLy8gQHR5cGUgTWFwXG4vLy9cbi8vLyBAcHJvcCAkY29sb3VyIC0gUmVwcmVzZW50YXRpb24gZm9yIHRoZSBnaXZlbiAkY29sb3VyLCB3aGVyZSAkY29sb3VyIGlzIHRoZVxuLy8vICAgZnJpZW5kbHkgbmFtZSBmb3IgdGhlIGNvbG91ciAoZS5nLiBcInJlZFwiOiAjZmYwMDAwKTtcbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1jb2xvdXJzOiAoXG4gIFwicHVycGxlXCI6ICMyZTM1OGIsXG4gIFwibGlnaHQtcHVycGxlXCI6ICM2ZjcyYWYsXG4gIFwiYnJpZ2h0LXB1cnBsZVwiOiAjOTEyYjg4LFxuICBcInBpbmtcIjogI2Q1Mzg4MCxcbiAgXCJsaWdodC1waW5rXCI6ICNmNDk5YmUsXG4gIFwicmVkXCI6ICNiMTBlMWUsXG4gIFwiYnJpZ2h0LXJlZFwiOiAjZGYzMDM0LFxuICBcIm9yYW5nZVwiOiAjZjQ3NzM4LFxuICBcImJyb3duXCI6ICNiNTg4NDAsXG4gIFwieWVsbG93XCI6ICNmZmJmNDcsXG4gIFwibGlnaHQtZ3JlZW5cIjogIzg1OTk0YixcbiAgXCJncmVlblwiOiAjMDA2NDM1LFxuICBcInR1cnF1b2lzZVwiOiAjMjhhMTk3LFxuICBcImxpZ2h0LWJsdWVcIjogIzJiOGNjNCxcbiAgXCJibHVlXCI6ICMwMDVlYTUsXG5cbiAgXCJibGFja1wiOiAjMGIwYzBjLFxuICBcImdyZXktMVwiOiAjNmY3NzdiLFxuICBcImdyZXktMlwiOiAjYmZjMWMzLFxuICBcImdyZXktM1wiOiAjZGVlMGUyLFxuICBcImdyZXktNFwiOiAjZjhmOGY4LFxuICBcIndoaXRlXCI6ICNmZmZmZmZcbikgIWRlZmF1bHQ7XG4iLCIvLy8vXG4vLy8gQGdyb3VwIHNldHRpbmdzL2NvbG91cnNcbi8vLy9cblxuLy8vIE9yZ2FuaXNhdGlvbiBjb2xvdXJzXG4vLy9cbi8vLyBAdHlwZSBNYXBcbi8vL1xuLy8vIEBwcm9wICRvcmdhbmlzYXRpb24uY29sb3VyIC0gQ29sb3VyIGZvciB0aGUgZ2l2ZW4gYCRvcmdhbmlzYXRpb25gXG4vLy8gQHByb3AgJG9yZ2FuaXNhdGlvbi5jb2xvdXItd2Vic2FmZSAtIFdlYnNhZmUgY29sb3VyIGZvciB0aGUgZ2l2ZW5cbi8vLyAgIGAkb3JnYW5pc2F0aW9uYC4gV2UgdXNlIGB3ZWJzYWZlYCB0byBtZWFuIHN0cm9uZyBlbm91Z2ggY29udHJhc3QgYWdhaW5zdFxuLy8vICAgd2hpdGUgdG8gYmUgdXNlZCBmb3IgY29weSBhbmQgbWVldCB0aGUgQUFBIChsYXJnZSB0ZXh0KSBhbmQgQUEgKHNtYWxsZXJcbi8vLyAgIGNvcHkpIFdDQUcgZ3VpZGVsaW5lcy5cbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1jb2xvdXJzLW9yZ2FuaXNhdGlvbnM6IChcbiAgXCJhdHRvcm5leS1nZW5lcmFscy1vZmZpY2VcIjogKFxuICAgIGNvbG91cjogIzlmMTg4OCxcbiAgICBjb2xvdXItd2Vic2FmZTogI2EwM2E4OFxuICApLFxuICBcImNhYmluZXQtb2ZmaWNlXCI6IChcbiAgICBjb2xvdXI6ICMwMDVhYmIsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMzNDdkYTRcbiAgKSxcbiAgXCJjaXZpbC1zZXJ2aWNlXCI6IChcbiAgICBjb2xvdXI6ICNhZjI5MmVcbiAgKSxcbiAgXCJkZXBhcnRtZW50LWZvci1idXNpbmVzcy1pbm5vdmF0aW9uLXNraWxsc1wiOiAoXG4gICAgY29sb3VyOiAjMDAzNDc5LFxuICAgIGNvbG91ci13ZWJzYWZlOiAjMzQ3ZGE0XG4gICksXG4gIFwiZGVwYXJ0bWVudC1mb3ItY29tbXVuaXRpZXMtYW5kLWxvY2FsLWdvdmVybm1lbnRcIjogKFxuICAgIGNvbG91cjogIzAwODU3ZSxcbiAgICBjb2xvdXItd2Vic2FmZTogIzM3ODM2ZVxuICApLFxuICBcImRlcGFydG1lbnQtZm9yLWN1bHR1cmUtbWVkaWEtc3BvcnRcIjogKFxuICAgIGNvbG91cjogI2Q0MDA3MixcbiAgICBjb2xvdXItd2Vic2FmZTogI2EwMzE1NVxuICApLFxuICBcImRlcGFydG1lbnQtZm9yLWVkdWNhdGlvblwiOiAoXG4gICAgY29sb3VyOiAjMDAzYTY5LFxuICAgIGNvbG91ci13ZWJzYWZlOiAjMzQ3Y2E5XG4gICksXG4gIFwiZGVwYXJ0bWVudC1mb3ItZW52aXJvbm1lbnQtZm9vZC1ydXJhbC1hZmZhaXJzXCI6IChcbiAgICBjb2xvdXI6ICMwMGEzM2IsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMwMDg5MzhcbiAgKSxcbiAgXCJkZXBhcnRtZW50LWZvci1pbnRlcm5hdGlvbmFsLWRldmVsb3BtZW50XCI6IChcbiAgICBjb2xvdXI6ICMwMDI4NzgsXG4gICAgY29sb3VyLXdlYnNhZmU6ICM0MDVlOWFcbiAgKSxcbiAgXCJkZXBhcnRtZW50LWZvci1pbnRlcm5hdGlvbmFsLXRyYWRlXCI6IChcbiAgICBjb2xvdXI6ICNjZjEwMmQsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMwMDVlYTVcbiAgKSxcbiAgXCJkZXBhcnRtZW50LWZvci10cmFuc3BvcnRcIjogKFxuICAgIGNvbG91cjogIzAwNmM1NixcbiAgICBjb2xvdXItd2Vic2FmZTogIzM5ODM3M1xuICApLFxuICBcImRlcGFydG1lbnQtZm9yLXdvcmstcGVuc2lvbnNcIjogKFxuICAgIGNvbG91cjogIzAwYmViNyxcbiAgICBjb2xvdXItd2Vic2FmZTogIzM3ODA3YlxuICApLFxuICBcImRlcGFydG1lbnQtb2YtZW5lcmd5LWNsaW1hdGUtY2hhbmdlXCI6IChcbiAgICBjb2xvdXI6ICMwMDlkZGIsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMyYjdjYWNcbiAgKSxcbiAgXCJkZXBhcnRtZW50LW9mLWhlYWx0aFwiOiAoXG4gICAgY29sb3VyOiAjMDBhZDkzLFxuICAgIGNvbG91ci13ZWJzYWZlOiAjMzk4MzZlXG4gICksXG4gIFwiZm9yZWlnbi1jb21tb253ZWFsdGgtb2ZmaWNlXCI6IChcbiAgICBjb2xvdXI6ICMwMDNlNzQsXG4gICAgY29sb3VyLXdlYnNhZmU6ICM0MDZlOTdcbiAgKSxcbiAgXCJnb3Zlcm5tZW50LWVxdWFsaXRpZXMtb2ZmaWNlXCI6IChcbiAgICBjb2xvdXI6ICAjOTMyNWIyXG4gICksXG4gIFwiaG0tZ292ZXJubWVudFwiOiAoXG4gICAgY29sb3VyOiAjMDA3NmMwLFxuICAgIGNvbG91ci13ZWJzYWZlOiAjMzQ3ZGE0XG4gICksXG4gIFwiaG0tcmV2ZW51ZS1jdXN0b21zXCI6IChcbiAgICBjb2xvdXI6ICMwMDkzOTAsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMwMDg2NzBcbiAgKSxcbiAgXCJobS10cmVhc3VyeVwiOiAoXG4gICAgY29sb3VyOiAjYWYyOTJlLFxuICAgIGNvbG91ci13ZWJzYWZlOiAjODMyMzIyXG4gICksXG4gIFwiaG9tZS1vZmZpY2VcIjogKFxuICAgIGNvbG91cjogIzkzMjViMixcbiAgICBjb2xvdXItd2Vic2FmZTogIzk0NDBiMlxuICApLFxuICBcIm1pbmlzdHJ5LW9mLWRlZmVuY2VcIjogKFxuICAgIGNvbG91cjogIzRkMjk0MixcbiAgICBjb2xvdXItd2Vic2FmZTogIzVhNWM5MlxuICApLFxuICBcIm1pbmlzdHJ5LW9mLWp1c3RpY2VcIjogKFxuICAgIGNvbG91cjogIzIzMWYyMCxcbiAgICBjb2xvdXItd2Vic2FmZTogIzVhNWM5MlxuICApLFxuICBcIm5vcnRoZXJuLWlyZWxhbmQtb2ZmaWNlXCI6IChcbiAgICBjb2xvdXI6ICMwMDI2NjMsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMzZTU5OGNcbiAgKSxcbiAgXCJvZmZpY2Utb2YtdGhlLWFkdm9jYXRlLWdlbmVyYWwtZm9yLXNjb3RsYW5kXCI6IChcbiAgICBjb2xvdXI6ICMwMDI2NjMsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMwMDVlYTVcbiAgKSxcbiAgXCJvZmZpY2Utb2YtdGhlLWxlYWRlci1vZi10aGUtaG91c2Utb2YtY29tbW9uc1wiOiAoXG4gICAgY29sb3VyOiAjMzE3MDIzLFxuICAgIGNvbG91ci13ZWJzYWZlOiAjMDA1ZjhmXG4gICksXG4gIFwib2ZmaWNlLW9mLXRoZS1sZWFkZXItb2YtdGhlLWhvdXNlLW9mLWxvcmRzXCI6IChcbiAgICBjb2xvdXI6ICM5YzEzMmUsXG4gICAgY29sb3VyLXdlYnNhZmU6ICNjMjM5NWRcbiAgKSxcbiAgXCJzY290bGFuZC1vZmZpY2VcIjogKFxuICAgIGNvbG91cjogIzAwMjY2MyxcbiAgICBjb2xvdXItd2Vic2FmZTogIzQwNWM4YVxuICApLFxuICBcInVrLWV4cG9ydC1maW5hbmNlXCI6IChcbiAgICBjb2xvdXI6ICMwMDU3NDcsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMwMDVlYTVcbiAgKSxcbiAgXCJ1ay10cmFkZS1pbnZlc3RtZW50XCI6IChcbiAgICBjb2xvdXI6ICNjODA2NTEsXG4gICAgY29sb3VyLXdlYnNhZmU6ICMwMDVlYTVcbiAgKSxcbiAgXCJ3YWxlcy1vZmZpY2VcIjogKFxuICAgIGNvbG91cjogI2EzMzAzOCxcbiAgICBjb2xvdXItd2Vic2FmZTogIzdhMjQyYVxuICApXG4pICFkZWZhdWx0O1xuIiwiLy8vL1xuLy8vIEBncm91cCBzZXR0aW5ncy9jb2xvdXJzXG4vLy8vXG5cbkBpbXBvcnQgXCIuLi9oZWxwZXJzL2NvbG91clwiO1xuXG5cblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBHZW5lcmljXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuLy8vIEJyYW5kIGNvbG91clxuLy8vXG4vLy8gQHR5cGUgQ29sb3VyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWJyYW5kLWNvbG91cjogZ292dWstY29sb3VyKFwiYmx1ZVwiKSAhZGVmYXVsdDtcblxuLy8vIFRleHQgY29sb3VyXG4vLy9cbi8vLyBAdHlwZSBDb2xvdXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstdGV4dC1jb2xvdXI6IGdvdnVrLWNvbG91cihcImJsYWNrXCIpICFkZWZhdWx0O1xuXG4vLy8gQ2FudmFzIGJhY2tncm91bmQgY29sb3VyXG4vLy9cbi8vLyBVc2VkIGJ5IHRoZSBmb290ZXIgY29tcG9uZW50IGFuZCB0ZW1wbGF0ZSB0byBnaXZlIHRoZSBpbGx1c2lvbiBvZiBhIGxvbmcgZm9vdGVyLlxuLy8vXG4vLy8gQHR5cGUgQ29sb3VyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWNhbnZhcy1iYWNrZ3JvdW5kLWNvbG91cjogZ292dWstY29sb3VyKFwiZ3JleS0zXCIpICFkZWZhdWx0O1xuXG4vLy8gQm9keSBiYWNrZ3JvdW5kIGNvbG91clxuLy8vXG4vLy8gQHR5cGUgQ29sb3VyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWJvZHktYmFja2dyb3VuZC1jb2xvdXI6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpICFkZWZhdWx0O1xuXG4vLy8gVGV4dCBjb2xvdXIgZm9yIHByaW50IG1lZGlhXG4vLy9cbi8vLyBVc2UgJ3RydWUgYmxhY2snIHRvIGF2b2lkIHByaW50ZXJzIHVzaW5nIGNvbG91ciBpbmsgdG8gcHJpbnQgYm9keSB0ZXh0XG4vLy9cbi8vLyBAdHlwZSBDb2xvdXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstcHJpbnQtdGV4dC1jb2xvdXI6ICMwMDAwMDAgIWRlZmF1bHQ7XG5cbi8vLyBTZWNvbmRhcnkgdGV4dCBjb2xvdXJcbi8vL1xuLy8vIFVzZWQgZm9yICdtdXRlZCcgdGV4dCwgaGVscCB0ZXh0LCBldGMuXG4vLy9cbi8vLyBAdHlwZSBDb2xvdXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstc2Vjb25kYXJ5LXRleHQtY29sb3VyOiBnb3Z1ay1jb2xvdXIoXCJncmV5LTFcIikgIWRlZmF1bHQ7XG5cbi8vLyBGb2N1cyBjb2xvdXJcbi8vL1xuLy8vIFVzZWQgZm9yIG91dGxpbmUgKGFuZCBiYWNrZ3JvdW5kLCB3aGVyZSBhcHByb3ByaWF0ZSkgd2hlbiBpbnRlcmFjdGl2ZVxuLy8vIGVsZW1lbnRzIChsaW5rcywgZm9ybSBjb250cm9scykgaGF2ZSBrZXlib2FyZCBmb2N1cy5cbi8vL1xuLy8vIEB0eXBlIENvbG91clxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1mb2N1cy1jb2xvdXI6IGdvdnVrLWNvbG91cihcInllbGxvd1wiKSAhZGVmYXVsdDtcblxuLy8vIEVycm9yIGNvbG91clxuLy8vXG4vLy8gVXNlZCB0byBoaWdobGlnaHQgZXJyb3IgbWVzc2FnZXMgYW5kIGZvcm0gY29udHJvbHMgaW4gYW4gZXJyb3Igc3RhdGVcbi8vL1xuLy8vIEB0eXBlIENvbG91clxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1lcnJvci1jb2xvdXI6IGdvdnVrLWNvbG91cihcInJlZFwiKSAhZGVmYXVsdDtcblxuLy8vIEJvcmRlciBjb2xvdXJcbi8vL1xuLy8vIFVzZWQgZm9yIGJvcmRlcnMsIHNlcGFyYXRvcnMsIHJ1bGVzLCBrZXlsaW5lcyBldGMuXG4vLy9cbi8vLyBAdHlwZSBDb2xvdXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstYm9yZGVyLWNvbG91cjogZ292dWstY29sb3VyKFwiZ3JleS0yXCIpICFkZWZhdWx0O1xuXG4vLy8gSW5wdXQgYm9yZGVyIGNvbG91clxuLy8vXG4vLy8gVXNlZCBmb3IgZm9ybSBpbnB1dHMgYW5kIGNvbnRyb2xzXG4vLy9cbi8vLyBAdHlwZSBDb2xvdXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstaW5wdXQtYm9yZGVyLWNvbG91cjogZ292dWstY29sb3VyKFwiYmxhY2tcIikgIWRlZmF1bHQ7XG5cblxuXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gTGlua3Ncbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG5cbi8vLyBMaW5rIGNvbG91clxuLy8vXG4vLy8gQHR5cGUgQ29sb3VyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWxpbmstY29sb3VyOiBnb3Z1ay1jb2xvdXIoXCJibHVlXCIpICFkZWZhdWx0O1xuXG4vLy8gVmlzaXRlZCBsaW5rIGNvbG91clxuLy8vXG4vLy8gQHR5cGUgQ29sb3VyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWxpbmstdmlzaXRlZC1jb2xvdXI6ICM0YzJjOTIgIWRlZmF1bHQ7XG5cbi8vLyBMaW5rIGhvdmVyIGNvbG91clxuLy8vXG4vLy8gQHR5cGUgQ29sb3VyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWxpbmstaG92ZXItY29sb3VyOiBnb3Z1ay1jb2xvdXIoXCJsaWdodC1ibHVlXCIpICFkZWZhdWx0O1xuXG4vLy8gQWN0aXZlIGxpbmsgY29sb3VyXG4vLy9cbi8vLyBAdHlwZSBDb2xvdXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstbGluay1hY3RpdmUtY29sb3VyOiBnb3Z1ay1jb2xvdXIoXCJsaWdodC1ibHVlXCIpICFkZWZhdWx0O1xuIiwiQGltcG9ydCBcIi4uL3NldHRpbmdzL2NvbG91cnMtcGFsZXR0ZVwiO1xuQGltcG9ydCBcIi4uL3NldHRpbmdzL2NvbG91cnMtb3JnYW5pc2F0aW9uc1wiO1xuXG4vLy8vXG4vLy8gQGdyb3VwIGhlbHBlcnMvY29sb3VyXG4vLy8vXG5cbi8vLyBHZXQgY29sb3VyXG4vLy9cbi8vLyBAcGFyYW0ge1N0cmluZ30gJGNvbG91ciAtIE5hbWUgb2YgY29sb3VyIGZyb20gdGhlIGNvbG91ciBwYWxldHRlXG4vLy8gICAoYCRnb3Z1ay1jb2xvdXJzYClcbi8vLyBAcmV0dXJuIHtDb2xvdXJ9IFJlcHJlc2VudGF0aW9uIG9mIG5hbWVkIGNvbG91clxuLy8vIEB0aHJvdyBpZiBgJGNvbG91cmAgaXMgbm90IGEgY29sb3VyIGZyb20gdGhlIGNvbG91ciBwYWxldHRlXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQGZ1bmN0aW9uIGdvdnVrLWNvbG91cigkY29sb3VyKSB7XG4gICRjb2xvdXI6IHF1b3RlKCRjb2xvdXIpO1xuXG4gIEBpZiBub3QgbWFwLWhhcy1rZXkoJGdvdnVrLWNvbG91cnMsICRjb2xvdXIpIHtcbiAgICBAZXJyb3IgXCJVbmtub3duIGNvbG91ciBgI3skY29sb3VyfWBcIjtcbiAgfVxuXG4gIEByZXR1cm4gbWFwLWdldCgkZ292dWstY29sb3VycywgJGNvbG91cik7XG59XG5cbi8vLyBHZXQgdGhlIGNvbG91ciBmb3IgYSBnb3Zlcm5tZW50IG9yZ2FuaXNhdGlvblxuLy8vXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRvcmdhbmlzYXRpb24gLSBPcmdhbmlzYXRpb24gbmFtZSwgbG93ZXJjYXNlLCBoeXBoZW5hdGVkXG4vLy8gQHBhcmFtIHtCb29sZWFufSAkd2Vic2FmZSBbdHJ1ZV0gLSBCeSBkZWZhdWx0IGEgJ3dlYnNhZmUnIHZlcnNpb24gb2YgdGhlXG4vLy8gICBjb2xvdXIgd2lsbCBiZSByZXR1cm5lZCB3aGljaCBtZWV0cyBjb250cmFzdCByZXF1aXJlbWVudHMgLiBJZiB5b3Ugd2FudCB0b1xuLy8vICAgdXNlIHRoZSBub24td2Vic2FmZSB2ZXJzaW9uIHlvdSBjYW4gc2V0IHRoaXMgdG8gYGZhbHNlYCBidXQgeW91ciBzaG91bGRcbi8vLyAgIGVuc3VyZSB0aGF0IHlvdSBzdGlsbCBtZWV0cyBjb250cmFzdCByZXF1aXJlbWVudHMgZm9yIGFjY2Vzc2liaWxpdHkgLSBmb3Jcbi8vLyAgIGV4YW1wbGUsIGRvbid0IHVzZSB0aGUgbm9uLXdlYnNhZmUgdmVyc2lvbiBmb3IgdGV4dC5cbi8vL1xuLy8vIEByZXR1cm4ge0NvbG91cn0gUmVwcmVzZW50YXRpb24gb2YgY29sb3VyIGZvciBvcmdhbmlzYXRpb25cbi8vLyBAdGhyb3cgaWYgYCRvcmdhbmlzYXRpb25gIGlzIG5vdCBhIGtub3duIG9yZ2FuaXNhdGlvblxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBmdW5jdGlvbiBnb3Z1ay1vcmdhbmlzYXRpb24tY29sb3VyKCRvcmdhbmlzYXRpb24sICR3ZWJzYWZlOiB0cnVlKSB7XG4gIEBpZiBub3QgbWFwLWhhcy1rZXkoJGdvdnVrLWNvbG91cnMtb3JnYW5pc2F0aW9ucywgJG9yZ2FuaXNhdGlvbikge1xuICAgIEBlcnJvciBcIlVua25vd24gb3JnYW5pc2F0aW9uIGAjeyRvcmdhbmlzYXRpb259YFwiO1xuICB9XG5cbiAgJG9yZy1jb2xvdXI6IG1hcC1nZXQoJGdvdnVrLWNvbG91cnMtb3JnYW5pc2F0aW9ucywgJG9yZ2FuaXNhdGlvbik7XG5cbiAgQGlmICgkd2Vic2FmZSBhbmQgbWFwLWhhcy1rZXkoJG9yZy1jb2xvdXIsIGNvbG91ci13ZWJzYWZlKSkge1xuICAgIEByZXR1cm4gbWFwLWdldCgkb3JnLWNvbG91ciwgY29sb3VyLXdlYnNhZmUpO1xuICB9IEBlbHNlIHtcbiAgICBAcmV0dXJuIG1hcC1nZXQoJG9yZy1jb2xvdXIsIGNvbG91cik7XG4gIH1cbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgc2V0dGluZ3Mvc3BhY2luZ1xuLy8vL1xuXG4vLy8gU2luZ2xlIHBvaW50IHNwYWNpbmcgdmFyaWFibGVzLiBBY2Nlc3MgdXNpbmcgYGdvdnVrLXNwYWNpbmcoKWBcbi8vLyAoc2VlIGBoZWxwZXJzL3NwYWNpbmdgKS5cbi8vL1xuLy8vIEB0eXBlIE1hcFxuLy8vIEBhY2Nlc3MgcHJpdmF0ZVxuXG4kZ292dWstc3BhY2luZy1wb2ludHM6IChcbiAgMDogMCxcbiAgMTogNXB4LFxuICAyOiAxMHB4LFxuICAzOiAxNXB4LFxuICA0OiAyMHB4LFxuICA1OiAyNXB4LFxuICA2OiAzMHB4LFxuICA3OiA0MHB4LFxuICA4OiA1MHB4LFxuICA5OiA2MHB4XG4pICFkZWZhdWx0O1xuXG4vLy8gUmVzcG9uc2l2ZSBzcGFjaW5nIG1hcHNcbi8vL1xuLy8vIFRoZXNlIGRlZmluaXRpb25zIGFyZSB1c2VkIHRvIGdlbmVyYXRlIHJlc3BvbnNpdmUgc3BhY2luZyB0aGF0IGFkYXB0c1xuLy8vIGFjY29yZGluZyB0byB0aGUgYnJlYWtwb2ludHMgKHNlZSAnaGVscGVycy9zcGFjaW5nJykuIFRoZXNlIG1hcHMgc2hvdWxkIGJlXG4vLy8gdXNlZCB3aGVyZXZlciBwb3NzaWJsZSB0byBzdGFuZGFyZGlzZSByZXNwb25zaXZlIHNwYWNpbmcuXG4vLy9cbi8vLyBZb3UgY2FuIGRlZmluZSBkaWZmZXJlbnQgYmVoYXZpb3VyIG9uIHRhYmxldCBhbmQgZGVza3RvcC4gVGhlICdudWxsJ1xuLy8vIGJyZWFrcG9pbnQgaXMgZm9yIG1vYmlsZS5cbi8vL1xuLy8vIEFjY2VzcyByZXNwb25zaXZlIHNwYWNpbmcgd2l0aCBgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW5gIG9yXG4vLy8gYGdvdnVrLXJlc3BvbnNpdmUtcGFkZGluZ2AgbWl4aW5zIChzZWUgYGhlbHBlcnMvc3BhY2luZ2ApLlxuLy8vXG4vLy8gQHR5cGUgTWFwXG4vLy8gQGFjY2VzcyBwcml2YXRlXG5cbiRnb3Z1ay1zcGFjaW5nLXJlc3BvbnNpdmUtc2NhbGU6IChcbiAgMDogKFxuICAgIG51bGw6IDAsXG4gICAgdGFibGV0OiAwXG4gICksXG4gIDE6IChcbiAgICBudWxsOiA1cHgsXG4gICAgdGFibGV0OiA1cHhcbiAgKSxcbiAgMjogKFxuICAgIG51bGw6IDEwcHgsXG4gICAgdGFibGV0OiAxMHB4XG4gICksXG4gIDM6IChcbiAgICBudWxsOiAxNXB4LFxuICAgIHRhYmxldDogMTVweFxuICApLFxuICA0OiAoXG4gICAgbnVsbDogMTVweCxcbiAgICB0YWJsZXQ6IDIwcHhcbiAgKSxcbiAgNTogKFxuICAgIG51bGw6IDE1cHgsXG4gICAgdGFibGV0OiAyNXB4XG4gICksXG4gIDY6IChcbiAgICBudWxsOiAyMHB4LFxuICAgIHRhYmxldDogMzBweFxuICApLFxuICA3OiAoXG4gICAgbnVsbDogMjVweCxcbiAgICB0YWJsZXQ6IDQwcHhcbiAgKSxcbiAgODogKFxuICAgIG51bGw6IDMwcHgsXG4gICAgdGFibGV0OiA1MHB4XG4gICksXG4gIDk6IChcbiAgICBudWxsOiA0MHB4LFxuICAgIHRhYmxldDogNjBweFxuICApXG4pICFkZWZhdWx0O1xuIiwiLy8vL1xuLy8vIEBncm91cCBzZXR0aW5ncy9tZWFzdXJlbWVudHNcbi8vLy9cblxuXG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gUGFnZSBsYXlvdXRcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG4vLy8gV2lkdGggb2YgbWFpbiBjb250YWluZXJcbi8vL1xuLy8vIEB0eXBlIE51bWJlclxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1wYWdlLXdpZHRoOiA5NjBweCAhZGVmYXVsdDtcblxuLy8vIFdpZHRoIG9mIGd1dHRlciBiZXR3ZWVuIGdyaWQgY29sdW1uc1xuLy8vXG4vLy8gQHR5cGUgTnVtYmVyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWd1dHRlcjogMzBweCAhZGVmYXVsdDtcblxuLy8vIFdpZHRoIG9mIGhhbGYgdGhlIGd1dHRlciBiZXR3ZWVuIGdyaWQgY29sdW1uc1xuLy8vXG4vLy8gQHR5cGUgTnVtYmVyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWd1dHRlci1oYWxmOiAkZ292dWstZ3V0dGVyIC8gMjtcblxuXG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gQm9yZGVyc1xuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG5cbi8vLyBTdGFuZGFyZCBib3JkZXIgd2lkdGhcbi8vL1xuLy8vIEB0eXBlIE51bWJlclxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1ib3JkZXItd2lkdGg6IDVweCAhZGVmYXVsdDtcblxuLy8vIFdpZGUgYm9yZGVyIHdpZHRoXG4vLy9cbi8vLyBAdHlwZSBOdW1iZXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstYm9yZGVyLXdpZHRoLXdpZGU6IDEwcHggIWRlZmF1bHQ7XG5cbi8vLyBCb3JkZXIgd2lkdGggb24gbW9iaWxlXG4vLy9cbi8vLyBAdHlwZSBOdW1iZXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstYm9yZGVyLXdpZHRoLW1vYmlsZTogNHB4ICFkZWZhdWx0O1xuXG4vLy8gRm9ybSBjb250cm9sIGJvcmRlciB3aWR0aFxuLy8vXG4vLy8gQHR5cGUgTnVtYmVyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQ6IDJweCAhZGVmYXVsdDtcblxuLy8vIEZvcm0gY29udHJvbCBib3JkZXIgd2lkdGggd2hlbiBpbiBlcnJvciBzdGF0ZVxuLy8vXG4vLy8gQHR5cGUgTnVtYmVyXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQtZXJyb3I6IDRweCAhZGVmYXVsdDtcblxuLy8vIEZvcm0gZ3JvdXAgYm9yZGVyIHdpZHRoIHdoZW4gaW4gZXJyb3Igc3RhdGVcbi8vL1xuLy8vIEB0eXBlIE51bWJlclxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1ncm91cC1lcnJvcjogJGdvdnVrLWJvcmRlci13aWR0aCAhZGVmYXVsdDtcblxuLy8vIEJvcmRlciB3aWR0aCBvZiBmb2N1cyBvdXRsaW5lXG4vLy9cbi8vLyBAdHlwZSBOdW1iZXJcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstZm9jdXMtd2lkdGg6IDNweCAhZGVmYXVsdDtcbiIsIi8vLy9cbi8vLyBAZ3JvdXAgc2V0dGluZ3MvdHlwb2dyYXBoeVxuLy8vL1xuXG4vLy8gTGlzdCBvZiBmb250IGZhbWlsaWVzIHRvIHVzZSBpZiB1c2luZyBOVEEgKHRoZSBkZWZhdWx0IGZvbnQgJ3N0YWNrJyBmb3Jcbi8vLyBHT1YuVUspXG4vLy9cbi8vLyBAdHlwZSBMaXN0XG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWZvbnQtZmFtaWx5LW50YTogXCJudGFcIiwgQXJpYWwsIHNhbnMtc2VyaWY7XG5cbi8vLyBMaXN0IG9mIGZvbnQgZmFtaWxpZXMgdG8gdXNlIGlmIHVzaW5nIHRoZSAndGFidWxhciBudW1iZXJzJyBzdWJzZXQgb2YgTlRBXG4vLy8gKHRoZSBkZWZhdWx0IGZvbnQgJ3N0YWNrJyBmb3IgR09WLlVLKVxuLy8vXG4vLy8gQmVjYXVzZSBudGF0YWJ1bGFybnVtYmVycyBvbmx5IGluY2x1ZGVzIHRoZSBkaWdpdHMgMC0xMCwgYWxsIG90aGVyIGdseXBoc1xuLy8vIHdpbGwgJ2ZhbGwtdGhyb3VnaCcgdGhlIHN0YWNrIHRvIE5UQS5cbi8vL1xuLy8vIEB0eXBlIExpc3Rcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstZm9udC1mYW1pbHktbnRhLXRhYnVsYXI6IFwibnRhdGFidWxhcm51bWJlcnNcIiwgJGdvdnVrLWZvbnQtZmFtaWx5LW50YTtcbiIsIi8vLy9cbi8vLyBAZ3JvdXAgc2V0dGluZ3MvdHlwb2dyYXBoeVxuLy8vL1xuXG5cblxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG4vLyBGb250IGZhbWlsaWVzXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuLy8vIEZvbnQgZmFtaWxpZXMgdG8gdXNlIGZvciBhbGwgdHlwb2dyYXBoeSBvbiBzY3JlZW4gbWVkaWFcbi8vL1xuLy8vIEB0eXBlIExpc3Rcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstZm9udC1mYW1pbHk6ICRnb3Z1ay1mb250LWZhbWlseS1udGEgIWRlZmF1bHQ7XG5cbi8vLyBGb250IGZhbWlsaWVzIHRvIHVzZSB3aGVuIGRpc3BsYXlpbmcgdGFidWxhciBudW1iZXJzXG4vLy9cbi8vLyBAdHlwZSBMaXN0XG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLWZvbnQtZmFtaWx5LXRhYnVsYXI6ICRnb3Z1ay1mb250LWZhbWlseS1udGEtdGFidWxhciAhZGVmYXVsdDtcblxuLy8vIEZvbnQgZmFtaWxpZXMgdG8gdXNlIGZvciBwcmludCBtZWRpYVxuLy8vXG4vLy8gQHR5cGUgTGlzdFxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1mb250LWZhbWlseS1wcmludDogc2Fucy1zZXJpZiAhZGVmYXVsdDtcblxuXG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gRm9udCB3ZWlnaHRzXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cblxuLy8vIEZvbnQgd2VpZ2h0IGZvciByZWd1bGFyIHR5cG9ncmFwaHlcbi8vL1xuLy8vIEB0eXBlIE51bWJlclxuLy8vIEBhY2Nlc3MgcHVibGljXG4kZ292dWstZm9udC13ZWlnaHQtcmVndWxhcjogNDAwICFkZWZhdWx0O1xuXG4vLy8gRm9udCB3ZWlnaHQgZm9yIGJvbGQgdHlwb2dyYXBoeVxuLy8vXG4vLy8gQHR5cGUgTnVtYmVyXG4vLy8gQGFjY2VzcyBwdWJsaWNcbiRnb3Z1ay1mb250LXdlaWdodC1ib2xkOiA3MDAgIWRlZmF1bHQ7XG4iLCIvLy8vXG4vLy8gQGdyb3VwIHNldHRpbmdzL3R5cG9ncmFwaHlcbi8vLy9cblxuLy8vIFdoZXRoZXIgb3Igbm90IHRvIGRlZmluZSBmb250IHNpemVzIGluIHJlbSwgaW1wcm92aW5nIGFjY2Vzc2liaWxpdHkgYnlcbi8vLyBhbGxvd2luZyB1c2VycyB0byBhZGp1c3QgdGhlIGJhc2UgZm9udC1zaXplLiBUaGlzIGlzIGN1cnJlbnRseSBvZmYgYnlcbi8vLyBkZWZhdWx0LCBidXQgd2lsbCBiZSBlbmFibGVkIGJ5IGRlZmF1bHQgZm9yIHByb2plY3RzIHRoYXQgZG8gbm90IHVzZVxuLy8vIGFscGhhZ292L2dvdnVrX3RlbXBsYXRlIGluIHRoZSBuZXh0IG1ham9yIHJlbGVhc2UuXG4vLy9cbi8vLyBJZiB5b3UgZW5hYmxlIHRoaXMsIHlvdSBzaG91bGQgbWFrZSBzdXJlIHRoYXQgYCRnb3Z1ay1yb290LWZvbnQtc2l6ZWAgaXMgc2V0XG4vLy8gY29ycmVjdGx5IGZvciB5b3VyIHByb2plY3QuXG4vLy9cbi8vLyBAdHlwZSBCb29sZWFuXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuJGdvdnVrLXR5cG9ncmFwaHktdXNlLXJlbTogZmFsc2UgIWRlZmF1bHQ7XG5cbi8vLyBSb290IGZvbnQgc2l6ZVxuLy8vXG4vLy8gVGhpcyBpcyB1c2VkIHRvIGNhbGN1bGF0ZSByZW0gc2l6ZXMgZm9yIHRoZSB0eXBvZ3JhcGh5LCBhbmQgc2hvdWxkIG1hdGNoIHRoZVxuLy8vIF9lZmZlY3RpdmVfIGZvbnQtc2l6ZSBvZiB5b3VyIHJvb3QgKG9yIGh0bWwpIGVsZW1lbnQuXG4vLy9cbi8vLyBJZGVhbGx5IHlvdSBzaG91bGQgbm90IGJlIHNldHRpbmcgdGhlIGZvbnQtc2l6ZSBvbiB0aGUgaHRtbCBvciByb290IGVsZW1lbnRcbi8vLyBpbiBvcmRlciB0byBhbGxvdyBpdCB0byBzY2FsZSB3aXRoIHVzZXItcHJlZmVyZW5jZSwgaW4gd2hpY2ggY2FzZSB0aGlzXG4vLy8gc2hvdWxkIGJlIHNldCB0byAxNnB4LlxuLy8vXG4vLy8gSWYgeW91IGFyZSBpbnRlZ3JhdGluZyBGcm9udGVuZCBpbnRvIGFuIGV4aXN0aW5nIHByb2plY3QgdGhhdCBhbHNvIHVzZXNcbi8vLyBhbHBoYWdvdi9nb3Z1a190ZW1wbGF0ZSB0aGVuIHlvdSBzaG91bGQgc2V0IHRoaXMgdG8gMTBweCB0byBtYXRjaCB0aGUgNjIuNSVcbi8vLyAoMTBweCkgYmFzZSBmb250IHNpemUgdGhhdCBnb3Z1a190ZW1wbGF0ZSBzZXRzIG9uIHRoZSA8aHRtbD4gZWxlbWVudC5cbi8vL1xuLy8vIEB0eXBlIE51bWJlclxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbiRnb3Z1ay1yb290LWZvbnQtc2l6ZTogMTZweCAhZGVmYXVsdDtcblxuLy8vIFJlc3BvbnNpdmUgdHlwb2dyYXBoeSBmb250IG1hcFxuLy8vXG4vLy8gVGhpcyBpcyB1c2VkIHRvIGdlbmVyYXRlIHJlc3BvbnNpdmUgdHlwb2dyYXBoeSB0aGF0IGFkYXB0cyBhY2NvcmRpbmcgdG8gdGhlXG4vLy8gYnJlYWtwb2ludHMuXG4vLy9cbi8vLyBGb250IHNpemUgYW5kIGZvbnQgd2VpZ2h0IGNhbiBiZSBkZWZpbmVkIGZvciBlYWNoIGJyZWFrcG9pbnQuIFlvdSBjYW4gZGVmaW5lXG4vLy8gZGlmZmVyZW50IGJlaGF2aW91ciBvbiB0YWJsZXQgYW5kIGRlc2t0b3AuIFRoZSAnbnVsbCcgYnJlYWtwb2ludCBpcyBmb3Jcbi8vLyBtb2JpbGUuXG4vLy9cbi8vLyBMaW5lLWhlaWdodHMgd2lsbCBhdXRvbWF0aWNhbGx5IGJlIGNvbnZlcnRlZCBmcm9tIHBpeGVsIG1lYXN1cmVtZW50cyBpbnRvXG4vLy8gcmVsYXRpdmUgdmFsdWVzLiBGb3IgZXhhbXBsZSwgd2l0aCBhIGZvbnQtc2l6ZSBvZiAxNnB4IGFuZCBhIGxpbmUtaGVpZ2h0IG9mXG4vLy8gMjRweCwgdGhlIGxpbmUtaGVpZ2h0IHdpbGwgYmUgY29udmVydGVkIHRvIDEuNSBiZWZvcmUgb3V0cHV0LlxuLy8vXG4vLy8gWW91IGNhbiBhbHNvIHNwZWNpZnkgYSBzZXBhcmF0ZSBmb250IHNpemUgYW5kIGxpbmUgaGVpZ2h0IGZvciBwcmludCBtZWRpYS5cbi8vL1xuLy8vIEB0eXBlIE1hcFxuLy8vXG4vLy8gQHByb3Age051bWJlcn0gJHBvaW50LiRicmVha3BvaW50LmZvbnQtc2l6ZSAtIEZvbnQgc2l6ZSBmb3IgYCRwb2ludGAgYXQgYCRicmVha3BvaW50YFxuLy8vIEBwcm9wIHtOdW1iZXJ9ICRwb2ludC4kYnJlYWtwb2ludC5saW5lLWhlaWdodCAtIExpbmUgaGVpZ2h0IGZvciBgJHBvaW50YCBhdCBgJGJyZWFrcG9pbnRgXG4vLy8gQHByb3Age051bWJlcn0gJHBvaW50LnByaW50LmZvbnQtc2l6ZSAtIEZvbnQgc2l6ZSBmb3IgYCRwb2ludGAgd2hlbiBwcmludGluZ1xuLy8vIEBwcm9wIHtOdW1iZXJ9ICRwb2ludC5wcmludC5saW5lLWhlaWdodCAtIExpbmUgaGVpZ2h0IGZvciBgJHBvaW50YCB3aGVuIHByaW50aW5nXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG4kZ292dWstdHlwb2dyYXBoeS1zY2FsZTogKFxuICA4MDogKFxuICAgIG51bGw6IChcbiAgICAgIGZvbnQtc2l6ZTogNTNweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiA1NXB4XG4gICAgKSxcbiAgICB0YWJsZXQ6IChcbiAgICAgIGZvbnQtc2l6ZTogODBweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiA4MHB4XG4gICAgKSxcbiAgICBwcmludDogKFxuICAgICAgZm9udC1zaXplOiA1M3B0LFxuICAgICAgbGluZS1oZWlnaHQ6IDEuMVxuICAgIClcbiAgKSxcbiAgNDg6IChcbiAgICBudWxsOiAoXG4gICAgICBmb250LXNpemU6IDMycHgsXG4gICAgICBsaW5lLWhlaWdodDogMzVweFxuICAgICksXG4gICAgdGFibGV0OiAoXG4gICAgICBmb250LXNpemU6IDQ4cHgsXG4gICAgICBsaW5lLWhlaWdodDogNTBweFxuICAgICksXG4gICAgcHJpbnQ6IChcbiAgICAgIGZvbnQtc2l6ZTogMzJwdCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAxLjE1XG4gICAgKVxuICApLFxuICAzNjogKFxuICAgIG51bGw6IChcbiAgICAgIGZvbnQtc2l6ZTogMjRweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNXB4XG4gICAgKSxcbiAgICB0YWJsZXQ6IChcbiAgICAgIGZvbnQtc2l6ZTogMzZweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiA0MHB4XG4gICAgKSxcbiAgICBwcmludDogKFxuICAgICAgZm9udC1zaXplOiAyNHB0LFxuICAgICAgbGluZS1oZWlnaHQ6IDEuMDVcbiAgICApXG4gICksXG4gIDI3OiAoXG4gICAgbnVsbDogKFxuICAgICAgZm9udC1zaXplOiAxOHB4LFxuICAgICAgbGluZS1oZWlnaHQ6IDIwcHhcbiAgICApLFxuICAgIHRhYmxldDogKFxuICAgICAgZm9udC1zaXplOiAyN3B4LFxuICAgICAgbGluZS1oZWlnaHQ6IDMwcHhcbiAgICApLFxuICAgIHByaW50OiAoXG4gICAgICBmb250LXNpemU6IDE4cHQsXG4gICAgICBsaW5lLWhlaWdodDogMS4xNVxuICAgIClcbiAgKSxcbiAgMjQ6IChcbiAgICBudWxsOiAoXG4gICAgICBmb250LXNpemU6IDE4cHgsXG4gICAgICBsaW5lLWhlaWdodDogMjBweFxuICAgICksXG4gICAgdGFibGV0OiAoXG4gICAgICBmb250LXNpemU6IDI0cHgsXG4gICAgICBsaW5lLWhlaWdodDogMzBweFxuICAgICksXG4gICAgcHJpbnQ6IChcbiAgICAgIGZvbnQtc2l6ZTogMThwdCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAxLjE1XG4gICAgKVxuICApLFxuICAxOTogKFxuICAgIG51bGw6IChcbiAgICAgIGZvbnQtc2l6ZTogMTZweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAyMHB4XG4gICAgKSxcbiAgICB0YWJsZXQ6IChcbiAgICAgIGZvbnQtc2l6ZTogMTlweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAyNXB4XG4gICAgKSxcbiAgICBwcmludDogKFxuICAgICAgZm9udC1zaXplOiAxNHB0LFxuICAgICAgbGluZS1oZWlnaHQ6IDEuMTVcbiAgICApXG4gICksXG4gIDE2OiAoXG4gICAgbnVsbDogKFxuICAgICAgZm9udC1zaXplOiAxNHB4LFxuICAgICAgbGluZS1oZWlnaHQ6IDE2cHhcbiAgICApLFxuICAgIHRhYmxldDogKFxuICAgICAgZm9udC1zaXplOiAxNnB4LFxuICAgICAgbGluZS1oZWlnaHQ6IDIwcHhcbiAgICApLFxuICAgIHByaW50OiAoXG4gICAgICBmb250LXNpemU6IDE0cHQsXG4gICAgICBsaW5lLWhlaWdodDogMS4yXG4gICAgKVxuICApLFxuICAxNDogKFxuICAgIG51bGw6IChcbiAgICAgIGZvbnQtc2l6ZTogMTJweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAxNXB4XG4gICAgKSxcbiAgICB0YWJsZXQ6IChcbiAgICAgIGZvbnQtc2l6ZTogMTRweCxcbiAgICAgIGxpbmUtaGVpZ2h0OiAyMHB4XG4gICAgKSxcbiAgICBwcmludDogKFxuICAgICAgZm9udC1zaXplOiAxMnB0LFxuICAgICAgbGluZS1oZWlnaHQ6IDEuMlxuICAgIClcbiAgKVxuKSAhZGVmYXVsdDtcbiIsIkBpbXBvcnQgXCJjb21wYXRpYmlsaXR5XCI7XG5AaW1wb3J0IFwiZXhwb3J0c1wiO1xuQGltcG9ydCBcImZvbnQtdXJsXCI7XG5AaW1wb3J0IFwiaWU4XCI7XG5AaW1wb3J0IFwiaWZmXCI7XG5AaW1wb3J0IFwiaW1hZ2UtdXJsXCI7XG5AaW1wb3J0IFwicHgtdG8tZW1cIjtcbkBpbXBvcnQgXCJweC10by1yZW1cIjtcbiIsIi8vLy9cbi8vLyBAZ3JvdXAgdG9vbHNcbi8vLy9cblxuLy8vIENvbmRpdGlvbmFsIENvbXBhdGliaWxpdHkgTWl4aW5cbi8vL1xuLy8vIFNlbGVjdGl2ZWx5IG91dHB1dCBhIGJsb2NrIChhdmFpbGFibGUgdG8gdGhlIG1peGluIGFzIEBjb250ZW50KSBpZiBhIGdpdmVuXG4vLy8gJHByb2R1Y3QgaXMgYWxzbyBpZGVudGlmaWVkIGFzIGJlaW5nIHVzZWQgaW4gdGhlIHByb2plY3QuXG4vLy9cbi8vLyBUaGlzIGNhbiB0aGVuIGJlIHVzZWQgdG8gaW5jbHVkZSBzdHlsZXMgdGhhdCBhcmUgb25seSBuZWVkZWQgdG8gb3ZlcnJpZGVcbi8vLyBzdHlsZXMgcHJvdmlkZWQgYnkgdGhvc2Ugb3RoZXIgcHJvZHVjdHMgKGUuZy4gd2hlcmUgZ292dWtfdGVtcGxhdGUgaGFzIGFcbi8vLyB2ZXJ5IHNwZWNpZmljIGxpbmsgc2VsZWN0b3IgdGhhdCBvdGhlcndpc2UgYWZmZWN0cyBidXR0b25zKS5cbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgIC8vIE92ZXJyaWRlIC5teS1jbGFzcyBpZiBHT1YuVUsgVGVtcGxhdGUgaXMgYWxzbyBiZWluZyB1c2VkXG4vLy8gICBAaW5jbHVkZSBnb3Z1ay1jb21wYXRpYmlsaXR5KGdvdnVrX3RlbXBsYXRlKSB7XG4vLy8gICAgIC5teS1jbGFzcyB7XG4vLy8gICAgICAgY29sb3I6IGluaGVyaXQ7XG4vLy8gICAgIH1cbi8vLyAgIH1cbi8vL1xuLy8vIEBwYXJhbSB7U3RyaW5nfSAkcHJvZHVjdCAtIE5hbWUgb2YgcHJvZHVjdCB0aGF0IHdlIGFyZSAnZGVmZW5kaW5nJyBhZ2FpbnN0LlxuLy8vIEBjb250ZW50IFBhc3NlZCBjb250ZW50IGlzIG91dHB1dHRlZCBvbmx5IGlmIEZyb250ZW5kIGlzIGJlaW5nIHVzZWQgd2l0aFxuLy8vICAgdGhpcyBwcm9kdWN0XG4vLy8gQHRocm93IEVycm9ycyBpZiBwcm9kdWN0IG5hbWUgaXMgbm90IHJlY29nbmlzZWRcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstY29tcGF0aWJpbGl0eSgkcHJvZHVjdCkge1xuICBAaWYgbWFwLWhhcy1rZXkoJF9nb3Z1ay1jb21wYXRpYmlsaXR5LCAkcHJvZHVjdCkge1xuICAgIEBpZiBtYXAtZ2V0KCRfZ292dWstY29tcGF0aWJpbGl0eSwgJHByb2R1Y3QpID09IHRydWUge1xuICAgICAgQGNvbnRlbnQ7XG4gICAgfVxuICB9IEBlbHNlIHtcbiAgICBAZXJyb3IgXCJOb24gZXhpc3RlbnQgcHJvZHVjdCAnI3skcHJvZHVjdH0nXCI7XG4gIH1cbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgdG9vbHNcbi8vLy9cblxuLy8vIExpc3Qgb2YgbW9kdWxlcyB3aGljaCBoYXZlIGFscmVhZHkgYmVlbiBleHBvcnRlZFxuLy8vXG4vLy8gQHR5cGUgTGlzdFxuLy8vIEBhY2Nlc3MgcHJpdmF0ZVxuXG4kX2dvdnVrLWltcG9ydGVkLW1vZHVsZXM6ICgpICFkZWZhdWx0O1xuXG4vLy8gRXhwb3J0IG1vZHVsZVxuLy8vXG4vLy8gRW5zdXJlIHRoYXQgdGhlIG1vZHVsZXMgb2YgQ1NTIHRoYXQgd2UgZGVmaW5lIHRocm91Z2hvdXQgRnJvbnRlbmQgYXJlIG9ubHlcbi8vLyBpbmNsdWRlZCBpbiB0aGUgZ2VuZXJhdGVkIENTUyBvbmNlLCBubyBtYXR0ZXIgaG93IG1hbnkgdGltZXMgdGhleSBhcmVcbi8vLyBpbXBvcnRlZCBhY3Jvc3MgdGhlIGluZGl2aWR1YWwgY29tcG9uZW50cy5cbi8vL1xuLy8vIEBwYXJhbSB7U3RyaW5nfSAkbmFtZSAtIE5hbWUgb2YgbW9kdWxlIC0gbXVzdCBiZSB1bmlxdWUgd2l0aGluIHRoZSBjb2RlYmFzZVxuLy8vIEBjb250ZW50IFRoZSBwYXNzZWQgY29udGVudCB3aWxsIG9ubHkgYmUgb3V0cHV0dGVkIGlmIGEgbW9kdWxlIG9mIHRoZSBzYW1lXG4vLy8gICAkbmFtZSBoYXMgbm90IGFscmVhZHkgYmVlbiBvdXRwdXR0ZWRcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstZXhwb3J0cygkbmFtZSkge1xuICAvLyBJZiB0aGUgbWl4aW4gaXMgbm90IGluIHRoZSBsaXN0IG9mIG1vZHVsZXMgYWxyZWFkeSBleHBvcnRlZC4uLlxuICBAaWYgKGluZGV4KCRfZ292dWstaW1wb3J0ZWQtbW9kdWxlcywgJG5hbWUpID09IG51bGwpIHtcbiAgICAvLyAuLi4gdGhlbiBhZGQgaXQgdG8gdGhlIGxpc3RcbiAgICAkX2dvdnVrLWltcG9ydGVkLW1vZHVsZXM6IGFwcGVuZCgkX2dvdnVrLWltcG9ydGVkLW1vZHVsZXMsICRuYW1lKSAhZ2xvYmFsO1xuICAgIC8vIC4uLiBhbmQgb3V0cHV0IHRoZSBDU1MgZm9yIHRoYXQgbW9kdWxlXG4gICAgQGNvbnRlbnQ7XG4gIH1cbiAgLy8gVGhlIG5leHQgdGltZSBleHBvcnRzIGlzIGNhbGxlZCBmb3IgdGhlIG1vZHVsZSBvZiB0aGUgc2FtZSBuYW1lLCBpdCB3aWxsIGJlXG4gIC8vIGZvdW5kIGluIHRoZSBsaXN0IGFuZCBzbyBub3RoaW5nIHdpbGwgYmUgb3V0cHV0dGVkLlxufVxuIiwiLy8vL1xuLy8vIEBncm91cCB0b29sc1xuLy8vL1xuXG4vLyBEaXNhYmxlIGluZGVudGF0aW9uIGxpbnRpbmcgaW4gdGhpcyBmaWxlIG9ubHlcbi8vIHNhc3MtbGludDpkaXNhYmxlIGluZGVudGF0aW9uXG5cbi8vLyBGb250IFVSTFxuLy8vXG4vLy8gSWYgYSBjdXN0b20gZm9udC11cmwgaGFuZGxlciBpcyBkZWZpbmVkICgkZ292dWstZm9udC11cmwtZnVuY3Rpb24pIHRoZW5cbi8vLyBpdCB3aWxsIGJlIGNhbGxlZCwgb3RoZXJ3aXNlIGEgdXJsIHdpbGwgYmUgcmV0dXJuZWQgd2l0aCB0aGUgZmlsZW5hbWVcbi8vLyBhcHBlbmRlZCB0byB0aGUgZm9udCBwYXRoLlxuLy8vXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRmaWxlbmFtZSAtIEZvbnQgZmlsZW5hbWVcbi8vLyBAcmV0dXJuIHtTdHJpbmd9IFVSTCBmb3IgdGhlIGZpbGVuYW1lLCB3cmFwcGVkIGluIGB1cmwoKWBcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AZnVuY3Rpb24gZ292dWstZm9udC11cmwoJGZpbGVuYW1lKSB7XG4gICR1c2UtY3VzdG9tLWZ1bmN0aW9uOiB2YXJpYWJsZS1leGlzdHMoXCJnb3Z1ay1mb250LXVybC1mdW5jdGlvblwiKVxuICAgIGFuZCAkZ292dWstZm9udC11cmwtZnVuY3Rpb25cbiAgICBhbmQgZnVuY3Rpb24tZXhpc3RzKCRnb3Z1ay1mb250LXVybC1mdW5jdGlvbik7XG5cbiAgQGlmICgkdXNlLWN1c3RvbS1mdW5jdGlvbikge1xuICAgIEByZXR1cm4gY2FsbChnZXQtZnVuY3Rpb24oJGdvdnVrLWZvbnQtdXJsLWZ1bmN0aW9uKSwgJGZpbGVuYW1lKTtcbiAgfSBAZWxzZSB7XG4gICAgQHJldHVybiB1cmwoJGdvdnVrLWZvbnRzLXBhdGggKyAkZmlsZW5hbWUpO1xuICB9XG59XG4iLCIvLy8vXG4vLy8gQGdyb3VwIHRvb2xzXG4vLy8vXG5cbi8vLyBDb25kaXRpb25hbGx5IGluY2x1ZGUgcnVsZXMgb25seSBmb3IgSUU4XG4vLy9cbi8vLyBAY29udGVudCBQYXNzZWQgY29udGVudCBpcyBvbmx5IG91dHB1dHRlZCBpZiB3ZSdyZSBjb21waWxpbmcgYSBzdHlsZXNoZWV0XG4vLy8gICB0aGF0IHRhcmdldHMgSUU4IChpZiBgJGdvdnVrLWlzLWllOGAgaXMgdHJ1ZSlcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBVc2FnZVxuLy8vXG4vLy8gICAuZm9vIHtcbi8vLyAgICAgbWluLXdpZHRoOiAxMDBweDtcbi8vLyAgICAgLy8gU3BlY2lmeSB3aWR0aCBmb3IgSUU4IG9ubHlcbi8vLyAgICAgQGluY2x1ZGUgZ292dWstaWYtaWU4IHtcbi8vLyAgICAgICB3aWR0aDogMTAwcHg7XG4vLy8gICAgIH1cbi8vLyAgIH1cbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1pZi1pZTgge1xuICBAaWYgJGdvdnVrLWlzLWllOCB7XG4gICAgQGNvbnRlbnQ7XG4gIH1cbn1cblxuLy8vIENvbmRpdGlvbmFsbHkgZXhjbHVkZSBydWxlcyBmb3IgSUU4XG4vLy9cbi8vLyBAY29udGVudCBQYXNzZWQgY29udGVudCBpcyBvbmx5IG91dHB1dHRlZCBpZiB3ZSdyZSBub3QgY29tcGlsaW5nIGFcbi8vLyAgIHN0eWxlc2hlZXQgdGhhdCB0YXJnZXRzIElFOCAoaWYgYCRnb3Z1ay1pcy1pZThgIGlzIGZhbHNlKVxuLy8vXG4vLy8gQGV4YW1wbGUgc2NzcyAtIFVzYWdlXG4vLy9cbi8vLyAgIC5mb28ge1xuLy8vICAgICBmb250LXdlaWdodDogYm9sZDtcbi8vL1xuLy8vICAgICAvLyBFbmhhbmNlIGZvbyBvbmx5IGZvciBtb2Rlcm4gYnJvd3NlcnMgKG5vdCBJRTgpXG4vLy8gICAgIEBpbmNsdWRlIGdvdnVrLW5vdC1pZTgge1xuLy8vICAgICAgIGZvbnQtZmFtaWx5OiBcIkNvbWljIFNhbnMgTVNcIiwgXCJDdXJseiBNVFwiIGN1cnNpdmUsIHNhbnMtc2VyaWY7XG4vLy8gICAgICAgY29sb3I6ICNGRjY5QjQ7XG4vLy8gICAgIH1cbi8vLyAgIH1cbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1ub3QtaWU4IHtcbiAgQGlmIG5vdCAkZ292dWstaXMtaWU4IHtcbiAgICBAY29udGVudDtcbiAgfVxufVxuIiwiLy8vL1xuLy8vIEBncm91cCB0b29sc1xuLy8vL1xuXG4vLy8gU3ludGFjdGljIHN1Z2FyIGFyb3VuZCBTYXNzJyBidWlsdC1pbiBgaWZgIGZ1bmN0aW9uIHRoYXQgZG9lcyBub3QgcmVxdWlyZVxuLy8vIHlvdSB0byBwYXNzIGEgdmFsdWUgZm9yIGAkaWYtZmFsc2VgLlxuLy8vXG4vLy8gQHBhcmFtIHtCb29sZWFufSAkY29uZGl0aW9uIC0gV2hldGhlciB0byByZXR1cm4gdGhlIHZhbHVlIG9mIGAkaWYtdHJ1ZWBcbi8vLyBAcGFyYW0ge01peGVkfSAkaWYtdHJ1ZSAtIFZhbHVlIHRvIHJldHVybiBpZiBgJGNvbmRpdGlvbmAgaXMgdHJ1dGh5XG4vLy8gQHJldHVybiB7TWl4ZWR9IFZhbHVlIG9mIGAkaWYtdHJ1ZWAgaWYgYCRjb25kaXRpb25gIGlzIHRydXRoeSwgZWxzZSBudWxsXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQGZ1bmN0aW9uIGlmZigkY29uZGl0aW9uLCAkaWYtdHJ1ZSkge1xuICBAcmV0dXJuIGlmKCRjb25kaXRpb24sICRpZi10cnVlLCBudWxsKTtcbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgdG9vbHNcbi8vLy9cblxuLy8gRGlzYWJsZSBpbmRlbnRhdGlvbiBsaW50aW5nIGluIHRoaXMgZmlsZSBvbmx5XG4vLyBzYXNzLWxpbnQ6ZGlzYWJsZSBpbmRlbnRhdGlvblxuXG4vLy8gSW1hZ2UgVVJMXG4vLy9cbi8vLyBJZiBhIGN1c3RvbSBpbWFnZS11cmwgaGFuZGxlciBpcyBkZWZpbmVkICgkZ292dWstaW1hZ2UtdXJsLWZ1bmN0aW9uKSB0aGVuXG4vLy8gaXQgd2lsbCBiZSBjYWxsZWQsIG90aGVyd2lzZSBhIHVybCB3aWxsIGJlIHJldHVybmVkIHdpdGggdGhlIGZpbGVuYW1lXG4vLy8gYXBwZW5kZWQgdG8gdGhlIGltYWdlIHBhdGguXG4vLy9cbi8vLyBAcGFyYW0ge1N0cmluZ30gRmlsZW5hbWUgZm9yIHRoZSBpbWFnZSB0byBsb2FkXG4vLy8gQHJldHVybiB7U3RyaW5nfSBVUkwgZm9yIHRoZSBmaWxlbmFtZSwgd3JhcHBlZCBpbiBgdXJsKClgXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQGZ1bmN0aW9uIGdvdnVrLWltYWdlLXVybCgkZmlsZW5hbWUpIHtcbiAgJHVzZS1jdXN0b20tZnVuY3Rpb246IHZhcmlhYmxlLWV4aXN0cyhcImdvdnVrLWltYWdlLXVybC1mdW5jdGlvblwiKVxuICAgIGFuZCAkZ292dWstaW1hZ2UtdXJsLWZ1bmN0aW9uXG4gICAgYW5kIGZ1bmN0aW9uLWV4aXN0cygkZ292dWstaW1hZ2UtdXJsLWZ1bmN0aW9uKTtcblxuICBAaWYgKCR1c2UtY3VzdG9tLWZ1bmN0aW9uKSB7XG4gICAgQHJldHVybiBjYWxsKGdldC1mdW5jdGlvbigkZ292dWstaW1hZ2UtdXJsLWZ1bmN0aW9uKSwgJGZpbGVuYW1lKTtcbiAgfSBAZWxzZSB7XG4gICAgQHJldHVybiB1cmwoJGdvdnVrLWltYWdlcy1wYXRoICsgJGZpbGVuYW1lKTtcbiAgfVxufVxuIiwiLy8vL1xuLy8vIEBncm91cCB0b29sc1xuLy8vL1xuXG4vLy8gQ29udmVydCBwaXhlbHMgdG8gZW1cbi8vL1xuLy8vIEBwYXJhbSB7TnVtYmVyfSAkdmFsdWUgLSBMZW5ndGggaW4gcGl4ZWxzXG4vLy8gQHBhcmFtIHtOdW1iZXJ9ICRjb250ZXh0LWZvbnQtc2l6ZSAtIEZvbnQgc2l6ZSBvZiBlbGVtZW50XG4vLy8gQHJldHVybiB7TnVtYmVyfSBMZW5ndGggaW4gZW1zXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQGZ1bmN0aW9uIGdvdnVrLWVtKCR2YWx1ZSwgJGNvbnRleHQtZm9udC1zaXplKSB7XG4gIEBpZiAodW5pdGxlc3MoJHZhbHVlKSkge1xuICAgICR2YWx1ZTogJHZhbHVlICogMXB4O1xuICB9XG4gIEBpZiAodW5pdGxlc3MoJGNvbnRleHQtZm9udC1zaXplKSkge1xuICAgICRjb250ZXh0LWZvbnQtc2l6ZTogJGNvbnRleHQtZm9udC1zaXplICogMXB4O1xuICB9XG4gIEByZXR1cm4gJHZhbHVlIC8gJGNvbnRleHQtZm9udC1zaXplICogMWVtO1xufVxuIiwiLy8vL1xuLy8vIEBncm91cCB0b29sc1xuLy8vL1xuXG4vLy8gQ29udmVydCBwaXhlbHMgdG8gcmVtXG4vLy9cbi8vLyBUaGUgJGdvdnVrLXJvb3QtZm9udC1zaXplIChkZWZpbmVkIGluIHNldHRpbmdzL190eXBvZ3JhcGh5LXJlc3BvbnNpdmUuc2Nzcylcbi8vLyBtdXN0IGJlIGNvbmZpZ3VyZWQgdG8gbWF0Y2ggdGhlIGZvbnQtc2l6ZSBvZiB5b3VyIHJvb3QgKGh0bWwpIGVsZW1lbnRcbi8vL1xuLy8vIEBwYXJhbSB7TnVtYmVyfSAkdmFsdWUgLSBMZW5ndGggaW4gcGl4ZWxzXG4vLy8gQHJldHVybiB7TnVtYmVyfSBMZW5ndGggaW4gcmVtc1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBmdW5jdGlvbiBnb3Z1ay1weC10by1yZW0oJHZhbHVlKSB7XG4gIEBpZiAodW5pdGxlc3MoJHZhbHVlKSkge1xuICAgICR2YWx1ZTogJHZhbHVlICogMXB4O1xuICB9XG5cbiAgQHJldHVybiAkdmFsdWUgLyAkZ292dWstcm9vdC1mb250LXNpemUgKiAxcmVtO1xufVxuIiwiQGltcG9ydCBcImNsZWFyZml4XCI7XG5AaW1wb3J0IFwiY29sb3VyXCI7XG5AaW1wb3J0IFwiZGV2aWNlLXBpeGVsc1wiO1xuQGltcG9ydCBcImZvY3VzYWJsZVwiO1xuQGltcG9ydCBcImZvbnQtZmFjZXNcIjtcbkBpbXBvcnQgXCJncmlkXCI7XG5AaW1wb3J0IFwibGlua3NcIjtcbkBpbXBvcnQgXCJtZWRpYS1xdWVyaWVzXCI7XG5AaW1wb3J0IFwic2hhcGUtYXJyb3dcIjtcbkBpbXBvcnQgXCJzcGFjaW5nXCI7XG5AaW1wb3J0IFwidHlwb2dyYXBoeVwiO1xuQGltcG9ydCBcInZpc3VhbGx5LWhpZGRlblwiO1xuIiwiLy8vL1xuLy8vIEBncm91cCBoZWxwZXJzXG4vLy8vXG5cbi8vLyBDbGVhciBmbG9hdGVkIGNvbnRlbnQgd2l0aGluIGEgY29udGFpbmVyIHVzaW5nIGEgcHNldWRvIGVsZW1lbnRcbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1jbGVhcmZpeCB7XG4gICY6YWZ0ZXIge1xuICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgY2xlYXI6IGJvdGg7XG4gIH1cbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgaGVscGVyc1xuLy8vL1xuXG4vLy8gTWVkaWEgcXVlcnkgZm9yIHJldGluYSBpbWFnZXMgKGRldmljZS1waXhlbC1yYXRpbylcbi8vL1xuLy8vIEBwYXJhbSB7TnVtYmVyfSAkcmF0aW8gWzJdIC0gRGV2aWNlIHBpeGVsIHJhdGlvXG4vLy8gQGNvbnRlbnQgUGFzc2VkIGNvbnRlbnQgd2lsbCBiZSBvdXRwdXR0ZWQgd2l0aGluIHRoZSBtZWRpYSBxdWVyeVxuLy8vXG4vLy8gQGV4YW1wbGUgc2NzcyAtIFByb3ZpZGluZyBhIEAyeCBpbWFnZSBmb3Igc2NyZWVucyB0aGF0IHN1cHBvcnQgaXRcbi8vLyAgIGJhY2tncm91bmQtaW1hZ2U6IGdvdnVrLWltYWdlLXVybChcIm15LWltYWdlLnBuZ1wiKTtcbi8vL1xuLy8vICAgQGluY2x1ZGUgZ292dWstZGV2aWNlLXBpeGVsLXJhdGlvIHtcbi8vLyAgICAgYmFja2dyb3VuZC1pbWFnZTogZ292dWstaW1hZ2UtdXJsKFwibXktaW1hZ2UtMngucG5nXCIpO1xuLy8vICAgfVxuLy8vXG4vLy8gQGV4YW1wbGUgc2NzcyAtIFVzaW5nIGEgY3VzdG9tIHJhdGlvXG4vLy8gICBiYWNrZ3JvdW5kLWltYWdlOiBnb3Z1ay1pbWFnZS11cmwoXCJteS1pbWFnZS5wbmdcIik7XG4vLy9cbi8vLyAgIEBpbmNsdWRlIGdvdnVrLWRldmljZS1waXhlbC1yYXRpbyB7XG4vLy8gICAgIGJhY2tncm91bmQtaW1hZ2U6IGdvdnVrLWltYWdlLXVybChcIm15LWltYWdlLTJ4LnBuZ1wiKTtcbi8vLyAgIH1cbi8vL1xuLy8vICAgQGluY2x1ZGUgZ292dWstZGV2aWNlLXBpeGVsLXJhdGlvKDMpIHtcbi8vLyAgICAgYmFja2dyb3VuZC1pbWFnZTogZ292dWstaW1hZ2UtdXJsKFwibXktaW1hZ2UtM3gucG5nXCIpO1xuLy8vICAgfVxuLy8vXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQG1peGluIGdvdnVrLWRldmljZS1waXhlbC1yYXRpbygkcmF0aW86IDIpIHtcbiAgQG1lZGlhIG9ubHkgc2NyZWVuIGFuZCAoLXdlYmtpdC1taW4tZGV2aWNlLXBpeGVsLXJhdGlvOiAkcmF0aW8pLFxuICAgIG9ubHkgc2NyZWVuIGFuZCAobWluLS1tb3otZGV2aWNlLXBpeGVsLXJhdGlvOiAkcmF0aW8pLFxuICAgIG9ubHkgc2NyZWVuIGFuZCAoICAgICBtaW4tZGV2aWNlLXBpeGVsLXJhdGlvOiAkcmF0aW8pLFxuICAgIG9ubHkgc2NyZWVuIGFuZCAoICAgICAgICAgICAgIG1pbi1yZXNvbHV0aW9uOiAjeygkcmF0aW8qOTYpfWRwaSksXG4gICAgb25seSBzY3JlZW4gYW5kICggICAgICAgICAgICAgbWluLXJlc29sdXRpb246ICN7JHJhdGlvfWRwcHgpIHtcbiAgICAgIEBjb250ZW50O1xuICAgIH1cbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgaGVscGVyc1xuLy8vL1xuXG4vLy8gRm9jdXNhYmxlIGhlbHBlclxuLy8vXG4vLy8gUHJvdmlkZXMgYW4gYWRkaXRpb25hbCBvdXRsaW5lIHRvIGNsZWFybHkgaW5kaWNhdGUgd2hlbiB0aGUgdGFyZ2V0IGVsZW1lbnQgaXNcbi8vLyBmb2N1c3NlZC4gVXNlZCBmb3IgaW50ZXJhY3RpdmUgZWxlbWVudHMgd2hpY2ggdGhlbXNlbHZlcyBoYXZlIHNvbWUgYmFja2dyb3VuZFxuLy8vIG9yIGJvcmRlciwgc3VjaCBhcyBtb3N0IGZvcm0gZWxlbWVudHMuXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstZm9jdXNhYmxlIHtcbiAgJjpmb2N1cyB7XG4gICAgb3V0bGluZTogJGdvdnVrLWZvY3VzLXdpZHRoIHNvbGlkICRnb3Z1ay1mb2N1cy1jb2xvdXI7XG4gICAgb3V0bGluZS1vZmZzZXQ6IDA7XG4gIH1cbn1cblxuLy8vIEZvY3VzYWJsZSB3aXRoIGZpbGwgaGVscGVyXG4vLy9cbi8vLyBQcm92aWRlcyBhbiBhZGRpdGlvbmFsIG91dGxpbmUgYW5kIGJhY2tncm91bmQgY29sb3VyIHRvIGNsZWFybHkgaW5kaWNhdGUgd2hlblxuLy8vIHRoZSB0YXJnZXQgZWxlbWVudCBpcyBmb2N1c3NlZC4gVXNlZCBmb3IgaW50ZXJhY3RpdmUgdGV4dC1iYXNlZCBlbGVtZW50cyBzdWNoXG4vLy8gYXMgbGlua3MuXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstZm9jdXNhYmxlLWZpbGwge1xuICAmOmZvY3VzIHtcbiAgICBvdXRsaW5lOiAkZ292dWstZm9jdXMtd2lkdGggc29saWQgJGdvdnVrLWZvY3VzLWNvbG91cjtcbiAgICBvdXRsaW5lLW9mZnNldDogMDtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZ292dWstZm9jdXMtY29sb3VyO1xuICB9XG59XG4iLCIvLy8vXG4vLy8gQGdyb3VwIGhlbHBlcnNcbi8vLy9cblxuLy8gRGlzYWJsZXMgbGludGluZyBmb3IgdGhpcyBmaWxlIG9ubHlcbi8vIHNhc3MtbGludDpkaXNhYmxlIG5vLWNzcy1jb21tZW50cywgbm8tZHVwbGljYXRlLXByb3BlcnRpZXMsIHByb3BlcnR5LXNvcnQtb3JkZXIsIGluZGVudGF0aW9uXG5cbkBpbXBvcnQgXCIuLi90b29scy9leHBvcnRzXCI7XG5cbi8vLyBGb250IEZhY2UgLSBOVEFcbi8vL1xuLy8vIE91dHB1dHMgdGhlIGZvbnQtZmFjZSBkZWNsYXJhdGlvbiBmb3IgTlRBIGF0IHRoZSByb290IG9mIHRoZSBDU1MgZG9jdW1lbnRcbi8vLyB0aGUgZmlyc3QgdGltZSBpdCBpcyBjYWxsZWQuXG4vLy9cbi8vLyBAYWNjZXNzIHByaXZhdGVcblxuQG1peGluIF9nb3Z1ay1mb250LWZhY2UtbnRhIHtcbiAgQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2hlbHBlcnMvZm9udC1mYWNlXCIpIHtcbiAgICBAYXQtcm9vdCB7XG4gICAgICAvKiEgQ29weXJpZ2h0IChjKSAyMDExIGJ5IE1hcmdhcmV0IENhbHZlcnQgJiBIZW5yaWsgS3ViZWwuIEFsbCByaWdodHMgcmVzZXJ2ZWQuIFRoZSBmb250IGhhcyBiZWVuIGN1c3RvbWlzZWQgZm9yIGV4Y2x1c2l2ZSB1c2Ugb24gZ292LnVrLiBUaGlzIGN1dCBpcyBub3QgY29tbWVyY2lhbGx5IGF2YWlsYWJsZS4gKi9cblxuICAgICAgQGZvbnQtZmFjZSB7XG4gICAgICAgIGZvbnQtZmFtaWx5OiBcIm50YVwiO1xuICAgICAgICBzcmM6IGdvdnVrLWZvbnQtdXJsKFwibGlnaHQtMmMwMzdjZjdlMS12MS5lb3RcIik7XG4gICAgICAgIHNyYzogZ292dWstZm9udC11cmwoXCJsaWdodC0yYzAzN2NmN2UxLXYxLmVvdD8jaWVmaXhcIikgZm9ybWF0KFwiZW1iZWRkZWQtb3BlbnR5cGVcIiksXG4gICAgICAgICAgICAgZ292dWstZm9udC11cmwoXCJsaWdodC1mMzhhZDQwNDU2LXYxLndvZmYyXCIpIGZvcm1hdChcIndvZmYyXCIpLFxuICAgICAgICAgICAgIGdvdnVrLWZvbnQtdXJsKFwibGlnaHQtNDU4ZjhlYTgxYy12MS53b2ZmXCIpIGZvcm1hdChcIndvZmZcIik7XG4gICAgICAgIGZvbnQtd2VpZ2h0OiBub3JtYWw7XG4gICAgICAgIGZvbnQtc3R5bGU6IG5vcm1hbDtcbiAgICAgICAgZm9udC1kaXNwbGF5OiBmYWxsYmFjaztcbiAgICAgIH1cblxuICAgICAgQGZvbnQtZmFjZSB7XG4gICAgICAgIGZvbnQtZmFtaWx5OiBcIm50YVwiO1xuICAgICAgICBzcmM6IGdvdnVrLWZvbnQtdXJsKFwiYm9sZC1mYjI2NzY0NjJhLXYxLmVvdFwiKTtcbiAgICAgICAgc3JjOiBnb3Z1ay1mb250LXVybChcImJvbGQtZmIyNjc2NDYyYS12MS5lb3Q/I2llZml4XCIpIGZvcm1hdChcImVtYmVkZGVkLW9wZW50eXBlXCIpLFxuICAgICAgICAgICAgIGdvdnVrLWZvbnQtdXJsKFwiYm9sZC1hMjQ1MmNiNjZmLXYxLndvZmYyXCIpIGZvcm1hdChcIndvZmYyXCIpLFxuICAgICAgICAgICAgIGdvdnVrLWZvbnQtdXJsKFwiYm9sZC1mMzhjNzkyYWMyLXYxLndvZmZcIikgZm9ybWF0KFwid29mZlwiKTtcbiAgICAgICAgZm9udC13ZWlnaHQ6IGJvbGQ7XG4gICAgICAgIGZvbnQtc3R5bGU6IG5vcm1hbDtcbiAgICAgICAgZm9udC1kaXNwbGF5OiBmYWxsYmFjaztcbiAgICAgIH1cblxuICAgICAgQGZvbnQtZmFjZSB7XG4gICAgICAgIGZvbnQtZmFtaWx5OiBcIm50YXRhYnVsYXJudW1iZXJzXCI7XG4gICAgICAgIHNyYzogZ292dWstZm9udC11cmwoXCJsaWdodC10YWJ1bGFyLTQ5OGVhOGZmZTItdjEuZW90XCIpO1xuICAgICAgICBzcmM6IGdvdnVrLWZvbnQtdXJsKFwibGlnaHQtdGFidWxhci00OThlYThmZmUyLXYxLmVvdD8jaWVmaXhcIikgZm9ybWF0KFwiZW1iZWRkZWQtb3BlbnR5cGVcIiksXG4gICAgICAgICAgICAgZ292dWstZm9udC11cmwoXCJsaWdodC10YWJ1bGFyLTg1MWIxMGNjZGQtdjEud29mZjJcIikgZm9ybWF0KFwid29mZjJcIiksXG4gICAgICAgICAgICAgZ292dWstZm9udC11cmwoXCJsaWdodC10YWJ1bGFyLTYyY2M2ZjBhMjgtdjEud29mZlwiKSBmb3JtYXQoXCJ3b2ZmXCIpO1xuICAgICAgICBmb250LXdlaWdodDogbm9ybWFsO1xuICAgICAgICBmb250LXN0eWxlOiBub3JtYWw7XG4gICAgICAgIGZvbnQtZGlzcGxheTogZmFsbGJhY2s7XG4gICAgICB9XG5cbiAgICAgIEBmb250LWZhY2Uge1xuICAgICAgICBmb250LWZhbWlseTogXCJudGF0YWJ1bGFybnVtYmVyc1wiO1xuICAgICAgICBzcmM6IGdvdnVrLWZvbnQtdXJsKFwiYm9sZC10YWJ1bGFyLTM1N2ZkZmJjYzMtdjEuZW90XCIpO1xuICAgICAgICBzcmM6IGdvdnVrLWZvbnQtdXJsKFwiYm9sZC10YWJ1bGFyLTM1N2ZkZmJjYzMtdjEuZW90PyNpZWZpeFwiKSBmb3JtYXQoXCJlbWJlZGRlZC1vcGVudHlwZVwiKSxcbiAgICAgICAgICAgICBnb3Z1ay1mb250LXVybChcImJvbGQtdGFidWxhci1iODkyMzhkODQwLXYxLndvZmYyXCIpIGZvcm1hdChcIndvZmYyXCIpLFxuICAgICAgICAgICAgIGdvdnVrLWZvbnQtdXJsKFwiYm9sZC10YWJ1bGFyLTc4NGMyMWFmYjgtdjEud29mZlwiKSBmb3JtYXQoXCJ3b2ZmXCIpO1xuICAgICAgICBmb250LXdlaWdodDogYm9sZDtcbiAgICAgICAgZm9udC1zdHlsZTogbm9ybWFsO1xuICAgICAgICBmb250LWRpc3BsYXk6IGZhbGxiYWNrO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuIiwiLy8vL1xuLy8vIEBncm91cCBoZWxwZXJzXG4vLy8vXG5cbi8vLyBNYXAgb2YgZ3JpZCBjb2x1bW4gd2lkdGhzXG4vLy9cbi8vLyBAdHlwZSBNYXBcbi8vLyBAYWNjZXNzIHByaXZhdGVcblxuJF9nb3Z1ay1ncmlkLXdpZHRoczogKFxuICBvbmUtcXVhcnRlcjogMjUlLFxuICBvbmUtdGhpcmQ6IDMzLjMzMzMlLFxuICBvbmUtaGFsZjogNTAlLFxuICB0d28tdGhpcmRzOiA2Ni42NjY2JSxcbiAgdGhyZWUtcXVhcnRlcnM6IDc1JSxcbiAgZnVsbDogMTAwJVxuKSAhZGVmYXVsdDtcblxuLy8vIEdyaWQgd2lkdGggcGVyY2VudGFnZVxuLy8vXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRrZXkgLSBOYW1lIG9mIGdyaWQgd2lkdGggKGUuZy4gdHdvLXRoaXJkcylcbi8vLyBAcmV0dXJuIHtOdW1iZXJ9IFBlcmNlbnRhZ2Ugd2lkdGhcbi8vLyBAdGhyb3cgaWYgYCRrZXlgIGlzIG5vdCBhIHZhbGlkIGdyaWQgd2lkdGhcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AZnVuY3Rpb24gZ3JpZC13aWR0aCgka2V5KSB7XG4gIEBpZiBtYXAtaGFzLWtleSgkX2dvdnVrLWdyaWQtd2lkdGhzLCAka2V5KSB7XG4gICAgQHJldHVybiBtYXAtZ2V0KCRfZ292dWstZ3JpZC13aWR0aHMsICRrZXkpO1xuICB9XG5cbiAgQGVycm9yIFwiVW5rbm93biBncmlkIHdpZHRoIGAjeyRrZXl9YFwiO1xufVxuXG4vLy8gR2VuZXJhdGUgZ3JpZCByb3cgc3R5bGVzXG4vLy9cbi8vLyBDcmVhdGVzIGEgZ3JpZCByb3cgY2xhc3Mgd2l0aCBhIHN0YW5kYXJkaXNlZCBtYXJnaW4uXG4vLy9cbi8vLyBAcGFyYW0ge1N0cmluZ30gJGNsYXNzIFtnb3Z1ay1ncmlkLXJvd10gQ1NTIGNsYXNzIG5hbWVcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBEZWZhdWx0XG4vLy8gICBAaW5jbHVkZSBnb3Z1ay1ncmlkLXJvdztcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBDdXN0b21pc2luZyB0aGUgY2xhc3MgbmFtZVxuLy8vICAgQGluY2x1ZGUgZ292dWstZ3JpZC1yb3coXCJhcHAtZ3JpZFwiKTtcbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1ncmlkLXJvdygkY2xhc3M6IFwiZ292dWstZ3JpZC1yb3dcIikge1xuICAuI3skY2xhc3N9IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1jbGVhcmZpeDtcbiAgICBtYXJnaW4tcmlnaHQ6IC0gKCRnb3Z1ay1ndXR0ZXItaGFsZik7XG4gICAgbWFyZ2luLWxlZnQ6IC0gKCRnb3Z1ay1ndXR0ZXItaGFsZik7XG4gIH1cbn1cblxuLy8vIEdlbmVyYXRlIGdyaWQgY29sdW1uIHN0eWxlc1xuLy8vXG4vLy8gQ3JlYXRlcyBhIGNyb3NzIGJyb3dzZXIgZ3JpZCBjb2x1bW4gd2l0aCBhIGNsYXNzIG9mICcuZ292dWstZ3JpZC1jb2x1bW4nIGJ5XG4vLy8gZGVmYXVsdCwgYW5kIGEgc3RhbmRhcmRpc2VkIGd1dHRlciBiZXR3ZWVuIHRoZSBjb2x1bW5zLlxuLy8vXG4vLy8gQ29tbW9uIHdpZHRocyBhcmUgcHJlZGVmaW5lZCBhYm92ZSBhcyBrZXl3b3JkcyBpbiB0aGUgYCRncmlkLXdpZHRoc2AgbWFwLlxuLy8vXG4vLy8gQnkgZGVmYXVsdCB0aGVpciB3aWR0aCBjaGFuZ2VzIGZyb20gMTAwJSB0byBzcGVjaWZpZWQgd2lkdGggYXQgdGhlICd0YWJsZXQnXG4vLy8gYnJlYWtwb2ludCwgYnV0IHRoYXQgY2FuIGJlIGNvbmZpZ3VyZWQgdG8gYmUgYW55IG90aGVyIGJyZWFrcG9pbnQgYnkgdXNpbmdcbi8vLyB0aGUgYCRhdGAgcGFyYW1ldGVyLlxuLy8vXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRjbGFzcyBbZ292dWstZ3JpZC1jb2x1bW5dIENTUyBjbGFzcyBuYW1lXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICR3aWR0aCBbZnVsbF0gb25lLXF1YXJ0ZXIgfCBvbmUtdGhpcmQgfCBvbmUtaGFsZiB8IHR3by10aGlyZCB8IHRocmVlLXF1YXJ0ZXJzIHwgZnVsbFxuLy8vIEBwYXJhbSB7U3RyaW5nfSAkZmxvYXQgW2xlZnRdIGxlZnQgfCByaWdodFxuLy8vIEBwYXJhbSB7U3RyaW5nfSAkYXQgW3RhYmxldF0gLSBtb2JpbGUgfCB0YWJsZXQgfCBkZXNrdG9wIHwgYW55IGN1c3RvbSBicmVha3BvaW50IGluIHB4IG9yIGVtXG4vLy9cbi8vLyBAZXhhbXBsZSBzY3NzIC0gRGVmYXVsdFxuLy8vICAgQGluY2x1ZGUgZ292dWstZ3JpZC1jb2x1bW4odHdvLXRoaXJkcylcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBDdXN0b21pc2luZyB0aGUgY2xhc3MgbmFtZVxuLy8vICAgQGluY2x1ZGUgZ292dWstZ3JpZC1jb2x1bW4ob25lLWhhbGYsICRjbGFzczogXCJ0ZXN0LWNvbHVtblwiKTtcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3MgLSBDdXN0b21pc2luZyB0aGUgYnJlYWtwb2ludCB3aGVyZSB3aWR0aCBwZXJjZW50YWdlIGlzIGFwcGxpZWRcbi8vLyAgIEBpbmNsdWRlIGdvdnVrLWdyaWQtY29sdW1uKG9uZS1oYWxmLCAkYXQ6IGRlc2t0b3ApO1xuLy8vXG4vLy8gQGV4YW1wbGUgc2NzcyAtIEN1c3RvbWlzaW5nIHRoZSBmbG9hdCBkaXJlY3Rpb25cbi8vLyAgIEBpbmNsdWRlIGdvdnVrLWdyaWQtY29sdW1uKG9uZS1oYWxmLCAkZmxvYXQ6IHJpZ2h0KTtcbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1ncmlkLWNvbHVtbigkd2lkdGg6IGZ1bGwsICRmbG9hdDogbGVmdCwgJGF0OiB0YWJsZXQsICRjbGFzczogXCJnb3Z1ay1ncmlkLWNvbHVtblwiKSB7XG5cbiAgLiN7JGNsYXNzfS0jeyR3aWR0aH0ge1xuICAgIC13ZWJraXQtYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgQGlmICRhdCAhPSBkZXNrdG9wIHtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgIH1cbiAgICBwYWRkaW5nOiAwICRnb3Z1ay1ndXR0ZXItaGFsZjtcbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogJGF0KSB7XG4gICAgICB3aWR0aDogZ3JpZC13aWR0aCgkd2lkdGgpO1xuICAgICAgZmxvYXQ6ICRmbG9hdDtcbiAgICB9XG4gIH1cbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgaGVscGVyc1xuLy8vL1xuXG4vLy8gQ29tbW9uIGxpbmsgbWl4aW5cbi8vL1xuLy8vIFByb3ZpZGVzIHRoZSB0eXBvZ3JhcGh5IGFuZCBmb2N1cyBzdGF0ZSwgcmVnYXJkbGVzcyBvZiBsaW5rIHN0eWxlLlxuLy8vXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQG1peGluIGdvdnVrLWxpbmstY29tbW9uIHtcbiAgQGluY2x1ZGUgZ292dWstdHlwb2dyYXBoeS1jb21tb247XG4gIEBpbmNsdWRlIGdvdnVrLWZvY3VzYWJsZS1maWxsO1xufVxuXG4vLy8gRGVmYXVsdCBsaW5rIHN0eWxlIG1peGluXG4vLy9cbi8vLyBQcm92aWRlcyB0aGUgZGVmYXVsdCB1bnZpc2l0ZWQsIHZpc2l0ZWQsIGhvdmVyIGFuZCBhY3RpdmUgc3RhdGVzIGZvciBsaW5rcy5cbi8vL1xuLy8vIElmIHlvdSB1c2UgdGhpcyBtaXhpbiBpbiBhIGNvbXBvbmVudCB5b3UgbXVzdCBhbHNvIGluY2x1ZGUgdGhlXG4vLy8gZ292dWstbGluay1jb21tb24gbWl4aW4gaW4gb3JkZXIgdG8gZ2V0IHRoZSBmb2N1cyBzdGF0ZS5cbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgIC5nb3Z1ay1jb21wb25lbnRfX2xpbmsge1xuLy8vICAgICBAaW5jbHVkZSBnb3Z1ay1saW5rLWNvbW1vbjtcbi8vLyAgICAgQGluY2x1ZGUgZ292dWstbGluay1zdHlsZS1tdXRlZDtcbi8vLyAgIH1cbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1saW5rLXN0eWxlLWRlZmF1bHQge1xuICAmOmxpbmsge1xuICAgIGNvbG9yOiAkZ292dWstbGluay1jb2xvdXI7XG4gIH1cblxuICAmOnZpc2l0ZWQge1xuICAgIGNvbG9yOiAkZ292dWstbGluay12aXNpdGVkLWNvbG91cjtcbiAgfVxuXG4gICY6aG92ZXIge1xuICAgIGNvbG9yOiAkZ292dWstbGluay1ob3Zlci1jb2xvdXI7XG4gIH1cblxuICAmOmFjdGl2ZSB7XG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWFjdGl2ZS1jb2xvdXI7XG4gIH1cbn1cblxuLy8vIE11dGVkIHN0eWxlIGxpbmsgbWl4aW5cbi8vL1xuLy8vIFVzZWQgZm9yIHNlY29uZGFyeSBsaW5rcyBvbiBhIHBhZ2UgLSB0aGUgbGluayB3aWxsIGFwcGVhciBpbiBtdXRlZCBjb2xvdXJzXG4vLy8gcmVnYXJkbGVzcyBvZiB2aXNpdGVkIHN0YXRlLlxuLy8vXG4vLy8gSWYgeW91IHVzZSB0aGlzIG1peGluIGluIGEgY29tcG9uZW50IHlvdSBtdXN0IGFsc28gaW5jbHVkZSB0aGVcbi8vLyBnb3Z1ay1saW5rLWNvbW1vbiBtaXhpbiBpbiBvcmRlciB0byBnZXQgdGhlIGZvY3VzIHN0YXRlLlxuLy8vXG4vLy8gQGV4YW1wbGUgc2Nzc1xuLy8vICAgLmdvdnVrLWNvbXBvbmVudF9fbGluayB7XG4vLy8gICAgIEBpbmNsdWRlIGdvdnVrLWxpbmstY29tbW9uO1xuLy8vICAgICBAaW5jbHVkZSBnb3Z1ay1saW5rLXN0eWxlLW11dGVkO1xuLy8vICAgfVxuLy8vXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQG1peGluIGdvdnVrLWxpbmstc3R5bGUtbXV0ZWQge1xuICAmOmxpbmssXG4gICY6dmlzaXRlZCxcbiAgJjpob3ZlcixcbiAgJjphY3RpdmUge1xuICAgIGNvbG9yOiAkZ292dWstc2Vjb25kYXJ5LXRleHQtY29sb3VyO1xuICB9XG5cbiAgLy8gV2hlbiBmb2N1c3NlZCwgdGhlIHRleHQgY29sb3VyIG5lZWRzIHRvIGJlIGRhcmtlciB0byBlbnN1cmUgdGhhdCBjb2xvdXJcbiAgLy8gY29udHJhc3QgaXMgc3RpbGwgYWNjZXB0YWJsZVxuICAmOmZvY3VzIHtcbiAgICBjb2xvcjogJGdvdnVrLXRleHQtY29sb3VyO1xuICB9XG5cbiAgLy8gYWxwaGFnb3YvZ292dWtfdGVtcGxhdGUgaW5jbHVkZXMgYSBzcGVjaWZpYyBhOmxpbms6Zm9jdXMgc2VsZWN0b3IgZGVzaWduZWRcbiAgLy8gdG8gbWFrZSB1bnZpc2l0ZWQgbGlua3MgYSBzbGlnaHRseSBkYXJrZXIgYmx1ZSB3aGVuIGZvY3Vzc2VkLCBzbyB3ZSBuZWVkIHRvXG4gIC8vIG92ZXJyaWRlIHRoZSB0ZXh0IGNvbG91ciBmb3IgdGhhdCBjb21iaW5hdGlvbiBvZiBzZWxlY3RvcnMuXG4gIEBpbmNsdWRlIGdvdnVrLWNvbXBhdGliaWxpdHkoZ292dWtfdGVtcGxhdGUpIHtcbiAgICAmOmxpbms6Zm9jdXMge1xuICAgICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgfVxuICB9XG59XG5cbi8vLyBUZXh0IHN0eWxlIGxpbmsgbWl4aW5cbi8vL1xuLy8vIE92ZXJyaWRlcyB0aGUgY29sb3VyIG9mIGxpbmtzIHRvIG1hdGNoIHRoZSB0ZXh0IGNvbG91ci4gR2VuZXJhbGx5IHVzZWQgYnlcbi8vLyBuYXZpZ2F0aW9uIGNvbXBvbmVudHMsIHN1Y2ggYXMgYnJlYWRjcnVtYnMgb3IgdGhlIGJhY2sgbGluay5cbi8vL1xuLy8vIElmIHlvdSB1c2UgdGhpcyBtaXhpbiBpbiBhIGNvbXBvbmVudCB5b3UgbXVzdCBhbHNvIGluY2x1ZGUgdGhlXG4vLy8gZ292dWstbGluay1jb21tb24gbWl4aW4gaW4gb3JkZXIgdG8gZ2V0IHRoZSBmb2N1cyBzdGF0ZS5cbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgIC5nb3Z1ay1jb21wb25lbnRfX2xpbmsge1xuLy8vICAgICBAaW5jbHVkZSBnb3Z1ay1saW5rLWNvbW1vbjtcbi8vLyAgICAgQGluY2x1ZGUgZ292dWstbGluay1zdHlsZS10ZXh0O1xuLy8vICAgfVxuLy8vXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQG1peGluIGdvdnVrLWxpbmstc3R5bGUtdGV4dCB7XG4gIC8vIE92ZXJyaWRlIGxpbmsgY29sb3VyIHRvIHVzZSB0ZXh0IGNvbG91clxuICAmOmxpbmssXG4gICY6dmlzaXRlZCxcbiAgJjpob3ZlcixcbiAgJjphY3RpdmUsXG4gICY6Zm9jdXMge1xuICAgIEBpbmNsdWRlIGdvdnVrLXRleHQtY29sb3VyO1xuICB9XG5cbiAgLy8gYWxwaGFnb3YvZ292dWtfdGVtcGxhdGUgaW5jbHVkZXMgYSBzcGVjaWZpYyBhOmxpbms6Zm9jdXMgc2VsZWN0b3IgZGVzaWduZWRcbiAgLy8gdG8gbWFrZSB1bnZpc2l0ZWQgbGlua3MgYSBzbGlnaHRseSBkYXJrZXIgYmx1ZSB3aGVuIGZvY3Vzc2VkLCBzbyB3ZSBuZWVkIHRvXG4gIC8vIG92ZXJyaWRlIHRoZSB0ZXh0IGNvbG91ciBmb3IgdGhhdCBjb21iaW5hdGlvbiBvZiBzZWxlY3RvcnMuXG4gIEBpbmNsdWRlIGdvdnVrLWNvbXBhdGliaWxpdHkoZ292dWtfdGVtcGxhdGUpIHtcbiAgICAmOmxpbms6Zm9jdXMge1xuICAgICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgfVxuICB9XG59XG5cbi8vLyBQcmludCBmcmllbmRseSBsaW5rIG1peGluXG4vLy9cbi8vLyBXaGVuIHByaW50aW5nLCBhcHBlbmQgdGhlIHRoZSBkZXN0aW5hdGlvbiBVUkwgdG8gdGhlIGxpbmsgdGV4dCwgYXMgbG9uZ1xuLy8vIGFzIHRoZSBVUkwgc3RhcnRzIHdpdGggZWl0aGVyIGAvYCwgYGh0dHA6Ly9gIG9yIGBodHRwczovL2AuXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstbGluay1wcmludC1mcmllbmRseSB7XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRtZWRpYS10eXBlOiBwcmludCkge1xuXG4gICAgJltocmVmXj1cIi9cIl0sXG4gICAgJltocmVmXj1cImh0dHA6Ly9cIl0sXG4gICAgJltocmVmXj1cImh0dHBzOi8vXCJdIHtcbiAgICAgICY6OmFmdGVyIHtcbiAgICAgICAgY29udGVudDogXCIgKFwiIGF0dHIoaHJlZikgXCIpXCI7XG4gICAgICAgIGZvbnQtc2l6ZTogOTAlO1xuXG4gICAgICAgIC8vIEJlY2F1c2UgdGhlIFVSTHMgbWF5IGJlIHZlcnkgbG9uZywgZW5zdXJlIHRoYXQgdGhleSBtYXkgYmUgYnJva2VuXG4gICAgICAgIC8vIGF0IGFyYml0cmFyeSBwb2ludHMgaWYgdGhlcmUgYXJlIG5vIG90aGVyd2lzZSBhY2NlcHRhYmxlIGJyZWFrXG4gICAgICAgIC8vIHBvaW50cyBpbiB0aGUgbGluZVxuICAgICAgICB3b3JkLXdyYXA6IGJyZWFrLXdvcmQ7XG4gICAgICB9XG4gICAgfVxuICB9XG59XG4iLCIvLy8vXG4vLy8gQGdyb3VwIGhlbHBlcnNcbi8vLy9cblxuXG5cbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuLy8gV3JhbmdsZSBzYXNzLW1xIGNvbmZpZy4uLlxuLy8gPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09XG5cbi8vIFBhc3Mgb3VyIGJyZWFrcG9pbnRzIGFuZCBzdGF0aWMgYnJlYWtwb2ludCBkZWZpbml0aW9ucyB0aHJvdWdoIHRvIHNhc3MtbXEuXG4kbXEtYnJlYWtwb2ludHM6IGlmKHZhcmlhYmxlLWV4aXN0cyhnb3Z1ay1icmVha3BvaW50cyksICRnb3Z1ay1icmVha3BvaW50cywgKCkpO1xuJG1xLXN0YXRpYy1icmVha3BvaW50OiBpZih2YXJpYWJsZS1leGlzdHMoZ292dWstaWU4LWJyZWFrcG9pbnQpLCAkZ292dWstaWU4LWJyZWFrcG9pbnQsIGRlc2t0b3ApO1xuXG4kbXEtc2hvdy1icmVha3BvaW50czogKCk7XG5cbkBpZiAodmFyaWFibGUtZXhpc3RzKGdvdnVrLXNob3ctYnJlYWtwb2ludHMpIGFuZCAkZ292dWstc2hvdy1icmVha3BvaW50cykge1xuICAkbXEtc2hvdy1icmVha3BvaW50czogbWFwLWtleXMoJGdvdnVrLWJyZWFrcG9pbnRzKTtcbn1cblxuLy8gV2hlbiBidWlsZGluZyBhIHN0eWxlc2hlZXQgZm9yIElFOCwgc2V0ICRtcS1yZXNwb25zaXZlIHRvIGZhbHNlIGluIG9yZGVyIHRvXG4vLyAncmFzdGVyaXplJyBhbnkgbWVkaWEgcXVlcmllcy5cblxuJG1xLXJlc3BvbnNpdmU6IHRydWU7XG5AaWYgKHZhcmlhYmxlLWV4aXN0cyhnb3Z1ay1pcy1pZTgpIGFuZCAkZ292dWstaXMtaWU4KSB7XG4gICRtcS1yZXNwb25zaXZlOiBmYWxzZTtcbn1cblxuLy8gVGhpcyBpcyBhIGhvcnJpYmxlLCBob3JyaWJsZSBoYWNrIHRvIHByZXZlbnQgdGhlICdkZXYgbW9kZScgQ1NTIHRvIGRpc3BsYXlcbi8vIHRoZSBjdXJyZW50IGJyZWFrcG9pbnQgZnJvbSBiZWluZyBpbmNsdWRlZCBtdWx0aXBsZSB0aW1lcy5cbi8vXG4vLyBXZSBjYW4ndCB1c2UgdGhlIGBleHBvcnRzYCBtaXhpbiBmb3IgdGhpcyBiZWNhdXNlIGltcG9ydCBkaXJlY3RpdmVzIGNhbm5vdCBiZVxuLy8gdXNlZCB3aXRoaW4gY29udHJvbCBkaXJlY3RpdmVzIPCfmKBcbiRzYXNzLW1xLWFscmVhZHktaW5jbHVkZWQ6IGZhbHNlICFkZWZhdWx0O1xuXG5AaWYgJHNhc3MtbXEtYWxyZWFkeS1pbmNsdWRlZCB7XG4gICRtcS1zaG93LWJyZWFrcG9pbnRzOiAoKTtcbn1cblxuQGltcG9ydCBcIi4uL3ZlbmRvci9zYXNzLW1xXCI7XG5cbiRzYXNzLW1xLWFscmVhZHktaW5jbHVkZWQ6IHRydWU7XG5cblxuXG4vLyA9PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT1cbi8vIEhlbHBlcnNcbi8vID09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PVxuXG4vLy8gTWVkaWEgUXVlcnlcbi8vL1xuLy8vIFRoaXMgaXMgYSBjdXJyZW50bHkgYSB3cmFwcGVyIGZvciBzYXNzLW1xIC0gYWJzdHJhY3RlZCBzbyB0aGF0IHdlIGNhblxuLy8vIHJlcGxhY2UgaXQgaW4gdGhlIGZ1dHVyZSBpZiB3ZSBzbyBjaG9vc2UuXG4vLy9cbi8vLyBAcGFyYW0ge1N0cmluZyB8IEJvb2xlYW59ICRmcm9tIFtmYWxzZV0gLSBPbmUgb2YgJGdvdnVrLWJyZWFrcG9pbnRzXG4vLy8gQHBhcmFtIHtTdHJpbmcgfCBCb29sZWFufSAkdW50aWwgW2ZhbHNlXSAtIE9uZSBvZiAkZ292dWstYnJlYWtwb2ludHNcbi8vLyBAcGFyYW0ge1N0cmluZyB8IEJvb2xlYW59ICRhbmQgW2ZhbHNlXSAtIEFkZGl0aW9uYWwgbWVkaWEgcXVlcnkgcGFyYW1ldGVyc1xuLy8vIEBwYXJhbSB7U3RyaW5nfSAkbWVkaWEtdHlwZSBbYWxsXSAtIE1lZGlhIHR5cGU6IHNjcmVlbiwgcHJpbnTigKZcbi8vL1xuLy8vIEBpZ25vcmUgVW5kb2N1bWVudGVkIG1xIEFQSSwgZm9yIGFkdmFuY2VkIHVzZSBvbmx5OlxuLy8vIEBpZ25vcmUgQHBhcmFtIHtNYXB9ICRicmVha3BvaW50cyBbJGdvdnVrLWJyZWFrcG9pbnRzXVxuLy8vIEBpZ25vcmUgQHBhcmFtIHtTdHJpbmd9ICRzdGF0aWMtYnJlYWtwb2ludCBbJGdvdnVrLWllOC1icmVha3BvaW50XVxuLy8vIEBpZ25vcmUgQHBhcmFtIHtCb29sZWFufSAkcmVzcG9uc2l2ZSBbJGdvdnVrLWlzLWllOF1cbi8vL1xuLy8vIEBjb250ZW50IHN0eWxpbmcgcnVsZXMsIHdyYXBwZWQgaW50byBhIEBtZWRpYSBxdWVyeSB3aGVuICRyZXNwb25zaXZlIGlzIHRydWVcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgLmVsZW1lbnQge1xuLy8vICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiBtb2JpbGUpIHtcbi8vLyAgICAgIGNvbG9yOiByZWQ7XG4vLy8gICAgfVxuLy8vICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCR1bnRpbDogdGFibGV0KSB7XG4vLy8gICAgICBjb2xvcjogYmx1ZTtcbi8vLyAgICB9XG4vLy8gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkobW9iaWxlLCB0YWJsZXQpIHtcbi8vLyAgICAgIGNvbG9yOiBncmVlbjtcbi8vLyAgICB9XG4vLy8gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCwgJGFuZDogJyhvcmllbnRhdGlvbjogbGFuZHNjYXBlKScpIHtcbi8vLyAgICAgIGNvbG9yOiB0ZWFsO1xuLy8vICAgIH1cbi8vLyAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSg5NTBweCkge1xuLy8vICAgICAgY29sb3I6IGhvdHBpbms7XG4vLy8gICAgfVxuLy8vICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KHRhYmxldCwgJG1lZGlhLXR5cGU6IHNjcmVlbikge1xuLy8vICAgICAgY29sb3I6IGhvdHBpbms7XG4vLy8gICAgfVxuLy8vICB9XG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstbWVkaWEtcXVlcnkoJGFyZ3MuLi4pIHtcbiAgQGluY2x1ZGUgbXEoJGFyZ3MuLi4pIHtcbiAgICBAY29udGVudDtcbiAgfTtcbn1cbiIsIi8vIG1xKCkgdjQuMC4yXG4vLyBzYXNzLW1xL3Nhc3MtbXFcblxuLy8gc2Fzcy1saW50OmRpc2FibGUtYWxsXG5cbkBjaGFyc2V0IFwiVVRGLThcIjsgLy8gRml4ZXMgYW4gaXNzdWUgd2hlcmUgUnVieSBsb2NhbGUgaXMgbm90IHNldCBwcm9wZXJseVxuICAgICAgICAgICAgICAgICAgLy8gU2VlIGh0dHBzOi8vZ2l0aHViLmNvbS9zYXNzLW1xL3Nhc3MtbXEvcHVsbC8xMFxuXG4vLy8gQmFzZSBmb250IHNpemUgb24gdGhlIGA8Ym9keT5gIGVsZW1lbnRcbi8vLyBAdHlwZSBOdW1iZXIgKHVuaXQpXG4kbXEtYmFzZS1mb250LXNpemU6IDE2cHggIWRlZmF1bHQ7XG5cbi8vLyBSZXNwb25zaXZlIG1vZGVcbi8vL1xuLy8vIFNldCB0byBgZmFsc2VgIHRvIGVuYWJsZSBzdXBwb3J0IGZvciBicm93c2VycyB0aGF0IGRvIG5vdCBzdXBwb3J0IEBtZWRpYSBxdWVyaWVzLFxuLy8vIChJRSA8PSA4LCBGaXJlZm94IDw9IDMsIE9wZXJhIDw9IDkpXG4vLy9cbi8vLyBZb3UgY291bGQgY3JlYXRlIGEgc3R5bGVzaGVldCBzZXJ2ZWQgZXhjbHVzaXZlbHkgdG8gb2xkZXIgYnJvd3NlcnMsXG4vLy8gd2hlcmUgQG1lZGlhIHF1ZXJpZXMgYXJlIHJhc3Rlcml6ZWRcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgLy8gb2xkLWllLnNjc3Ncbi8vLyAgJG1xLXJlc3BvbnNpdmU6IGZhbHNlO1xuLy8vICBAaW1wb3J0ICdtYWluJzsgLy8gQG1lZGlhIHF1ZXJpZXMgaW4gdGhpcyBmaWxlIHdpbGwgYmUgcmFzdGVyaXplZCB1cCB0byAkbXEtc3RhdGljLWJyZWFrcG9pbnRcbi8vLyAgICAgICAgICAgICAgICAgICAvLyBsYXJnZXIgYnJlYWtwb2ludHMgd2lsbCBiZSBpZ25vcmVkXG4vLy9cbi8vLyBAdHlwZSBCb29sZWFuXG4vLy8gQGxpbmsgaHR0cHM6Ly9naXRodWIuY29tL3Nhc3MtbXEvc2Fzcy1tcSNyZXNwb25zaXZlLW1vZGUtb2ZmIERpc2FibGVkIHJlc3BvbnNpdmUgbW9kZSBkb2N1bWVudGF0aW9uXG4kbXEtcmVzcG9uc2l2ZTogdHJ1ZSAhZGVmYXVsdDtcblxuLy8vIEJyZWFrcG9pbnQgbGlzdFxuLy8vXG4vLy8gTmFtZSB5b3VyIGJyZWFrcG9pbnRzIGluIGEgd2F5IHRoYXQgY3JlYXRlcyBhIHViaXF1aXRvdXMgbGFuZ3VhZ2Vcbi8vLyBhY3Jvc3MgdGVhbSBtZW1iZXJzLiBJdCB3aWxsIGltcHJvdmUgY29tbXVuaWNhdGlvbiBiZXR3ZWVuXG4vLy8gc3Rha2Vob2xkZXJzLCBkZXNpZ25lcnMsIGRldmVsb3BlcnMsIGFuZCB0ZXN0ZXJzLlxuLy8vXG4vLy8gQHR5cGUgTWFwXG4vLy8gQGxpbmsgaHR0cHM6Ly9naXRodWIuY29tL3Nhc3MtbXEvc2Fzcy1tcSNzZWVpbmctdGhlLWN1cnJlbnRseS1hY3RpdmUtYnJlYWtwb2ludCBGdWxsIGRvY3VtZW50YXRpb24gYW5kIGV4YW1wbGVzXG4kbXEtYnJlYWtwb2ludHM6IChcbiAgICBtb2JpbGU6ICAzMjBweCxcbiAgICB0YWJsZXQ6ICA3NDBweCxcbiAgICBkZXNrdG9wOiA5ODBweCxcbiAgICB3aWRlOiAgICAxMzAwcHhcbikgIWRlZmF1bHQ7XG5cbi8vLyBTdGF0aWMgYnJlYWtwb2ludCAoZm9yIGZpeGVkLXdpZHRoIGxheW91dHMpXG4vLy9cbi8vLyBEZWZpbmUgdGhlIGJyZWFrcG9pbnQgZnJvbSAkbXEtYnJlYWtwb2ludHMgdGhhdCBzaG91bGRcbi8vLyBiZSB1c2VkIGFzIHRoZSB0YXJnZXQgd2lkdGggZm9yIHRoZSBmaXhlZC13aWR0aCBsYXlvdXRcbi8vLyAoaS5lLiB3aGVuICRtcS1yZXNwb25zaXZlIGlzIHNldCB0byAnZmFsc2UnKSBpbiBhIG9sZC1pZS5zY3NzXG4vLy9cbi8vLyBAZXhhbXBsZSBzY3NzXG4vLy8gIC8vIHRhYmxldC1vbmx5LnNjc3Ncbi8vLyAgLy9cbi8vLyAgLy8gSWdub3JlIGFsbCBzdHlsZXMgYWJvdmUgdGFibGV0IGJyZWFrcG9pbnQsXG4vLy8gIC8vIGFuZCBmaXggdGhlIHN0eWxlcyAoZS5nLiBsYXlvdXQpIGF0IHRhYmxldCB3aWR0aFxuLy8vICAkbXEtcmVzcG9uc2l2ZTogZmFsc2U7XG4vLy8gICRtcS1zdGF0aWMtYnJlYWtwb2ludDogdGFibGV0O1xuLy8vICBAaW1wb3J0ICdtYWluJzsgLy8gQG1lZGlhIHF1ZXJpZXMgaW4gdGhpcyBmaWxlIHdpbGwgYmUgcmFzdGVyaXplZCB1cCB0byB0YWJsZXRcbi8vLyAgICAgICAgICAgICAgICAgICAvLyBsYXJnZXIgYnJlYWtwb2ludHMgd2lsbCBiZSBpZ25vcmVkXG4vLy9cbi8vLyBAdHlwZSBTdHJpbmdcbi8vLyBAbGluayBodHRwczovL2dpdGh1Yi5jb20vc2Fzcy1tcS9zYXNzLW1xI2FkZGluZy1jdXN0b20tYnJlYWtwb2ludHMgRnVsbCBkb2N1bWVudGF0aW9uIGFuZCBleGFtcGxlc1xuJG1xLXN0YXRpYy1icmVha3BvaW50OiBkZXNrdG9wICFkZWZhdWx0O1xuXG4vLy8gU2hvdyBicmVha3BvaW50cyBpbiB0aGUgdG9wIHJpZ2h0IGNvcm5lclxuLy8vXG4vLy8gSWYgeW91IHdhbnQgdG8gZGlzcGxheSB0aGUgY3VycmVudGx5IGFjdGl2ZSBicmVha3BvaW50IGluIHRoZSB0b3Bcbi8vLyByaWdodCBjb3JuZXIgb2YgeW91ciBzaXRlIGR1cmluZyBkZXZlbG9wbWVudCwgYWRkIHRoZSBicmVha3BvaW50c1xuLy8vIHRvIHRoaXMgbGlzdCwgb3JkZXJlZCBieSB3aWR0aCwgZS5nLiAobW9iaWxlLCB0YWJsZXQsIGRlc2t0b3ApLlxuLy8vXG4vLy8gQHR5cGUgbWFwXG4kbXEtc2hvdy1icmVha3BvaW50czogKCkgIWRlZmF1bHQ7XG5cbi8vLyBDdXN0b21pemUgdGhlIG1lZGlhIHR5cGUgKGUuZy4gYEBtZWRpYSBzY3JlZW5gIG9yIGBAbWVkaWEgcHJpbnRgKVxuLy8vIEJ5IGRlZmF1bHQgc2Fzcy1tcSB1c2VzIGFuIFwiYWxsXCIgbWVkaWEgdHlwZSAoYEBtZWRpYSBhbGwgYW5kIOKApmApXG4vLy9cbi8vLyBAdHlwZSBTdHJpbmdcbi8vLyBAbGluayBodHRwczovL2dpdGh1Yi5jb20vc2Fzcy1tcS9zYXNzLW1xI2NoYW5naW5nLW1lZGlhLXR5cGUgRnVsbCBkb2N1bWVudGF0aW9uIGFuZCBleGFtcGxlc1xuJG1xLW1lZGlhLXR5cGU6IGFsbCAhZGVmYXVsdDtcblxuLy8vIENvbnZlcnQgcGl4ZWxzIHRvIGVtc1xuLy8vXG4vLy8gQHBhcmFtIHtOdW1iZXJ9ICRweCAtIHZhbHVlIHRvIGNvbnZlcnRcbi8vLyBAcGFyYW0ge051bWJlcn0gJGJhc2UtZm9udC1zaXplICgkbXEtYmFzZS1mb250LXNpemUpIC0gYDxib2R5PmAgZm9udCBzaXplXG4vLy9cbi8vLyBAZXhhbXBsZSBzY3NzXG4vLy8gICRmb250LXNpemUtaW4tZW1zOiBtcS1weDJlbSgxNnB4KTtcbi8vLyAgcCB7IGZvbnQtc2l6ZTogbXEtcHgyZW0oMTZweCk7IH1cbi8vL1xuLy8vIEByZXF1aXJlcyAkbXEtYmFzZS1mb250LXNpemVcbi8vLyBAcmV0dXJucyB7TnVtYmVyfVxuQGZ1bmN0aW9uIG1xLXB4MmVtKCRweCwgJGJhc2UtZm9udC1zaXplOiAkbXEtYmFzZS1mb250LXNpemUpIHtcbiAgICBAaWYgdW5pdGxlc3MoJHB4KSB7XG4gICAgICAgIEB3YXJuIFwiQXNzdW1pbmcgI3skcHh9IHRvIGJlIGluIHBpeGVscywgYXR0ZW1wdGluZyB0byBjb252ZXJ0IGl0IGludG8gcGl4ZWxzLlwiO1xuICAgICAgICBAcmV0dXJuIG1xLXB4MmVtKCRweCAqIDFweCwgJGJhc2UtZm9udC1zaXplKTtcbiAgICB9IEBlbHNlIGlmIHVuaXQoJHB4KSA9PSBlbSB7XG4gICAgICAgIEByZXR1cm4gJHB4O1xuICAgIH1cbiAgICBAcmV0dXJuICgkcHggLyAkYmFzZS1mb250LXNpemUpICogMWVtO1xufVxuXG4vLy8gR2V0IGEgYnJlYWtwb2ludCdzIHdpZHRoXG4vLy9cbi8vLyBAcGFyYW0ge1N0cmluZ30gJG5hbWUgLSBOYW1lIG9mIHRoZSBicmVha3BvaW50LiBPbmUgb2YgJG1xLWJyZWFrcG9pbnRzXG4vLy9cbi8vLyBAZXhhbXBsZSBzY3NzXG4vLy8gICR0YWJsZXQtd2lkdGg6IG1xLWdldC1icmVha3BvaW50LXdpZHRoKHRhYmxldCk7XG4vLy8gIEBtZWRpYSAobWluLXdpZHRoOiBtcS1nZXQtYnJlYWtwb2ludC13aWR0aChkZXNrdG9wKSkge31cbi8vL1xuLy8vIEByZXF1aXJlcyB7VmFyaWFibGV9ICRtcS1icmVha3BvaW50c1xuLy8vXG4vLy8gQHJldHVybnMge051bWJlcn0gVmFsdWUgaW4gcGl4ZWxzXG5AZnVuY3Rpb24gbXEtZ2V0LWJyZWFrcG9pbnQtd2lkdGgoJG5hbWUsICRicmVha3BvaW50czogJG1xLWJyZWFrcG9pbnRzKSB7XG4gICAgQGlmIG1hcC1oYXMta2V5KCRicmVha3BvaW50cywgJG5hbWUpIHtcbiAgICAgICAgQHJldHVybiBtYXAtZ2V0KCRicmVha3BvaW50cywgJG5hbWUpO1xuICAgIH0gQGVsc2Uge1xuICAgICAgICBAd2FybiBcIkJyZWFrcG9pbnQgI3skbmFtZX0gd2Fzbid0IGZvdW5kIGluICRicmVha3BvaW50cy5cIjtcbiAgICB9XG59XG5cbi8vLyBNZWRpYSBRdWVyeSBtaXhpblxuLy8vXG4vLy8gQHBhcmFtIHtTdHJpbmcgfCBCb29sZWFufSAkZnJvbSAoZmFsc2UpIC0gT25lIG9mICRtcS1icmVha3BvaW50c1xuLy8vIEBwYXJhbSB7U3RyaW5nIHwgQm9vbGVhbn0gJHVudGlsIChmYWxzZSkgLSBPbmUgb2YgJG1xLWJyZWFrcG9pbnRzXG4vLy8gQHBhcmFtIHtTdHJpbmcgfCBCb29sZWFufSAkYW5kIChmYWxzZSkgLSBBZGRpdGlvbmFsIG1lZGlhIHF1ZXJ5IHBhcmFtZXRlcnNcbi8vLyBAcGFyYW0ge1N0cmluZ30gJG1lZGlhLXR5cGUgKCRtcS1tZWRpYS10eXBlKSAtIE1lZGlhIHR5cGU6IHNjcmVlbiwgcHJpbnTigKZcbi8vL1xuLy8vIEBpZ25vcmUgVW5kb2N1bWVudGVkIEFQSSwgZm9yIGFkdmFuY2VkIHVzZSBvbmx5OlxuLy8vIEBpZ25vcmUgQHBhcmFtIHtNYXB9ICRicmVha3BvaW50cyAoJG1xLWJyZWFrcG9pbnRzKVxuLy8vIEBpZ25vcmUgQHBhcmFtIHtTdHJpbmd9ICRzdGF0aWMtYnJlYWtwb2ludCAoJG1xLXN0YXRpYy1icmVha3BvaW50KVxuLy8vXG4vLy8gQGNvbnRlbnQgc3R5bGluZyBydWxlcywgd3JhcHBlZCBpbnRvIGEgQG1lZGlhIHF1ZXJ5IHdoZW4gJHJlc3BvbnNpdmUgaXMgdHJ1ZVxuLy8vXG4vLy8gQHJlcXVpcmVzIHtWYXJpYWJsZX0gJG1xLW1lZGlhLXR5cGVcbi8vLyBAcmVxdWlyZXMge1ZhcmlhYmxlfSAkbXEtYnJlYWtwb2ludHNcbi8vLyBAcmVxdWlyZXMge1ZhcmlhYmxlfSAkbXEtc3RhdGljLWJyZWFrcG9pbnRcbi8vLyBAcmVxdWlyZXMge2Z1bmN0aW9ufSBtcS1weDJlbVxuLy8vIEByZXF1aXJlcyB7ZnVuY3Rpb259IG1xLWdldC1icmVha3BvaW50LXdpZHRoXG4vLy9cbi8vLyBAbGluayBodHRwczovL2dpdGh1Yi5jb20vc2Fzcy1tcS9zYXNzLW1xI3Jlc3BvbnNpdmUtbW9kZS1vbi1kZWZhdWx0IEZ1bGwgZG9jdW1lbnRhdGlvbiBhbmQgZXhhbXBsZXNcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgLmVsZW1lbnQge1xuLy8vICAgIEBpbmNsdWRlIG1xKCRmcm9tOiBtb2JpbGUpIHtcbi8vLyAgICAgIGNvbG9yOiByZWQ7XG4vLy8gICAgfVxuLy8vICAgIEBpbmNsdWRlIG1xKCR1bnRpbDogdGFibGV0KSB7XG4vLy8gICAgICBjb2xvcjogYmx1ZTtcbi8vLyAgICB9XG4vLy8gICAgQGluY2x1ZGUgbXEobW9iaWxlLCB0YWJsZXQpIHtcbi8vLyAgICAgIGNvbG9yOiBncmVlbjtcbi8vLyAgICB9XG4vLy8gICAgQGluY2x1ZGUgbXEoJGZyb206IHRhYmxldCwgJGFuZDogJyhvcmllbnRhdGlvbjogbGFuZHNjYXBlKScpIHtcbi8vLyAgICAgIGNvbG9yOiB0ZWFsO1xuLy8vICAgIH1cbi8vLyAgICBAaW5jbHVkZSBtcSg5NTBweCkge1xuLy8vICAgICAgY29sb3I6IGhvdHBpbms7XG4vLy8gICAgfVxuLy8vICAgIEBpbmNsdWRlIG1xKHRhYmxldCwgJG1lZGlhLXR5cGU6IHNjcmVlbikge1xuLy8vICAgICAgY29sb3I6IGhvdHBpbms7XG4vLy8gICAgfVxuLy8vICAgIC8vIEFkdmFuY2VkIHVzZTpcbi8vLyAgICAkbXktYnJlYWtwb2ludHM6IChMOiA5MDBweCwgWEw6IDEyMDBweCk7XG4vLy8gICAgQGluY2x1ZGUgbXEoTCwgJGJyZWFrcG9pbnRzOiAkbXktYnJlYWtwb2ludHMsICRzdGF0aWMtYnJlYWtwb2ludDogTCkge1xuLy8vICAgICAgY29sb3I6IGhvdHBpbms7XG4vLy8gICAgfVxuLy8vICB9XG5AbWl4aW4gbXEoXG4gICAgJGZyb206IGZhbHNlLFxuICAgICR1bnRpbDogZmFsc2UsXG4gICAgJGFuZDogZmFsc2UsXG4gICAgJG1lZGlhLXR5cGU6ICRtcS1tZWRpYS10eXBlLFxuICAgICRicmVha3BvaW50czogJG1xLWJyZWFrcG9pbnRzLFxuICAgICRyZXNwb25zaXZlOiAkbXEtcmVzcG9uc2l2ZSxcbiAgICAkc3RhdGljLWJyZWFrcG9pbnQ6ICRtcS1zdGF0aWMtYnJlYWtwb2ludFxuKSB7XG4gICAgJG1pbi13aWR0aDogMDtcbiAgICAkbWF4LXdpZHRoOiAwO1xuICAgICRtZWRpYS1xdWVyeTogJyc7XG5cbiAgICAvLyBGcm9tOiB0aGlzIGJyZWFrcG9pbnQgKGluY2x1c2l2ZSlcbiAgICBAaWYgJGZyb20ge1xuICAgICAgICBAaWYgdHlwZS1vZigkZnJvbSkgPT0gbnVtYmVyIHtcbiAgICAgICAgICAgICRtaW4td2lkdGg6IG1xLXB4MmVtKCRmcm9tKTtcbiAgICAgICAgfSBAZWxzZSB7XG4gICAgICAgICAgICAkbWluLXdpZHRoOiBtcS1weDJlbShtcS1nZXQtYnJlYWtwb2ludC13aWR0aCgkZnJvbSwgJGJyZWFrcG9pbnRzKSk7XG4gICAgICAgIH1cbiAgICB9XG5cbiAgICAvLyBVbnRpbDogdGhhdCBicmVha3BvaW50IChleGNsdXNpdmUpXG4gICAgQGlmICR1bnRpbCB7XG4gICAgICAgIEBpZiB0eXBlLW9mKCR1bnRpbCkgPT0gbnVtYmVyIHtcbiAgICAgICAgICAgICRtYXgtd2lkdGg6IG1xLXB4MmVtKCR1bnRpbCk7XG4gICAgICAgIH0gQGVsc2Uge1xuICAgICAgICAgICAgJG1heC13aWR0aDogbXEtcHgyZW0obXEtZ2V0LWJyZWFrcG9pbnQtd2lkdGgoJHVudGlsLCAkYnJlYWtwb2ludHMpKSAtIC4wMWVtO1xuICAgICAgICB9XG4gICAgfVxuXG4gICAgLy8gUmVzcG9uc2l2ZSBzdXBwb3J0IGlzIGRpc2FibGVkLCByYXN0ZXJpemUgdGhlIG91dHB1dCBvdXRzaWRlIEBtZWRpYSBibG9ja3NcbiAgICAvLyBUaGUgYnJvd3NlciB3aWxsIHJlbHkgb24gdGhlIGNhc2NhZGUgaXRzZWxmLlxuICAgIEBpZiAkcmVzcG9uc2l2ZSA9PSBmYWxzZSB7XG4gICAgICAgICRzdGF0aWMtYnJlYWtwb2ludC13aWR0aDogbXEtZ2V0LWJyZWFrcG9pbnQtd2lkdGgoJHN0YXRpYy1icmVha3BvaW50LCAkYnJlYWtwb2ludHMpO1xuICAgICAgICAkdGFyZ2V0LXdpZHRoOiBtcS1weDJlbSgkc3RhdGljLWJyZWFrcG9pbnQtd2lkdGgpO1xuXG4gICAgICAgIC8vIE91dHB1dCBvbmx5IHJ1bGVzIHRoYXQgc3RhcnQgYXQgb3Igc3BhbiBvdXIgdGFyZ2V0IHdpZHRoXG4gICAgICAgIEBpZiAoXG4gICAgICAgICAgICAkYW5kID09IGZhbHNlXG4gICAgICAgICAgICBhbmQgJG1pbi13aWR0aCA8PSAkdGFyZ2V0LXdpZHRoXG4gICAgICAgICAgICBhbmQgKFxuICAgICAgICAgICAgICAgICR1bnRpbCA9PSBmYWxzZSBvciAkbWF4LXdpZHRoID49ICR0YXJnZXQtd2lkdGhcbiAgICAgICAgICAgIClcbiAgICAgICAgICAgIGFuZCAkbWVkaWEtdHlwZSAhPSAncHJpbnQnXG4gICAgICAgICkge1xuICAgICAgICAgICAgQGNvbnRlbnQ7XG4gICAgICAgIH1cbiAgICB9XG5cbiAgICAvLyBSZXNwb25zaXZlIHN1cHBvcnQgaXMgZW5hYmxlZCwgb3V0cHV0IHJ1bGVzIGluc2lkZSBAbWVkaWEgcXVlcmllc1xuICAgIEBlbHNlIHtcbiAgICAgICAgQGlmICRtaW4td2lkdGggIT0gMCB7ICRtZWRpYS1xdWVyeTogJyN7JG1lZGlhLXF1ZXJ5fSBhbmQgKG1pbi13aWR0aDogI3skbWluLXdpZHRofSknOyB9XG4gICAgICAgIEBpZiAkbWF4LXdpZHRoICE9IDAgeyAkbWVkaWEtcXVlcnk6ICcjeyRtZWRpYS1xdWVyeX0gYW5kIChtYXgtd2lkdGg6ICN7JG1heC13aWR0aH0pJzsgfVxuICAgICAgICBAaWYgJGFuZCAgICAgICAgICAgIHsgJG1lZGlhLXF1ZXJ5OiAnI3skbWVkaWEtcXVlcnl9IGFuZCAjeyRhbmR9JzsgfVxuXG4gICAgICAgIC8vIFJlbW92ZSB1bm5lY2Vzc2FyeSBtZWRpYSBxdWVyeSBwcmVmaXggJ2FsbCBhbmQgJ1xuICAgICAgICBAaWYgKCRtZWRpYS10eXBlID09ICdhbGwnIGFuZCAkbWVkaWEtcXVlcnkgIT0gJycpIHtcbiAgICAgICAgICAgICRtZWRpYS10eXBlOiAnJztcbiAgICAgICAgICAgICRtZWRpYS1xdWVyeTogc3RyLXNsaWNlKHVucXVvdGUoJG1lZGlhLXF1ZXJ5KSwgNik7XG4gICAgICAgIH1cblxuICAgICAgICBAbWVkaWEgI3skbWVkaWEtdHlwZSArICRtZWRpYS1xdWVyeX0ge1xuICAgICAgICAgICAgQGNvbnRlbnQ7XG4gICAgICAgIH1cbiAgICB9XG59XG5cbi8vLyBRdWljayBzb3J0XG4vLy9cbi8vLyBAYXV0aG9yIFNhbSBSaWNoYXJkc1xuLy8vIEBhY2Nlc3MgcHJpdmF0ZVxuLy8vIEBwYXJhbSB7TGlzdH0gJGxpc3QgLSBMaXN0IHRvIHNvcnRcbi8vLyBAcmV0dXJucyB7TGlzdH0gU29ydGVkIExpc3RcbkBmdW5jdGlvbiBfbXEtcXVpY2stc29ydCgkbGlzdCkge1xuICAgICRsZXNzOiAgKCk7XG4gICAgJGVxdWFsOiAoKTtcbiAgICAkbGFyZ2U6ICgpO1xuXG4gICAgQGlmIGxlbmd0aCgkbGlzdCkgPiAxIHtcbiAgICAgICAgJHNlZWQ6IG50aCgkbGlzdCwgY2VpbChsZW5ndGgoJGxpc3QpIC8gMikpO1xuXG4gICAgICAgIEBlYWNoICRpdGVtIGluICRsaXN0IHtcbiAgICAgICAgICAgIEBpZiAoJGl0ZW0gPT0gJHNlZWQpIHtcbiAgICAgICAgICAgICAgICAkZXF1YWw6IGFwcGVuZCgkZXF1YWwsICRpdGVtKTtcbiAgICAgICAgICAgIH0gQGVsc2UgaWYgKCRpdGVtIDwgJHNlZWQpIHtcbiAgICAgICAgICAgICAgICAkbGVzczogYXBwZW5kKCRsZXNzLCAkaXRlbSk7XG4gICAgICAgICAgICB9IEBlbHNlIGlmICgkaXRlbSA+ICRzZWVkKSB7XG4gICAgICAgICAgICAgICAgJGxhcmdlOiBhcHBlbmQoJGxhcmdlLCAkaXRlbSk7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cblxuICAgICAgICBAcmV0dXJuIGpvaW4oam9pbihfbXEtcXVpY2stc29ydCgkbGVzcyksICRlcXVhbCksIF9tcS1xdWljay1zb3J0KCRsYXJnZSkpO1xuICAgIH1cblxuICAgIEByZXR1cm4gJGxpc3Q7XG59XG5cbi8vLyBTb3J0IGEgbWFwIGJ5IHZhbHVlcyAod29ya3Mgd2l0aCBudW1iZXJzIG9ubHkpXG4vLy9cbi8vLyBAYWNjZXNzIHByaXZhdGVcbi8vLyBAcGFyYW0ge01hcH0gJG1hcCAtIE1hcCB0byBzb3J0XG4vLy8gQHJldHVybnMge01hcH0gTWFwIHNvcnRlZCBieSB2YWx1ZVxuQGZ1bmN0aW9uIF9tcS1tYXAtc29ydC1ieS12YWx1ZSgkbWFwKSB7XG4gICAgJG1hcC1zb3J0ZWQ6ICgpO1xuICAgICRtYXAta2V5czogbWFwLWtleXMoJG1hcCk7XG4gICAgJG1hcC12YWx1ZXM6IG1hcC12YWx1ZXMoJG1hcCk7XG4gICAgJG1hcC12YWx1ZXMtc29ydGVkOiBfbXEtcXVpY2stc29ydCgkbWFwLXZhbHVlcyk7XG5cbiAgICAvLyBSZW9yZGVyIGtleS92YWx1ZSBwYWlycyBiYXNlZCBvbiBrZXkgdmFsdWVzXG4gICAgQGVhY2ggJHZhbHVlIGluICRtYXAtdmFsdWVzLXNvcnRlZCB7XG4gICAgICAgICRpbmRleDogaW5kZXgoJG1hcC12YWx1ZXMsICR2YWx1ZSk7XG4gICAgICAgICRrZXk6IG50aCgkbWFwLWtleXMsICRpbmRleCk7XG4gICAgICAgICRtYXAtc29ydGVkOiBtYXAtbWVyZ2UoJG1hcC1zb3J0ZWQsICgka2V5OiAkdmFsdWUpKTtcblxuICAgICAgICAvLyBVbnNldCB0aGUgdmFsdWUgaW4gJG1hcC12YWx1ZXMgdG8gcHJldmVudCB0aGUgbG9vcFxuICAgICAgICAvLyBmcm9tIGZpbmRpbmcgdGhlIHNhbWUgaW5kZXggdHdpY2VcbiAgICAgICAgJG1hcC12YWx1ZXM6IHNldC1udGgoJG1hcC12YWx1ZXMsICRpbmRleCwgMCk7XG4gICAgfVxuXG4gICAgQHJldHVybiAkbWFwLXNvcnRlZDtcbn1cblxuLy8vIEFkZCBhIGJyZWFrcG9pbnRcbi8vL1xuLy8vIEBwYXJhbSB7U3RyaW5nfSAkbmFtZSAtIE5hbWUgb2YgdGhlIGJyZWFrcG9pbnRcbi8vLyBAcGFyYW0ge051bWJlcn0gJHdpZHRoIC0gV2lkdGggb2YgdGhlIGJyZWFrcG9pbnRcbi8vL1xuLy8vIEByZXF1aXJlcyB7VmFyaWFibGV9ICRtcS1icmVha3BvaW50c1xuLy8vXG4vLy8gQGV4YW1wbGUgc2Nzc1xuLy8vICBAaW5jbHVkZSBtcS1hZGQtYnJlYWtwb2ludCh0dnNjcmVlbiwgMTkyMHB4KTtcbi8vLyAgQGluY2x1ZGUgbXEodHZzY3JlZW4pIHt9XG5AbWl4aW4gbXEtYWRkLWJyZWFrcG9pbnQoJG5hbWUsICR3aWR0aCkge1xuICAgICRuZXctYnJlYWtwb2ludDogKCRuYW1lOiAkd2lkdGgpO1xuICAgICRtcS1icmVha3BvaW50czogbWFwLW1lcmdlKCRtcS1icmVha3BvaW50cywgJG5ldy1icmVha3BvaW50KSAhZ2xvYmFsO1xuICAgICRtcS1icmVha3BvaW50czogX21xLW1hcC1zb3J0LWJ5LXZhbHVlKCRtcS1icmVha3BvaW50cykgIWdsb2JhbDtcbn1cblxuLy8vIFNob3cgdGhlIGFjdGl2ZSBicmVha3BvaW50IGluIHRoZSB0b3AgcmlnaHQgY29ybmVyIG9mIHRoZSB2aWV3cG9ydFxuLy8vIEBsaW5rIGh0dHBzOi8vZ2l0aHViLmNvbS9zYXNzLW1xL3Nhc3MtbXEjc2VlaW5nLXRoZS1jdXJyZW50bHktYWN0aXZlLWJyZWFrcG9pbnRcbi8vL1xuLy8vIEBwYXJhbSB7TGlzdH0gJHNob3ctYnJlYWtwb2ludHMgKCRtcS1zaG93LWJyZWFrcG9pbnRzKSAtIExpc3Qgb2YgYnJlYWtwb2ludHMgdG8gc2hvdyBpbiB0aGUgdG9wIHJpZ2h0IGNvcm5lclxuLy8vIEBwYXJhbSB7TWFwfSAkYnJlYWtwb2ludHMgKCRtcS1icmVha3BvaW50cykgLSBCcmVha3BvaW50IG5hbWVzIGFuZCBzaXplc1xuLy8vXG4vLy8gQHJlcXVpcmVzIHtWYXJpYWJsZX0gJG1xLWJyZWFrcG9pbnRzXG4vLy8gQHJlcXVpcmVzIHtWYXJpYWJsZX0gJG1xLXNob3ctYnJlYWtwb2ludHNcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgLy8gU2hvdyBicmVha3BvaW50cyB1c2luZyBnbG9iYWwgc2V0dGluZ3Ncbi8vLyAgQGluY2x1ZGUgbXEtc2hvdy1icmVha3BvaW50cztcbi8vL1xuLy8vICAvLyBTaG93IGJyZWFrcG9pbnRzIHVzaW5nIGN1c3RvbSBzZXR0aW5nc1xuLy8vICBAaW5jbHVkZSBtcS1zaG93LWJyZWFrcG9pbnRzKChMLCBYTCksIChTOiAzMDBweCwgTDogODAwcHgsIFhMOiAxMjAwcHgpKTtcbkBtaXhpbiBtcS1zaG93LWJyZWFrcG9pbnRzKCRzaG93LWJyZWFrcG9pbnRzOiAkbXEtc2hvdy1icmVha3BvaW50cywgJGJyZWFrcG9pbnRzOiAkbXEtYnJlYWtwb2ludHMpIHtcbiAgICBib2R5OmJlZm9yZSB7XG4gICAgICAgIGJhY2tncm91bmQtY29sb3I6ICNGQ0Y4RTM7XG4gICAgICAgIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCAjRkJFRUQ1O1xuICAgICAgICBib3JkZXItbGVmdDogMXB4IHNvbGlkICNGQkVFRDU7XG4gICAgICAgIGNvbG9yOiAjQzA5ODUzO1xuICAgICAgICBmb250OiBzbWFsbC1jYXB0aW9uO1xuICAgICAgICBwYWRkaW5nOiAzcHggNnB4O1xuICAgICAgICBwb2ludGVyLWV2ZW50czogbm9uZTtcbiAgICAgICAgcG9zaXRpb246IGZpeGVkO1xuICAgICAgICByaWdodDogMDtcbiAgICAgICAgdG9wOiAwO1xuICAgICAgICB6LWluZGV4OiAxMDA7XG5cbiAgICAgICAgLy8gTG9vcCB0aHJvdWdoIHRoZSBicmVha3BvaW50cyB0aGF0IHNob3VsZCBiZSBzaG93blxuICAgICAgICBAZWFjaCAkc2hvdy1icmVha3BvaW50IGluICRzaG93LWJyZWFrcG9pbnRzIHtcbiAgICAgICAgICAgICR3aWR0aDogbXEtZ2V0LWJyZWFrcG9pbnQtd2lkdGgoJHNob3ctYnJlYWtwb2ludCwgJGJyZWFrcG9pbnRzKTtcbiAgICAgICAgICAgIEBpbmNsdWRlIG1xKCRzaG93LWJyZWFrcG9pbnQsICRicmVha3BvaW50czogJGJyZWFrcG9pbnRzKSB7XG4gICAgICAgICAgICAgICAgY29udGVudDogXCIjeyRzaG93LWJyZWFrcG9pbnR9IOKJpSAjeyR3aWR0aH0gKCN7bXEtcHgyZW0oJHdpZHRoKX0pXCI7XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG59XG5cbkBpZiBsZW5ndGgoJG1xLXNob3ctYnJlYWtwb2ludHMpID4gMCB7XG4gICAgQGluY2x1ZGUgbXEtc2hvdy1icmVha3BvaW50cztcbn1cblxuLy8gc2Fzcy1saW50OmVuYWJsZS1hbGxcbiIsIi8vLy9cbi8vLyBAZ3JvdXAgaGVscGVyc1xuLy8vL1xuXG4vLy8gQ2FsY3VsYXRlIHRoZSBoZWlnaHQgb2YgYW4gZXF1aWxhdGVyYWwgdHJpYW5nbGVcbi8vL1xuLy8vIE11bHRpcGx5aW5nIGhhbGYgdGhlIGxlbmd0aCBvZiB0aGUgYmFzZSBvZiBhbiBlcXVpbGF0ZXJhbCB0cmlhbmdsZSBieSB0aGVcbi8vLyBzcXVhcmUgcm9vdCBvZiB0aHJlZSBnaXZlcyB1cyBpdHMgaGVpZ2h0LiBXZSB1c2UgMS43MzIgYXMgYW4gYXBwcm94aW1hdGlvbi5cbi8vL1xuLy8vIEBwYXJhbSB7TnVtYmVyfSAkYmFzZSAtIExlbmd0aCBvZiB0aGUgYmFzZSBvZiB0aGUgdHJpYW5nbGVcbi8vLyBAcmV0dXJuIHtOdW1iZXJ9IENhbGN1bGF0ZWQgaGVpZ2h0IG9mIHRoZSB0cmlhbmdsZVxuLy8vIEBhY2Nlc3MgcHJpdmF0ZVxuXG5AZnVuY3Rpb24gX2dvdnVrLWVxdWlsYXRlcmFsLWhlaWdodCgkYmFzZSkge1xuICAkc3F1YXJlLXJvb3Qtb2YtdGhyZWU6IDEuNzMyO1xuXG4gIEByZXR1cm4gKCRiYXNlIC8gMikgKiAkc3F1YXJlLXJvb3Qtb2YtdGhyZWU7XG59XG5cbi8vLyBBcnJvdyBtaXhpblxuLy8vXG4vLy8gR2VuZXJhdGUgQXJyb3dzICh0cmlhbmdsZXMpIGJ5IHVzaW5nIGEgbWl4IG9mIHRyYW5zcGFyZW50ICgxKSBhbmQgY29sb3VyZWRcbi8vLyBib3JkZXJzLiBUaGUgY29sb3VyZWQgYm9yZGVycyBpbmhlcml0IHRoZSB0ZXh0IGNvbG91ciBvZiB0aGUgZWxlbWVudCAoMikuXG4vLy9cbi8vLyBFbnN1cmUgdGhlIGFycm93IGlzIHJlbmRlcmVkIGNvcnJlY3RseSBpZiBicm93c2VyIGNvbG91cnMgYXJlIG92ZXJyaWRkZW4gYnlcbi8vLyBwcm92aWRpbmcgYSBjbGlwIHBhdGggKDMpLiBXaXRob3V0IHRoaXMgdGhlIHRyYW5zcGFyZW50IGJvcmRlcnMgYXJlXG4vLy8gb3ZlcnJpZGRlbiB0byBiZWNvbWUgdmlzaWJsZSB3aGljaCByZXN1bHRzIGluIGEgc3F1YXJlLlxuLy8vXG4vLy8gV2UgbmVlZCBib3RoIGJlY2F1c2Ugb2xkZXIgYnJvd3NlcnMgZG8gbm90IHN1cHBvcnQgY2xpcC1wYXRoLlxuLy8vXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRkaXJlY3Rpb24gLSBEaXJlY3Rpb24gZm9yIGFycm93OiB1cCwgcmlnaHQsIGRvd24sIGxlZnQuXG4vLy8gQHBhcmFtIHtOdW1iZXJ9ICRiYXNlIC0gTGVuZ3RoIG9mIHRoZSB0cmlhbmdsZSAnYmFzZScgc2lkZVxuLy8vIEBwYXJhbSB7TnVtYmVyfSAkaGVpZ2h0IFtudWxsXSAtIEhlaWdodCBvZiB0cmlhbmdsZS4gT21pdCBmb3IgZXF1aWxhdGVyYWwuXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRkaXNwbGF5IFtibG9ja10gLSBDU1MgZGlzcGxheSBwcm9wZXJ0eSBvZiB0aGUgYXJyb3dcbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay1zaGFwZS1hcnJvdygkZGlyZWN0aW9uLCAkYmFzZSwgJGhlaWdodDogbnVsbCwgJGRpc3BsYXk6IGJsb2NrKSB7XG4gIGRpc3BsYXk6ICRkaXNwbGF5O1xuXG4gIHdpZHRoOiAwO1xuICBoZWlnaHQ6IDA7XG5cbiAgYm9yZGVyLXN0eWxlOiBzb2xpZDtcbiAgYm9yZGVyLWNvbG9yOiB0cmFuc3BhcmVudDsgLy8gMVxuXG4gICRwZXJwZW5kaWN1bGFyOiAkYmFzZSAvIDI7XG5cbiAgQGlmICgkaGVpZ2h0ID09IG51bGwpIHtcbiAgICAkaGVpZ2h0OiBfZ292dWstZXF1aWxhdGVyYWwtaGVpZ2h0KCRiYXNlKTtcbiAgfVxuXG4gIEBpZiAkZGlyZWN0aW9uID09IFwidXBcIiB7XG4gICAgLXdlYmtpdC1jbGlwLXBhdGg6IHBvbHlnb24oNTAlIDAlLCAwJSAxMDAlLCAxMDAlIDEwMCUpO1xuICAgICAgICAgICAgY2xpcC1wYXRoOiBwb2x5Z29uKDUwJSAwJSwgMCUgMTAwJSwgMTAwJSAxMDAlKTsgLy8gM1xuXG4gICAgYm9yZGVyLXdpZHRoOiAwICRwZXJwZW5kaWN1bGFyICRoZWlnaHQgJHBlcnBlbmRpY3VsYXI7XG4gICAgYm9yZGVyLWJvdHRvbS1jb2xvcjogaW5oZXJpdDsgLy8gMlxuICB9IEBlbHNlIGlmICRkaXJlY3Rpb24gPT0gXCJyaWdodFwiIHtcbiAgICAtd2Via2l0LWNsaXAtcGF0aDogcG9seWdvbigwJSAwJSwgMTAwJSA1MCUsIDAlIDEwMCUpO1xuICAgICAgICAgICAgY2xpcC1wYXRoOiBwb2x5Z29uKDAlIDAlLCAxMDAlIDUwJSwgMCUgMTAwJSk7IC8vIDNcblxuICAgIGJvcmRlci13aWR0aDogJHBlcnBlbmRpY3VsYXIgMCAkcGVycGVuZGljdWxhciAkaGVpZ2h0O1xuICAgIGJvcmRlci1sZWZ0LWNvbG9yOiBpbmhlcml0OyAvLyAyXG4gIH0gQGVsc2UgaWYgJGRpcmVjdGlvbiA9PSBcImRvd25cIiB7XG4gICAgLXdlYmtpdC1jbGlwLXBhdGg6IHBvbHlnb24oMCUgMCUsIDUwJSAxMDAlLCAxMDAlIDAlKTtcbiAgICAgICAgICAgIGNsaXAtcGF0aDogcG9seWdvbigwJSAwJSwgNTAlIDEwMCUsIDEwMCUgMCUpOyAvLyAzXG5cbiAgICBib3JkZXItd2lkdGg6ICRoZWlnaHQgJHBlcnBlbmRpY3VsYXIgMCAkcGVycGVuZGljdWxhcjtcbiAgICBib3JkZXItdG9wLWNvbG9yOiBpbmhlcml0OyAvLyAyXG4gIH0gQGVsc2UgaWYgJGRpcmVjdGlvbiA9PSBcImxlZnRcIiB7XG4gICAgLXdlYmtpdC1jbGlwLXBhdGg6IHBvbHlnb24oMCUgNTAlLCAxMDAlIDEwMCUsIDEwMCUgMCUpO1xuICAgICAgICAgICAgY2xpcC1wYXRoOiBwb2x5Z29uKDAlIDUwJSwgMTAwJSAxMDAlLCAxMDAlIDAlKTsgLy8gM1xuXG4gICAgYm9yZGVyLXdpZHRoOiAkcGVycGVuZGljdWxhciAkaGVpZ2h0ICRwZXJwZW5kaWN1bGFyIDA7XG4gICAgYm9yZGVyLXJpZ2h0LWNvbG9yOiBpbmhlcml0OyAvLyAyXG4gIH0gQGVsc2Uge1xuICAgIEBlcnJvciBcIkludmFsaWQgYXJyb3cgZGlyZWN0aW9uOiBleHBlY3RlZCBgdXBgLCBgcmlnaHRgLCBgZG93bmAgb3IgYGxlZnRgLCBnb3QgYCN7JGRpcmVjdGlvbn1gXCI7XG4gIH1cbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgaGVscGVyc1xuLy8vL1xuXG4vLy8gU2luZ2xlIHBvaW50IHNwYWNpbmdcbi8vL1xuLy8vIFJldHVybnMgbWVhc3VyZW1lbnQgY29ycmVzcG9uZGluZyB0byB0aGUgc3BhY2luZyBwb2ludCByZXF1ZXN0ZWQuXG4vLy9cbi8vLyBAcGFyYW0ge051bWJlcn0gJHNwYWNpbmctcG9pbnQgLSBQb2ludCBvbiB0aGUgc3BhY2luZyBzY2FsZSAoc2V0IGluIGBzZXR0aW5ncy9fc3BhY2luZy5zY2NzYClcbi8vL1xuLy8vIEByZXR1cm5zIHtTdHJpbmd9IFNwYWNpbmcgTWVhc3VyZW1lbnQgZWcuIDEwcHhcbi8vL1xuLy8vIEBleGFtcGxlIHNjc3Ncbi8vLyAgIC5lbGVtZW50IHtcbi8vLyAgICAgcGFkZGluZzogZ292dWstc3BhY2luZyg1KTtcbi8vLyAgICAgdG9wOiBnb3Z1ay1zcGFjaW5nKDIpICFpbXBvcnRhbnQ7IC8vIGlmIGAhaW1wb3J0YW50YCBpcyByZXF1aXJlZFxuLy8vICAgfVxuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBmdW5jdGlvbiBnb3Z1ay1zcGFjaW5nKCRzcGFjaW5nLXBvaW50KSB7XG5cbiAgJGFjdHVhbC1pbnB1dC10eXBlOiB0eXBlLW9mKCRzcGFjaW5nLXBvaW50KTtcbiAgQGlmICRhY3R1YWwtaW5wdXQtdHlwZSAhPSBcIm51bWJlclwiIHtcbiAgICBAZXJyb3IgXCJFeHBlY3RlZCBhIG51bWJlciAoaW50ZWdlciksIGJ1dCBnb3QgYSBcIlxuICAgICsgXCIjeyRhY3R1YWwtaW5wdXQtdHlwZX0uXCI7XG4gIH1cblxuICBAaWYgbm90IG1hcC1oYXMta2V5KCRnb3Z1ay1zcGFjaW5nLXBvaW50cywgJHNwYWNpbmctcG9pbnQpIHtcbiAgICBAZXJyb3IgXCJVbmtub3duIHNwYWNpbmcgdmFyaWFibGUgYCN7JHNwYWNpbmctcG9pbnR9YC4gTWFrZSBzdXJlIHlvdSBhcmUgdXNpbmcgYSBwb2ludCBmcm9tIHRoZSBzcGFjaW5nIHNjYWxlIGluIGBfc2V0dGluZ3Mvc3BhY2luZy5zY3NzYC5cIjtcbiAgfVxuXG4gIEByZXR1cm4gbWFwLWdldCgkZ292dWstc3BhY2luZy1wb2ludHMsICRzcGFjaW5nLXBvaW50KTtcbn1cblxuLy8vIFJlc3BvbnNpdmUgc3BhY2luZ1xuLy8vXG4vLy8gQWRkcyByZXNwb25zaXZlIHNwYWNpbmcgKGVpdGhlciBwYWRkaW5nIG9yIG1hcmdpbiwgZGVwZW5kaW5nIG9uIGAkcHJvcGVydHlgKVxuLy8vIGJ5IGZldGNoaW5nIGEgJ3NwYWNpbmcgbWFwJyBmcm9tIHRoZSByZXNwb25zaXZlIHNwYWNpbmcgc2NhbGUsIHdoaWNoIGRlZmluZXNcbi8vLyBkaWZmZXJlbnQgc3BhY2luZyB2YWx1ZXMgYXQgZGlmZmVyZW50IGJyZWFrcG9pbnRzLlxuLy8vXG4vLy8gVG8gZ2VuZXJhdGUgcmVzcG9uc2l2ZSBzcGFjaW5nLCB1c2UgJ2dvdnVrLXJlc3BvbnNpdmUtbWFyZ2luJyBvclxuLy8vICdnb3Z1ay1yZXNwb25zaXZlLXBhZGRpbmcnIG1peGluc1xuLy8vXG4vLy8gQHBhcmFtIHtOdW1iZXJ9ICRyZXNwb25zaXZlLXNwYWNpbmctcG9pbnQgLSBQb2ludCBvbiB0aGUgcmVzcG9uc2l2ZSBzcGFjaW5nXG4vLy8gICBzY2FsZSwgY29ycmVzcG9uZHMgdG8gYSBtYXAgb2YgYnJlYWtwb2ludHMgYW5kIHNwYWNpbmcgdmFsdWVzXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICRwcm9wZXJ0eSAtIFByb3BlcnR5IHRvIGFkZCBzcGFjaW5nIHRvIChlLmcuICdtYXJnaW4nKVxuLy8vIEBwYXJhbSB7U3RyaW5nfSAkZGlyZWN0aW9uIFthbGxdIC0gRGlyZWN0aW9uIHRvIGFkZCBzcGFjaW5nIHRvXG4vLy8gICAoYHRvcGAsIGByaWdodGAsIGBib3R0b21gLCBgbGVmdGAsIGBhbGxgKVxuLy8vIEBwYXJhbSB7Qm9vbGVhbn0gJGltcG9ydGFudCBbZmFsc2VdIC0gV2hldGhlciB0byBtYXJrIGFzIGAhaW1wb3J0YW50YFxuLy8vIEBwYXJhbSB7TnVtYmVyfSAkYWRqdXN0bWVudCBbZmFsc2VdIC0gT2Zmc2V0IHRvIGFkanVzdCBzcGFjaW5nIGJ5XG4vLy9cbi8vLyBAYWNjZXNzIHByaXZhdGVcblxuQG1peGluIF9nb3Z1ay1yZXNwb25zaXZlLXNwYWNpbmcoJHJlc3BvbnNpdmUtc3BhY2luZy1wb2ludCwgJHByb3BlcnR5LCAkZGlyZWN0aW9uOiBcImFsbFwiLCAkaW1wb3J0YW50OiBmYWxzZSwgJGFkanVzdG1lbnQ6IGZhbHNlKSB7XG5cbiAgJGFjdHVhbC1pbnB1dC10eXBlOiB0eXBlLW9mKCRyZXNwb25zaXZlLXNwYWNpbmctcG9pbnQpO1xuICBAaWYgJGFjdHVhbC1pbnB1dC10eXBlICE9IFwibnVtYmVyXCIge1xuICAgIEBlcnJvciBcIkV4cGVjdGVkIGEgbnVtYmVyIChpbnRlZ2VyKSwgYnV0IGdvdCBhIFwiICsgXCIjeyRhY3R1YWwtaW5wdXQtdHlwZX0uXCI7XG4gIH1cblxuICBAaWYgbm90IG1hcC1oYXMta2V5KCRnb3Z1ay1zcGFjaW5nLXJlc3BvbnNpdmUtc2NhbGUsICRyZXNwb25zaXZlLXNwYWNpbmctcG9pbnQpIHtcbiAgICBAZXJyb3IgXCJVbmtub3duIHNwYWNpbmcgcG9pbnQgYCN7JHJlc3BvbnNpdmUtc3BhY2luZy1wb2ludH1gLiBNYWtlIHN1cmUgeW91IGFyZSB1c2luZyBhIHBvaW50IGZyb20gdGhlIFwiXG4gICAgKyBcInJlc3BvbnNpdmUgc3BhY2luZyBzY2FsZSBpbiBgX3NldHRpbmdzL3NwYWNpbmcuc2Nzc2AuXCI7XG4gIH1cblxuICAvLyBNYWtlIHN1cmUgdGhhdCB0aGUgcmV0dXJuIHZhbHVlIGZyb20gYF9zZXR0aW5ncy9zcGFjaW5nLnNjc3NgIGlzIGEgbWFwLlxuICAkc2NhbGUtbWFwOiBtYXAtZ2V0KCRnb3Z1ay1zcGFjaW5nLXJlc3BvbnNpdmUtc2NhbGUsICRyZXNwb25zaXZlLXNwYWNpbmctcG9pbnQpO1xuICAkYWN0dWFsLW1hcC10eXBlOiB0eXBlLW9mKCRzY2FsZS1tYXApO1xuICBAaWYgJGFjdHVhbC1tYXAtdHlwZSAhPSBcIm1hcFwiIHtcbiAgICBAZXJyb3IgXCJFeHBlY3RlZCBhIG51bWJlciAoaW50ZWdlciksIGJ1dCBnb3QgYSBcIlxuICAgICsgXCIjeyRhY3R1YWwtbWFwLXR5cGV9LiBNYWtlIHN1cmUgeW91IGFyZSB1c2luZyBhIG1hcCB0byBzZXQgdGhlIHJlc3BvbnNpdmUgc3BhY2luZyBpbiBgX3NldHRpbmdzL3NwYWNpbmcuc2Nzc2ApXCI7XG4gIH1cblxuICAvLyBMb29wIHRocm91Z2ggZWFjaCBicmVha3BvaW50IGluIHRoZSBtYXBcbiAgQGVhY2ggJGJyZWFrcG9pbnQsICRicmVha3BvaW50LXZhbHVlIGluICRzY2FsZS1tYXAge1xuXG4gICAgQGlmICgkYWRqdXN0bWVudCkge1xuICAgICAgJGJyZWFrcG9pbnQtdmFsdWU6ICRicmVha3BvaW50LXZhbHVlICsgJGFkanVzdG1lbnQ7XG4gICAgfVxuXG4gICAgLy8gVGhlICdudWxsJyBicmVha3BvaW50IGlzIGZvciBtb2JpbGUuXG4gICAgQGlmICRicmVha3BvaW50ID09IG51bGwge1xuXG4gICAgICBAaWYgJGRpcmVjdGlvbiA9PSBhbGwge1xuICAgICAgICAjeyRwcm9wZXJ0eX06ICRicmVha3BvaW50LXZhbHVlIGlmZigkaW1wb3J0YW50LCAhaW1wb3J0YW50KTtcbiAgICAgIH0gQGVsc2Uge1xuICAgICAgICAjeyRwcm9wZXJ0eX0tI3skZGlyZWN0aW9ufTogJGJyZWFrcG9pbnQtdmFsdWUgaWZmKCRpbXBvcnRhbnQsICFpbXBvcnRhbnQpO1xuICAgICAgfVxuICAgIH0gQGVsc2Uge1xuICAgICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206ICRicmVha3BvaW50KSB7XG4gICAgICAgIEBpZiAkZGlyZWN0aW9uID09IGFsbCB7XG4gICAgICAgICAgI3skcHJvcGVydHl9OiAkYnJlYWtwb2ludC12YWx1ZSBpZmYoJGltcG9ydGFudCwgIWltcG9ydGFudCk7XG4gICAgICAgIH0gQGVsc2Uge1xuICAgICAgICAgICN7JHByb3BlcnR5fS0jeyRkaXJlY3Rpb259OiAkYnJlYWtwb2ludC12YWx1ZSBpZmYoJGltcG9ydGFudCwgIWltcG9ydGFudCk7XG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG4gIH1cbn1cblxuLy8vIFJlc3BvbnNpdmUgbWFyZ2luXG4vLy9cbi8vLyBBZGRzIHJlc3BvbnNpdmUgbWFyZ2luIGJ5IGZldGNoaW5nIGEgJ3NwYWNpbmcgbWFwJyBmcm9tIHRoZSByZXNwb25zaXZlXG4vLy8gc3BhY2luZyBzY2FsZSwgd2hpY2ggZGVmaW5lcyBkaWZmZXJlbnQgc3BhY2luZyB2YWx1ZXMgYXQgZGlmZmVyZW50XG4vLy8gYnJlYWtwb2ludHMuIFdyYXBwZXIgZm9yIHRoZSBgX2dvdnVrLXJlc3BvbnNpdmUtc3BhY2luZ2AgbWl4aW4uXG4vLy9cbi8vLyBAc2VlIHttaXhpbn0gX2dvdnVrLXJlc3BvbnNpdmUtc3BhY2luZ1xuLy8vXG4vLy8gQHBhcmFtIHtOdW1iZXJ9ICRyZXNwb25zaXZlLXNwYWNpbmctcG9pbnQgLSBQb2ludCBvbiB0aGUgcmVzcG9uc2l2ZSBzcGFjaW5nXG4vLy8gc2NhbGUsIGNvcnJlc3BvbmRzIHRvIGEgbWFwIG9mIGJyZWFrcG9pbnRzIGFuZCBzcGFjaW5nIHZhbHVlc1xuLy8vIEBwYXJhbSB7U3RyaW5nfSAkZGlyZWN0aW9uIFthbGxdIC0gRGlyZWN0aW9uIHRvIGFkZCBzcGFjaW5nIHRvXG4vLy8gICAoYHRvcGAsIGByaWdodGAsIGBib3R0b21gLCBgbGVmdGAsIGBhbGxgKVxuLy8vIEBwYXJhbSB7Qm9vbGVhbn0gJGltcG9ydGFudCBbZmFsc2VdIC0gV2hldGhlciB0byBtYXJrIGFzIGAhaW1wb3J0YW50YFxuLy8vIEBwYXJhbSB7TnVtYmVyfSAkYWRqdXN0bWVudCBbZmFsc2VdIC0gT2Zmc2V0IHRvIGFkanVzdCBzcGFjaW5nIGJ5XG4vLy9cbi8vLyBAZXhhbXBsZSBzY3NzXG4vLy8gICAuZWxlbWVudCB7XG4vLy8gICAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig2LCBcImxlZnRcIiwgJGFkanVzdG1lbnQ6IDFweCk7XG4vLy8gICB9XG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oJHJlc3BvbnNpdmUtc3BhY2luZy1wb2ludCwgJGRpcmVjdGlvbjogXCJhbGxcIiwgJGltcG9ydGFudDogZmFsc2UsICRhZGp1c3RtZW50OiBmYWxzZSkge1xuICBAaW5jbHVkZSBfZ292dWstcmVzcG9uc2l2ZS1zcGFjaW5nKCRyZXNwb25zaXZlLXNwYWNpbmctcG9pbnQsIFwibWFyZ2luXCIsICRkaXJlY3Rpb24sICRpbXBvcnRhbnQsICRhZGp1c3RtZW50KTtcbn1cblxuLy8vIFJlc3BvbnNpdmUgcGFkZGluZ1xuLy8vXG4vLy8gQWRkcyByZXNwb25zaXZlIHBhZGRpbmcgYnkgZmV0Y2hpbmcgYSAnc3BhY2luZyBtYXAnIGZyb20gdGhlIHJlc3BvbnNpdmVcbi8vLyBzcGFjaW5nIHNjYWxlLCB3aGljaCBkZWZpbmVzIGRpZmZlcmVudCBzcGFjaW5nIHZhbHVlcyBhdCBkaWZmZXJlbnRcbi8vLyBicmVha3BvaW50cy4gV3JhcHBlciBmb3IgdGhlIGBfZ292dWstcmVzcG9uc2l2ZS1zcGFjaW5nYCBtaXhpbi5cbi8vL1xuLy8vIEBzZWUge21peGlufSBfZ292dWstcmVzcG9uc2l2ZS1zcGFjaW5nXG4vLy9cbi8vLyBAcGFyYW0ge051bWJlcn0gJHJlc3BvbnNpdmUtc3BhY2luZy1wb2ludCAtIFBvaW50IG9uIHRoZSByZXNwb25zaXZlIHNwYWNpbmdcbi8vLyAgIHNjYWxlLCBjb3JyZXNwb25kcyB0byBhIG1hcCBvZiBicmVha3BvaW50cyBhbmQgc3BhY2luZyB2YWx1ZXNcbi8vLyBAcGFyYW0ge1N0cmluZ30gJGRpcmVjdGlvbiBbYWxsXSAtIERpcmVjdGlvbiB0byBhZGQgc3BhY2luZyB0b1xuLy8vICAgKGB0b3BgLCBgcmlnaHRgLCBgYm90dG9tYCwgYGxlZnRgLCBgYWxsYClcbi8vLyBAcGFyYW0ge0Jvb2xlYW59ICRpbXBvcnRhbnQgW2ZhbHNlXSAtIFdoZXRoZXIgdG8gbWFyayBhcyBgIWltcG9ydGFudGBcbi8vLyBAcGFyYW0ge051bWJlcn0gJGFkanVzdG1lbnQgW2ZhbHNlXSAtIE9mZnNldCB0byBhZGp1c3Qgc3BhY2luZ1xuLy8vXG4vLy8gQGV4YW1wbGUgc2Nzc1xuLy8vICAgLmVsZW1lbnQge1xuLy8vICAgICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1wYWRkaW5nKDYsIFwibGVmdFwiLCAkYWRqdXN0bWVudDogMXB4KTtcbi8vLyAgIH1cbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cblxuQG1peGluIGdvdnVrLXJlc3BvbnNpdmUtcGFkZGluZygkcmVzcG9uc2l2ZS1zcGFjaW5nLXBvaW50LCAkZGlyZWN0aW9uOiBcImFsbFwiLCAkaW1wb3J0YW50OiBmYWxzZSwgJGFkanVzdG1lbnQ6IGZhbHNlKSB7XG4gIEBpbmNsdWRlIF9nb3Z1ay1yZXNwb25zaXZlLXNwYWNpbmcoJHJlc3BvbnNpdmUtc3BhY2luZy1wb2ludCwgXCJwYWRkaW5nXCIsICRkaXJlY3Rpb24sICRpbXBvcnRhbnQsICRhZGp1c3RtZW50KTtcbn1cbiIsIi8vLy9cbi8vLyBAZ3JvdXAgaGVscGVyc1xuLy8vL1xuXG5AaW1wb3J0IFwiLi4vdG9vbHMvcHgtdG8tcmVtXCI7XG5cbi8vLyAnQ29tbW9uIHR5cG9ncmFwaHknIGhlbHBlclxuLy8vXG4vLy8gU2V0cyB0aGUgZm9udCBmYW1pbHkgYW5kIGFzc29jaWF0ZWQgcHJvcGVydGllcywgc3VjaCBhcyBmb250IHNtb290aGluZy4gQWxzb1xuLy8vIG92ZXJyaWRlcyB0aGUgZm9udCBmb3IgcHJpbnQuXG4vLy9cbi8vLyBAcGFyYW0ge0xpc3R9ICRmb250LWZhbWlseSBbJGdvdnVrLWZvbnQtZmFtaWx5XSBGb250IGZhbWlseSB0byB1c2Vcbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstdHlwb2dyYXBoeS1jb21tb24oJGZvbnQtZmFtaWx5OiAkZ292dWstZm9udC1mYW1pbHkpIHtcbiAgZm9udC1mYW1pbHk6ICRmb250LWZhbWlseTtcbiAgLXdlYmtpdC1mb250LXNtb290aGluZzogYW50aWFsaWFzZWQ7XG4gIC1tb3otb3N4LWZvbnQtc21vb3RoaW5nOiBncmF5c2NhbGU7XG5cbiAgLy8gSWYgdXNpbmcgTlRBLCBpbmNsdWRlIHRoZSBmb250LWZhY2UgZGVmaW5pdGlvblxuICBAaWYgKCRnb3Z1ay1mb250LWZhbWlseSA9PSAkZ292dWstZm9udC1mYW1pbHktbnRhKSB7XG4gICAgQGluY2x1ZGUgX2dvdnVrLWZvbnQtZmFjZS1udGE7XG4gIH1cblxuICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkbWVkaWEtdHlwZTogcHJpbnQpIHtcbiAgICBmb250LWZhbWlseTogJGdvdnVrLWZvbnQtZmFtaWx5LXByaW50O1xuICB9XG59XG5cbi8vLyBUZXh0IGNvbG91ciBoZWxwZXJcbi8vL1xuLy8vIFNldHMgdGhlIHRleHQgY29sb3VyLCBpbmNsdWRpbmcgYSBzdWl0YWJsZSBvdmVycmlkZSBmb3IgcHJpbnQuXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstdGV4dC1jb2xvdXIge1xuICBjb2xvcjogJGdvdnVrLXRleHQtY29sb3VyO1xuXG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRtZWRpYS10eXBlOiBwcmludCkge1xuICAgIGNvbG9yOiAkZ292dWstcHJpbnQtdGV4dC1jb2xvdXI7XG4gIH1cbn1cblxuLy8vIFJlZ3VsYXIgZm9udCB3ZWlnaHQgaGVscGVyXG4vLy9cbi8vLyBAcGFyYW0ge0Jvb2xlYW59ICRpbXBvcnRhbnQgW2ZhbHNlXSAtIFdoZXRoZXIgdG8gbWFyayBkZWNsYXJhdGlvbnMgYXNcbi8vLyAgIGAhaW1wb3J0YW50YC4gR2VuZXJhbGx5IFVzZWQgdG8gY3JlYXRlIG92ZXJyaWRlIGNsYXNzZXMuXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQG1peGluIGdvdnVrLXR5cG9ncmFwaHktd2VpZ2h0LXJlZ3VsYXIoJGltcG9ydGFudDogZmFsc2UpIHtcbiAgZm9udC13ZWlnaHQ6ICRnb3Z1ay1mb250LXdlaWdodC1yZWd1bGFyIGlmZigkaW1wb3J0YW50LCAhaW1wb3J0YW50KTtcbn1cblxuLy8vIEJvbGQgZm9udCB3ZWlnaHQgaGVscGVyXG4vLy9cbi8vLyBAcGFyYW0ge0Jvb2xlYW59ICRpbXBvcnRhbnQgW2ZhbHNlXSAtIFdoZXRoZXIgdG8gbWFyayBkZWNsYXJhdGlvbnMgYXNcbi8vLyAgIGAhaW1wb3J0YW50YC4gR2VuZXJhbGx5IFVzZWQgdG8gY3JlYXRlIG92ZXJyaWRlIGNsYXNzZXMuXG4vLy8gQGFjY2VzcyBwdWJsaWNcblxuQG1peGluIGdvdnVrLXR5cG9ncmFwaHktd2VpZ2h0LWJvbGQoJGltcG9ydGFudDogZmFsc2UpIHtcbiAgZm9udC13ZWlnaHQ6ICRnb3Z1ay1mb250LXdlaWdodC1ib2xkIGlmZigkaW1wb3J0YW50LCAhaW1wb3J0YW50KTtcbn1cblxuLy8vIENvbnZlcnQgbGluZS1oZWlnaHRzIHNwZWNpZmllZCBpbiBwaXhlbHMgaW50byBhIHJlbGF0aXZlIHZhbHVlLCB1bmxlc3Ncbi8vLyB0aGV5IGFyZSBhbHJlYWR5IHVuaXQtbGVzcyAoYW5kIHRodXMgYWxyZWFkeSB0cmVhdGVkIGFzIHJlbGF0aXZlIHZhbHVlcylcbi8vLyBvciB0aGUgdW5pdHMgZG8gbm90IG1hdGNoIHRoZSB1bml0cyB1c2VkIGZvciB0aGUgZm9udCBzaXplLlxuLy8vXG4vLy8gQHBhcmFtIHtOdW1iZXJ9ICRsaW5lLWhlaWdodCBMaW5lIGhlaWdodFxuLy8vIEBwYXJhbSB7TnVtYmVyfSAkZm9udC1zaXplIEZvbnQgc2l6ZVxuLy8vIEByZXR1cm4ge051bWJlcn0gVGhlIGxpbmUgaGVpZ2h0IGFzIGVpdGhlciBhIHJlbGF0aXZlIHZhbHVlIG9yIHVubW9kaWZpZWRcbi8vL1xuLy8vIEBhY2Nlc3MgcHJpdmF0ZVxuQGZ1bmN0aW9uIF9nb3Z1ay1saW5lLWhlaWdodCgkbGluZS1oZWlnaHQsICRmb250LXNpemUpIHtcbiAgQGlmIG5vdCB1bml0bGVzcygkbGluZS1oZWlnaHQpIGFuZCB1bml0KCRsaW5lLWhlaWdodCkgPT0gdW5pdCgkZm9udC1zaXplKSB7XG4gICAgJGxpbmUtaGVpZ2h0OiAkbGluZS1oZWlnaHQgLyAkZm9udC1zaXplO1xuICB9XG5cbiAgQHJldHVybiAkbGluZS1oZWlnaHQ7XG59XG5cbi8vLyBSZXNwb25zaXZlIHR5cG9ncmFwaHkgaGVscGVyXG4vLy9cbi8vLyBUYWtlcyBhICdmb250IG1hcCcgYXMgYW4gYXJndW1lbnQgYW5kIHVzZXMgaXQgdG8gY3JlYXRlIGZvbnQtc2l6ZSBhbmRcbi8vLyBsaW5lLWhlaWdodCBkZWNsYXJhdGlvbnMgZm9yIGRpZmZlcmVudCBicmVha3BvaW50cywgYW5kIGZvciBwcmludC5cbi8vL1xuLy8vIEV4YW1wbGUgZm9udCBtYXA6XG4vLy9cbi8vLyAkbXktZm9udC1tYXA6IChcbi8vLyAgIG51bGw6IChcbi8vLyAgICAgZm9udC1zaXplOiAxNnB4LFxuLy8vICAgICBsaW5lLWhlaWdodDogMjBweFxuLy8vICAgKSxcbi8vLyAgIHRhYmxldDogKFxuLy8vICAgICBmb250LXNpemU6IDE5cHgsXG4vLy8gICAgIGxpbmUtaGVpZ2h0OiAyNXB4XG4vLy8gICApLFxuLy8vICAgcHJpbnQ6IChcbi8vLyAgICAgZm9udC1zaXplOiAxNHB0LFxuLy8vICAgICBsaW5lLWhlaWdodDogMS4xNVxuLy8vICAgKVxuLy8vICk7XG4vLy9cbi8vLyBAcGFyYW0ge01hcH0gJGZvbnQtbWFwIC0gRm9udCBtYXBcbi8vLyBAcGFyYW0ge051bWJlcn0gJG92ZXJyaWRlLWxpbmUtaGVpZ2h0IFtmYWxzZV0gLSBOb24gcmVzcG9uc2l2ZSBjdXN0b20gbGluZVxuLy8vICAgaGVpZ2h0LiBPbWl0IHRvIHVzZSB0aGUgbGluZSBoZWlnaHQgZnJvbSB0aGUgZm9udCBtYXAuXG4vLy8gQHBhcmFtIHtCb29sZWFufSAkaW1wb3J0YW50IFtmYWxzZV0gLSBXaGV0aGVyIHRvIG1hcmsgZGVjbGFyYXRpb25zIGFzXG4vLy8gICBgIWltcG9ydGFudGAuXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstdHlwb2dyYXBoeS1yZXNwb25zaXZlKCRzaXplLCAkb3ZlcnJpZGUtbGluZS1oZWlnaHQ6IGZhbHNlLCAkaW1wb3J0YW50OiBmYWxzZSkge1xuXG4gIEBpZiBub3QgbWFwLWhhcy1rZXkoJGdvdnVrLXR5cG9ncmFwaHktc2NhbGUsICRzaXplKSB7XG4gICAgQGVycm9yIFwiVW5rbm93biBmb250IHNpemUgYCN7JHNpemV9YCAtIGV4cGVjdGVkIGEgcG9pbnQgZnJvbSB0aGUgdHlwb2dyYXBoeSBzY2FsZS5cIjtcbiAgfVxuXG4gICRmb250LW1hcDogbWFwLWdldCgkZ292dWstdHlwb2dyYXBoeS1zY2FsZSwgJHNpemUpO1xuXG4gIEBlYWNoICRicmVha3BvaW50LCAkYnJlYWtwb2ludC1tYXAgaW4gJGZvbnQtbWFwIHtcbiAgICAkZm9udC1zaXplOiBtYXAtZ2V0KCRicmVha3BvaW50LW1hcCwgXCJmb250LXNpemVcIik7XG4gICAgJGZvbnQtc2l6ZS1yZW06IGdvdnVrLXB4LXRvLXJlbSgkZm9udC1zaXplKTtcblxuICAgICRsaW5lLWhlaWdodDogX2dvdnVrLWxpbmUtaGVpZ2h0KFxuICAgICAgJGxpbmUtaGVpZ2h0OiBpZigkb3ZlcnJpZGUtbGluZS1oZWlnaHQsXG4gICAgICAgICRvdmVycmlkZS1saW5lLWhlaWdodCxcbiAgICAgICAgbWFwLWdldCgkYnJlYWtwb2ludC1tYXAsIFwibGluZS1oZWlnaHRcIilcbiAgICAgICksXG4gICAgICAkZm9udC1zaXplOiAkZm9udC1zaXplXG4gICAgKTtcblxuICAgIC8vIE1hcmsgcnVsZXMgYXMgIWltcG9ydGFudCBpZiAkaW1wb3J0YW50IGlzIHRydWUgLSB0aGlzIHdpbGwgcmVzdWx0IGluXG4gICAgLy8gdGhlc2UgdmFyaWFibGVzIGJlY29taW5nIHN0cmluZ3MsIHNvIHRoaXMgbmVlZHMgdG8gaGFwcGVuICphZnRlciogdGhleVxuICAgIC8vIGFyZSB1c2VkIGluIGNhbGN1bGF0aW9uc1xuICAgICRmb250LXNpemU6ICRmb250LXNpemUgaWZmKCRpbXBvcnRhbnQsICFpbXBvcnRhbnQpO1xuICAgICRmb250LXNpemUtcmVtOiAkZm9udC1zaXplLXJlbSBpZmYoJGltcG9ydGFudCwgIWltcG9ydGFudCk7XG4gICAgJGxpbmUtaGVpZ2h0OiAkbGluZS1oZWlnaHQgaWZmKCRpbXBvcnRhbnQsICFpbXBvcnRhbnQpO1xuXG4gICAgQGlmICRicmVha3BvaW50ID09IG51bGwge1xuICAgICAgZm9udC1zaXplOiAkZm9udC1zaXplOyAvLyBzYXNzLWxpbnQ6ZGlzYWJsZSBuby1kdXBsaWNhdGUtcHJvcGVydGllc1xuICAgICAgQGlmICRnb3Z1ay10eXBvZ3JhcGh5LXVzZS1yZW0ge1xuICAgICAgICBmb250LXNpemU6ICRmb250LXNpemUtcmVtOyAvLyBzYXNzLWxpbnQ6ZGlzYWJsZSBuby1kdXBsaWNhdGUtcHJvcGVydGllc1xuICAgICAgfVxuICAgICAgbGluZS1oZWlnaHQ6ICRsaW5lLWhlaWdodDtcbiAgICB9IEBlbHNlaWYgJGJyZWFrcG9pbnQgPT0gXCJwcmludFwiIHtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRtZWRpYS10eXBlOiBwcmludCkge1xuICAgICAgICBmb250LXNpemU6ICRmb250LXNpemU7XG4gICAgICAgIGxpbmUtaGVpZ2h0OiAkbGluZS1oZWlnaHQ7XG4gICAgICB9XG4gICAgfSBAZWxzZSB7XG4gICAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogJGJyZWFrcG9pbnQpIHtcbiAgICAgICAgZm9udC1zaXplOiAkZm9udC1zaXplOyAvLyBzYXNzLWxpbnQ6ZGlzYWJsZSBuby1kdXBsaWNhdGUtcHJvcGVydGllc1xuICAgICAgICBAaWYgJGdvdnVrLXR5cG9ncmFwaHktdXNlLXJlbSB7XG4gICAgICAgICAgZm9udC1zaXplOiAkZm9udC1zaXplLXJlbTsgLy8gc2Fzcy1saW50OmRpc2FibGUgbm8tZHVwbGljYXRlLXByb3BlcnRpZXNcbiAgICAgICAgfVxuICAgICAgICBsaW5lLWhlaWdodDogJGxpbmUtaGVpZ2h0O1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG4vLy8gRm9udCBoZWxwZXJcbi8vL1xuLy8vIEBwYXJhbSB7TnVtYmVyfSAkc2l6ZSAtIFNpemUgb2YgdGhlIGZvbnQgYXMgaXQgd291bGQgYXBwZWFyIG9uIGRlc2t0b3AgLVxuLy8vICAgdXNlcyB0aGUgcmVzcG9uc2l2ZSBmb250IHNpemUgbWFwXG4vLy8gQHBhcmFtIHtTdHJpbmd9ICR3ZWlnaHQgW3JlZ3VsYXJdIC0gV2VpZ2h0OiBgYm9sZGAgb3IgYHJlZ3VsYXJgXG4vLy8gQHBhcmFtIHtCb29sZWFufSAkdGFidWxhciBbZmFsc2VdIC0gV2hldGhlciB0byB1c2UgdGFidWxhciBudW1iZXJzIG9yIG5vdFxuLy8vIEBwYXJhbSB7TnVtYmVyfSAkbGluZS1oZWlnaHQgW2ZhbHNlXSAtIExpbmUtaGVpZ2h0LCBpZiBvdmVycmlkaW5nIHRoZSBkZWZhdWx0XG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstZm9udCgkc2l6ZSwgJHdlaWdodDogcmVndWxhciwgJHRhYnVsYXI6IGZhbHNlLCAkbGluZS1oZWlnaHQ6IGZhbHNlKSB7XG4gIEBpZiAkdGFidWxhciB7XG4gICAgQGluY2x1ZGUgZ292dWstdHlwb2dyYXBoeS1jb21tb24oJGZvbnQtZmFtaWx5OiAkZ292dWstZm9udC1mYW1pbHktdGFidWxhcik7XG4gIH0gQGVsc2Uge1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktY29tbW9uO1xuICB9XG5cbiAgQGlmICR3ZWlnaHQgPT0gcmVndWxhciB7XG4gICAgQGluY2x1ZGUgZ292dWstdHlwb2dyYXBoeS13ZWlnaHQtcmVndWxhcjtcbiAgfSBAZWxzZSBpZiAkd2VpZ2h0ID09IGJvbGQge1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktd2VpZ2h0LWJvbGQ7XG4gIH1cblxuICBAaWYgJHNpemUge1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktcmVzcG9uc2l2ZSgkc2l6ZSwgJG92ZXJyaWRlLWxpbmUtaGVpZ2h0OiAkbGluZS1oZWlnaHQpO1xuICB9XG59XG4iLCIvLy8vXG4vLy8gQGdyb3VwIGhlbHBlcnNcbi8vLy9cblxuLy8vIEhpZGUgYW4gZWxlbWVudCB2aXN1YWxseSwgYnV0IGhhdmUgaXQgYXZhaWxhYmxlIGZvciBzY3JlZW4gcmVhZGVyc1xuLy8vXG4vLy8gQGxpbmsgaHR0cHM6Ly9zbm9vay5jYS9hcmNoaXZlcy9odG1sX2FuZF9jc3MvaGlkaW5nLWNvbnRlbnQtZm9yLWFjY2Vzc2liaWxpdHlcbi8vLyAgIC0gSGlkaW5nIENvbnRlbnQgZm9yIEFjY2Vzc2liaWxpdHksIEpvbmF0aGFuIFNub29rLCBGZWJydWFyeSAyMDExXG4vLy8gQGxpbmsgaHR0cHM6Ly9naXRodWIuY29tL2g1YnAvaHRtbDUtYm9pbGVycGxhdGUvYmxvYi85ZjEzNjk1ZDIxZmY5MmM1NWM3OGRmYTlmMTZiYjAyYTFiNmU5MTFmL3NyYy9jc3MvbWFpbi5jc3MjTDEyMS1MMTU4XG4vLy8gICAtIGg1YnAvaHRtbDUtYm9pbGVycGxhdGUgLSBUaGFua3MhXG4vLy9cbi8vLyBAYWNjZXNzIHB1YmxpY1xuXG5AbWl4aW4gZ292dWstdmlzdWFsbHktaGlkZGVuIHtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuXG4gIHdpZHRoOiAxcHg7XG4gIGhlaWdodDogMXB4O1xuICBtYXJnaW46IC0xcHg7XG4gIHBhZGRpbmc6IDA7XG5cbiAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgY2xpcDogcmVjdCgwIDAgMCAwKTtcbiAgLXdlYmtpdC1jbGlwLXBhdGg6IGluc2V0KDUwJSk7XG4gICAgICAgICAgY2xpcC1wYXRoOiBpbnNldCg1MCUpO1xuXG4gIGJvcmRlcjogMDtcblxuICAvLyBGb3IgbG9uZyBjb250ZW50LCBsaW5lIGZlZWRzIGFyZSBub3QgaW50ZXJwcmV0ZWQgYXMgc3BhY2VzIGFuZCBzbWFsbCB3aWR0aFxuICAvLyBjYXVzZXMgY29udGVudCB0byB3cmFwIDEgd29yZCBwZXIgbGluZTpcbiAgLy8gaHR0cHM6Ly9tZWRpdW0uY29tL0BqZXNzZWJlYWNoL2Jld2FyZS1zbXVzaGVkLW9mZi1zY3JlZW4tYWNjZXNzaWJsZS10ZXh0LTU5NTJhNGMyY2JmZVxuICB3aGl0ZS1zcGFjZTogbm93cmFwO1xufVxuXG4vLy8gSGlkZSBhbiBlbGVtZW50IHZpc3VhbGx5LCBidXQgaGF2ZSBpdCBhdmFpbGFibGUgZm9yIHNjcmVlbiByZWFkZXJzIHdoaWxzdFxuLy8vIGFsbG93aW5nIHRoZSBlbGVtZW50IHRvIGJlIGZvY3VzZWQgd2hlbiBuYXZpZ2F0ZWQgdG8gdmlhIHRoZSBrZXlib2FyZCAoZS5nLlxuLy8vIGZvciB0aGUgc2tpcCBsaW5rKVxuLy8vXG4vLy8gVGhpcyBpcyBzbGlnaHRseSBsZXNzIG9waW5pb25hdGVkIGFib3V0IGJvcmRlcnMgYW5kIHBhZGRpbmcgdG8gbWFrZSBpdFxuLy8vIGVhc2llciB0byBzdHlsZSB0aGUgZm9jdXNzZWQgZWxlbWVudC5cbi8vL1xuLy8vIEBhY2Nlc3MgcHVibGljXG5cbkBtaXhpbiBnb3Z1ay12aXN1YWxseS1oaWRkZW4tZm9jdXNhYmxlIHtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuXG4gIHdpZHRoOiAxcHg7XG4gIGhlaWdodDogMXB4O1xuICBtYXJnaW46IC0xcHg7XG5cbiAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgY2xpcDogcmVjdCgwIDAgMCAwKTtcbiAgLXdlYmtpdC1jbGlwLXBhdGg6IGluc2V0KDUwJSk7XG4gICAgICAgICAgY2xpcC1wYXRoOiBpbnNldCg1MCUpO1xuXG4gIC8vIEZvciBsb25nIGNvbnRlbnQsIGxpbmUgZmVlZHMgYXJlIG5vdCBpbnRlcnByZXRlZCBhcyBzcGFjZXMgYW5kIHNtYWxsIHdpZHRoXG4gIC8vIGNhdXNlcyBjb250ZW50IHRvIHdyYXAgMSB3b3JkIHBlciBsaW5lOlxuICAvLyBodHRwczovL21lZGl1bS5jb20vQGplc3NlYmVhY2gvYmV3YXJlLXNtdXNoZWQtb2ZmLXNjcmVlbi1hY2Nlc3NpYmxlLXRleHQtNTk1MmE0YzJjYmZlXG4gIHdoaXRlLXNwYWNlOiBub3dyYXA7XG5cbiAgJjphY3RpdmUsXG4gICY6Zm9jdXMge1xuICAgIHBvc2l0aW9uOiBzdGF0aWM7XG5cbiAgICB3aWR0aDogYXV0bztcbiAgICBoZWlnaHQ6IGF1dG87XG4gICAgbWFyZ2luOiBpbmhlcml0O1xuXG4gICAgb3ZlcmZsb3c6IHZpc2libGU7XG4gICAgY2xpcDogYXV0bztcbiAgICAtd2Via2l0LWNsaXAtcGF0aDogbm9uZTtcbiAgICAgICAgICAgIGNsaXAtcGF0aDogbm9uZTtcblxuICAgIHdoaXRlLXNwYWNlOiBpbmhlcml0O1xuICB9XG59XG4iLCJAaW1wb3J0IFwibGlua3NcIjtcbkBpbXBvcnQgXCJsaXN0c1wiO1xuQGltcG9ydCBcInRlbXBsYXRlXCI7XG5AaW1wb3J0IFwidHlwb2dyYXBoeVwiO1xuQGltcG9ydCBcInNlY3Rpb24tYnJlYWtcIjtcbkBpbXBvcnQgXCJnbG9iYWwtc3R5bGVzXCI7XG4iLCJAaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29yZS9saW5rc1wiKSB7XG5cbiAgJWdvdnVrLWxpbmsge1xuICAgIEBpbmNsdWRlIGdvdnVrLWxpbmstY29tbW9uO1xuICAgIEBpbmNsdWRlIGdvdnVrLWxpbmstc3R5bGUtZGVmYXVsdDtcbiAgICBAaW5jbHVkZSBnb3Z1ay1saW5rLXByaW50LWZyaWVuZGx5O1xuICB9XG5cbiAgLmdvdnVrLWxpbmsge1xuICAgIEBleHRlbmQgJWdvdnVrLWxpbms7XG4gIH1cblxuICAvLyBWYXJpYW50IGNsYXNzZXMgc2hvdWxkIGFsd2F5cyBiZSB1c2VkIGluIGNvbmp1bmN0aW9uIHdpdGggdGhlIC5nb3Z1ay1saW5rXG4gIC8vIGNsYXNzLCBzbyB3ZSBkbyBub3QgbmVlZCB0aGUgY29tbW9uIGxpbmsgc3R5bGVzIGFzIHRoZXkgd2lsbCBiZSBpbmhlcml0ZWQuXG5cbiAgLmdvdnVrLWxpbmstLW11dGVkIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1saW5rLXN0eWxlLW11dGVkO1xuICB9XG5cbiAgLmdvdnVrLWxpbmstLXRleHQtY29sb3VyIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1saW5rLXN0eWxlLXRleHQ7XG4gIH1cblxuICAvLyAnTm8gdmlzaXRlZCBzdGF0ZScgbGluayBtaXhpblxuICAvL1xuICAvLyBVc2VkIGluIGNhc2VzIHdoZXJlIGl0IGlzIG5vdCBoZWxwZnVsIHRvIGRpc3Rpbmd1aXNoIGJldHdlZW4gdmlzaXRlZCBhbmRcbiAgLy8gbm9uLXZpc2l0ZWQgbGlua3MuXG4gIC8vXG4gIC8vIEZvciBleGFtcGxlLCBuYXZpZ2F0aW9uIGxpbmtzIHRvIHBhZ2VzIHdpdGggZHluYW1pYyBjb250ZW50IGxpa2UgYWRtaW5cbiAgLy8gZGFzaGJvYXJkcy4gVGhlIGNvbnRlbnQgb24gdGhlIHBhZ2UgaXMgY2hhbmdpbmcgYWxsIHRoZSB0aW1lLCBzbyB0aGUgZmFjdFxuICAvLyB0aGF0IHlvdeKAmXZlIHZpc2l0ZWQgaXQgYmVmb3JlIGlzIG5vdCBpbXBvcnRhbnQuXG4gIC8vXG4gIC8vIFRoaXMgaXMgbm90IGFic3RyYWN0ZWQgYXMgYSBtaXhpbiBiZWNhdXNlIGl0IGRvZXMgbm90IHByb3ZpZGUgc3RhdGVzIGZvclxuICAvLyBhbGwgcHNldWRvLXNlbGVjdG9ycyBzbyBpdCBkb2VzIG5vdCBtYWtlIHNlbnNlIHRvIHVzZSBpdCBpbiBjb21wb3NpdGlvbi5cbiAgLmdvdnVrLWxpbmstLW5vLXZpc2l0ZWQtc3RhdGUge1xuICAgICY6dmlzaXRlZCB7XG4gICAgICBjb2xvcjogJGdvdnVrLWxpbmstY29sb3VyO1xuICAgIH1cbiAgfVxufVxuIiwiQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvcmUvbGlzdHNcIikge1xuXG4gICVnb3Z1ay1saXN0IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgbWFyZ2luLXRvcDogMDtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig0LCBcImJvdHRvbVwiKTtcbiAgICBwYWRkaW5nLWxlZnQ6IDA7XG4gICAgbGlzdC1zdHlsZS10eXBlOiBub25lO1xuXG4gICAgLy8gQWRkIGEgdG9wIG1hcmdpbiBmb3IgbmVzdGVkIGxpc3RzXG4gICAgJWdvdnVrLWxpc3Qge1xuICAgICAgbWFyZ2luLXRvcDogZ292dWstc3BhY2luZygyKTtcbiAgICB9XG4gIH1cblxuICAlZ292dWstbGlzdCA+IGxpIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogdGFibGV0KSB7XG4gICAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDEpO1xuICAgIH1cbiAgfVxuXG4gICVnb3Z1ay1saXN0IGEge1xuICAgICY6bGluayB7XG4gICAgICBjb2xvcjogJGdvdnVrLWxpbmstY29sb3VyO1xuICAgIH1cblxuICAgICY6dmlzaXRlZCB7XG4gICAgICBjb2xvcjogJGdvdnVrLWxpbmstdmlzaXRlZC1jb2xvdXI7XG4gICAgfVxuXG4gICAgJjpob3ZlciB7XG4gICAgICBjb2xvcjogJGdvdnVrLWxpbmstaG92ZXItY29sb3VyO1xuICAgIH1cblxuICAgICY6YWN0aXZlIHtcbiAgICAgIGNvbG9yOiAkZ292dWstbGluay1hY3RpdmUtY29sb3VyO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1saXN0IHtcbiAgICBAZXh0ZW5kICVnb3Z1ay1saXN0O1xuICB9XG5cbiAgJWdvdnVrLWxpc3QtLWJ1bGxldCB7XG4gICAgcGFkZGluZy1sZWZ0OiBnb3Z1ay1zcGFjaW5nKDQpO1xuXG4gICAgbGlzdC1zdHlsZS10eXBlOiBkaXNjO1xuICB9XG5cbiAgLmdvdnVrLWxpc3QtLWJ1bGxldCB7XG4gICAgQGV4dGVuZCAlZ292dWstbGlzdC0tYnVsbGV0O1xuICB9XG5cbiAgJWdvdnVrLWxpc3QtLW51bWJlciB7XG4gICAgcGFkZGluZy1sZWZ0OiBnb3Z1ay1zcGFjaW5nKDQpO1xuICAgIGxpc3Qtc3R5bGUtdHlwZTogZGVjaW1hbDtcbiAgfVxuXG4gIC5nb3Z1ay1saXN0LS1udW1iZXIge1xuICAgIEBleHRlbmQgJWdvdnVrLWxpc3QtLW51bWJlcjtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uL3NldHRpbmdzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29yZS90ZW1wbGF0ZVwiKSB7XG5cbiAgLy8gQXBwbGllZCB0byB0aGUgPGh0bWw+IGVsZW1lbnRcbiAgLmdvdnVrLXRlbXBsYXRlIHtcbiAgICAvLyBTZXQgdGhlIG92ZXJhbGwgcGFnZSBiYWNrZ3JvdW5kIGNvbG91ciB0byB0aGUgc2FtZSBjb2xvdXIgYXMgdXNlZCBieSB0aGVcbiAgICAvLyBmb290ZXIgdG8gZ2l2ZSB0aGUgaWxsdXNpb24gb2YgYSBsb25nIGZvb3Rlci5cbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZ292dWstY2FudmFzLWJhY2tncm91bmQtY29sb3VyO1xuICB9XG5cbiAgLy8gQXBwbGllZCB0byB0aGUgPGJvZHk+IGVsZW1lbnRcbiAgLmdvdnVrLXRlbXBsYXRlX19ib2R5IHtcbiAgICAvLyBUaGUgZGVmYXVsdCBtYXJnaW5zIHNldCBieSB1c2VyLWFnZW50cyBhcmUgbm90IHJlcXVpcmVkIHNpbmNlIHdlIGhhdmUgb3VyXG4gICAgLy8gb3duIGNvbnRhaW5lcnMuXG4gICAgbWFyZ2luOiAwO1xuICAgIC8vIFNldCB0aGUgb3ZlcmFsbCBib2R5IG9mIHRoZSBwYWdlIGJhY2sgdG8gdGhlIHR5cGljYWwgYmFja2dyb3VuZCBjb2xvdXIuXG4gICAgYmFja2dyb3VuZC1jb2xvcjogJGdvdnVrLWJvZHktYmFja2dyb3VuZC1jb2xvdXI7XG4gIH1cbn1cbiIsIkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb3JlL3R5cG9ncmFwaHlcIikge1xuXG4gIC8vIEhlYWRpbmdzXG5cbiAgJWdvdnVrLWhlYWRpbmcteGwge1xuICAgIEBpbmNsdWRlIGdvdnVrLXRleHQtY29sb3VyO1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDQ4LCAkd2VpZ2h0OiBib2xkKTtcblxuICAgIGRpc3BsYXk6IGJsb2NrO1xuXG4gICAgbWFyZ2luLXRvcDogMDtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig4LCBcImJvdHRvbVwiKTtcbiAgfVxuXG4gIC5nb3Z1ay1oZWFkaW5nLXhsIHtcbiAgICBAZXh0ZW5kICVnb3Z1ay1oZWFkaW5nLXhsO1xuICB9XG5cbiAgJWdvdnVrLWhlYWRpbmctbCB7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMzYsICR3ZWlnaHQ6IGJvbGQpO1xuXG4gICAgZGlzcGxheTogYmxvY2s7XG5cbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDYsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLWhlYWRpbmctbCB7XG4gICAgQGV4dGVuZCAlZ292dWstaGVhZGluZy1sO1xuICB9XG5cbiAgJWdvdnVrLWhlYWRpbmctbSB7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMjQsICR3ZWlnaHQ6IGJvbGQpO1xuXG4gICAgZGlzcGxheTogYmxvY2s7XG5cbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLWhlYWRpbmctbSB7XG4gICAgQGV4dGVuZCAlZ292dWstaGVhZGluZy1tO1xuICB9XG5cbiAgJWdvdnVrLWhlYWRpbmctcyB7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTksICR3ZWlnaHQ6IGJvbGQpO1xuXG4gICAgZGlzcGxheTogYmxvY2s7XG5cbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLWhlYWRpbmctcyB7XG4gICAgQGV4dGVuZCAlZ292dWstaGVhZGluZy1zO1xuICB9XG5cbiAgLy8gQ2FwdGlvbnMgdG8gYmUgdXNlZCBpbnNpZGUgaGVhZGluZ3NcblxuICAuZ292dWstY2FwdGlvbi14bCB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMjcpO1xuXG4gICAgZGlzcGxheTogYmxvY2s7XG5cbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDEpO1xuXG4gICAgY29sb3I6ICRnb3Z1ay1zZWNvbmRhcnktdGV4dC1jb2xvdXI7XG4gIH1cblxuICAuZ292dWstY2FwdGlvbi1sIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAyNCk7XG5cbiAgICBkaXNwbGF5OiBibG9jaztcblxuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMSk7XG4gICAgY29sb3I6ICRnb3Z1ay1zZWNvbmRhcnktdGV4dC1jb2xvdXI7XG5cbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogdGFibGV0KSB7XG4gICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1jYXB0aW9uLW0ge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcblxuICAgIGRpc3BsYXk6IGJsb2NrO1xuXG4gICAgY29sb3I6ICRnb3Z1ay1zZWNvbmRhcnktdGV4dC1jb2xvdXI7XG4gIH1cblxuICAvLyBCb2R5IChwYXJhZ3JhcGhzKVxuXG4gICVnb3Z1ay1ib2R5LWwge1xuICAgIEBpbmNsdWRlIGdvdnVrLXRleHQtY29sb3VyO1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDI0KTtcblxuICAgIG1hcmdpbi10b3A6IDA7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNiwgXCJib3R0b21cIik7XG4gIH1cblxuICAuZ292dWstYm9keS1sIHtcbiAgICBAZXh0ZW5kICVnb3Z1ay1ib2R5LWw7XG4gIH1cblxuICAlZ292dWstYm9keS1tIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG5cbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLWJvZHktbSB7XG4gICAgQGV4dGVuZCAlZ292dWstYm9keS1tO1xuICB9XG5cbiAgJWdvdnVrLWJvZHktcyB7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTYpO1xuXG4gICAgbWFyZ2luLXRvcDogMDtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig0LCBcImJvdHRvbVwiKTtcbiAgfVxuXG4gIC5nb3Z1ay1ib2R5LXMge1xuICAgIEBleHRlbmQgJWdvdnVrLWJvZHktcztcbiAgfVxuXG4gICVnb3Z1ay1ib2R5LXhzIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxNCk7XG5cbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLWJvZHkteHMge1xuICAgIEBleHRlbmQgJWdvdnVrLWJvZHkteHM7XG4gIH1cblxuICAvLyBVc2FnZSBhbGlhc2VzXG5cbiAgLy8gVXNpbmcgZXh0ZW5kIHRvIGFsaWFzIG1lYW5zIHdlIGFsc28gaW5oZXJpdCBhbnkgY29udGV4dHVhbCBhZGp1c3RtZW50cyB0aGF0XG4gIC8vIHJlZmVyIHRvIHRoZSAnb3JpZ2luYWwnIGNsYXNzIG5hbWVcblxuICAuZ292dWstYm9keS1sZWFkIHtcbiAgICBAZXh0ZW5kICVnb3Z1ay1ib2R5LWw7XG4gIH1cblxuICAuZ292dWstYm9keSB7XG4gICAgQGV4dGVuZCAlZ292dWstYm9keS1tO1xuICB9XG5cbiAgLy8gQ29udGV4dHVhbCBhZGp1c3RtZW50c1xuICAvLyBBZGQgdG9wIHBhZGRpbmcgdG8gaGVhZGluZ3MgdGhhdCBhcHBlYXIgZGlyZWN0bHkgYWZ0ZXIgcGFyYWdyYXBocy5cblxuICAlZ292dWstYm9keS1sICArICVnb3Z1ay1oZWFkaW5nLWwge1xuICAgIHBhZGRpbmctdG9wOiBnb3Z1ay1zcGFjaW5nKDEpO1xuXG4gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgICAgcGFkZGluZy10b3A6IGdvdnVrLXNwYWNpbmcoMik7XG4gICAgfVxuICB9XG5cbiAgJWdvdnVrLWJvZHktbSAgKyAlZ292dWstaGVhZGluZy1sLFxuICAlZ292dWstYm9keS1zICArICVnb3Z1ay1oZWFkaW5nLWwsXG4gICVnb3Z1ay1saXN0ICsgJWdvdnVrLWhlYWRpbmctbCB7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1wYWRkaW5nKDQsIFwidG9wXCIpO1xuICB9XG5cbiAgJWdvdnVrLWJvZHktbSArICVnb3Z1ay1oZWFkaW5nLW0sXG4gICVnb3Z1ay1ib2R5LXMgKyAlZ292dWstaGVhZGluZy1tLFxuICAlZ292dWstbGlzdCArICVnb3Z1ay1oZWFkaW5nLW0sXG4gICVnb3Z1ay1ib2R5LW0gKyAlZ292dWstaGVhZGluZy1zLFxuICAlZ292dWstYm9keS1zICsgJWdvdnVrLWhlYWRpbmctcyxcbiAgJWdvdnVrLWxpc3QgKyAlZ292dWstaGVhZGluZy1zIHtcbiAgICBwYWRkaW5nLXRvcDogZ292dWstc3BhY2luZygxKTtcblxuICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiB0YWJsZXQpIHtcbiAgICAgIHBhZGRpbmctdG9wOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAgIH1cbiAgfVxufVxuIiwiQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvcmUvc2VjdGlvbi1icmVha1wiKSB7XG5cbiAgJWdvdnVrLXNlY3Rpb24tYnJlYWsge1xuICAgIG1hcmdpbjogMDtcbiAgICBib3JkZXI6IDA7XG5cbiAgICAvLyBmaXggZG91YmxlLXdpZHRoIHNlY3Rpb24gYnJlYWsgYW5kIGZvcmNlZCB2aXNpYmxlIHNlY3Rpb24gYnJlYWtcbiAgICAvLyB3aGVuIGNvbWJpbmVkIHdpdGggc3R5bGVzIGZyb20gYWxwaGFnb3YvZWxlbWVudHNcbiAgICBAaW5jbHVkZSBnb3Z1ay1jb21wYXRpYmlsaXR5KGdvdnVrX2VsZW1lbnRzKSB7XG4gICAgICBoZWlnaHQ6IDA7XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLXNlY3Rpb24tYnJlYWsge1xuICAgIEBleHRlbmQgJWdvdnVrLXNlY3Rpb24tYnJlYWs7XG4gIH1cblxuICAvLyBTaXplc1xuXG4gICVnb3Z1ay1zZWN0aW9uLWJyZWFrLS14bCB7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oOCwgXCJ0b3BcIik7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oOCwgXCJib3R0b21cIik7XG4gIH1cblxuICAuZ292dWstc2VjdGlvbi1icmVhay0teGwge1xuICAgIEBleHRlbmQgJWdvdnVrLXNlY3Rpb24tYnJlYWstLXhsO1xuICB9XG5cbiAgJWdvdnVrLXNlY3Rpb24tYnJlYWstLWwge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDYsIFwidG9wXCIpO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDYsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLXNlY3Rpb24tYnJlYWstLWwge1xuICAgIEBleHRlbmQgJWdvdnVrLXNlY3Rpb24tYnJlYWstLWw7XG4gIH1cblxuICAlZ292dWstc2VjdGlvbi1icmVhay0tbSB7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNCwgXCJ0b3BcIik7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNCwgXCJib3R0b21cIik7XG4gIH1cblxuICAuZ292dWstc2VjdGlvbi1icmVhay0tbSB7XG4gICAgQGV4dGVuZCAlZ292dWstc2VjdGlvbi1icmVhay0tbTtcbiAgfVxuXG4gIC8vIFZpc2libGUgdmFyaWFudFxuXG4gICVnb3Z1ay1zZWN0aW9uLWJyZWFrLS12aXNpYmxlIHtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gIH1cblxuICAuZ292dWstc2VjdGlvbi1icmVhay0tdmlzaWJsZSB7XG4gICAgQGV4dGVuZCAlZ292dWstc2VjdGlvbi1icmVhay0tdmlzaWJsZTtcbiAgfVxufVxuIiwiQGltcG9ydCBcImxpbmtzXCI7XG5AaW1wb3J0IFwidHlwb2dyYXBoeVwiO1xuXG5AbWl4aW4gZ292dWstZ2xvYmFsLXN0eWxlcyB7XG4gIGEge1xuICAgIEBleHRlbmQgJWdvdnVrLWxpbms7XG4gIH1cblxuICBwIHtcbiAgICBAZXh0ZW5kICVnb3Z1ay1ib2R5LW07XG4gIH1cbn1cblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvcmUvZ2xvYmFsLXN0eWxlc1wiKSB7XG5cbiAgQGlmICRnb3Z1ay1nbG9iYWwtc3R5bGVzID09IHRydWUge1xuICAgIEBpbmNsdWRlIGdvdnVrLWdsb2JhbC1zdHlsZXM7XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCJmb3JtLWdyb3VwXCI7XG5AaW1wb3J0IFwiZ3JpZFwiO1xuQGltcG9ydCBcIm1haW4td3JhcHBlclwiO1xuQGltcG9ydCBcIndpZHRoLWNvbnRhaW5lclwiO1xuIiwiQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL29iamVjdHMvZm9ybS1ncm91cFwiKSB7XG5cbiAgLmdvdnVrLWZvcm0tZ3JvdXAge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDYsIFwiYm90dG9tXCIpO1xuXG4gICAgLmdvdnVrLWZvcm0tZ3JvdXA6bGFzdC1vZi10eXBlIHtcbiAgICAgIG1hcmdpbi1ib3R0b206IDA7IC8vIFJlbW92ZSBtYXJnaW4gZnJvbSBsYXN0IGl0ZW0gaW4gbmVzdGVkIGdyb3Vwc1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1mb3JtLWdyb3VwLS1lcnJvciB7XG4gICAgcGFkZGluZy1sZWZ0OiBnb3Z1ay1zcGFjaW5nKDMpO1xuICAgIGJvcmRlci1sZWZ0OiAkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZ3JvdXAtZXJyb3Igc29saWQgJGdvdnVrLWVycm9yLWNvbG91cjtcblxuICAgIC5nb3Z1ay1mb3JtLWdyb3VwIHtcbiAgICAgIC8vIFJlc2V0IGVycm9yIHN0eWxlcyBpbiBuZXN0ZWQgZm9ybSBncm91cHMgdGhhdCBtaWdodCBoYXZlIGVycm9yIGNsYXNzXG4gICAgICBwYWRkaW5nOiAwO1xuICAgICAgYm9yZGVyOiAwO1xuICAgIH1cbiAgfVxufVxuIiwiQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL29iamVjdHMvZ3JpZFwiKSB7XG4gIC8vbW9zdCBjb21tb24gdXNhZ2VcbiAgQGluY2x1ZGUgZ292dWstZ3JpZC1yb3c7XG4gIEBpbmNsdWRlIGdvdnVrLWdyaWQtY29sdW1uKG9uZS1xdWFydGVyKTtcbiAgQGluY2x1ZGUgZ292dWstZ3JpZC1jb2x1bW4ob25lLXRoaXJkKTtcbiAgQGluY2x1ZGUgZ292dWstZ3JpZC1jb2x1bW4ob25lLWhhbGYpO1xuICBAaW5jbHVkZSBnb3Z1ay1ncmlkLWNvbHVtbih0d28tdGhpcmRzKTtcbiAgQGluY2x1ZGUgZ292dWstZ3JpZC1jb2x1bW4odGhyZWUtcXVhcnRlcnMpO1xuICBAaW5jbHVkZSBnb3Z1ay1ncmlkLWNvbHVtbihmdWxsKTtcbn1cbiIsIi8vIEV4YW1wbGUgdXNhZ2Ugd2l0aCBCcmVhZGNydW1icywgcGhhc2UgYmFubmVycywgYmFjayBsaW5rczpcbi8vIDxkaXYgY2xhc3M9XCJnb3Z1ay13aWR0aC1jb250YWluZXJcIj5cbi8vICAgPCEtLSBCcmVhZGNydW1icywgcGhhc2UgYmFubmVycywgYmFjayBsaW5rcyBhcmUgcGxhY2VkIGluIGhlcmUuIC0tPlxuLy8gICA8ZGl2IGNsYXNzPVwiZ292dWstbWFpbi13cmFwcGVyXCI+XG4vLyAgICAgICA8IS0tIFdyYXBwZXIgZm9yIHRoZSBtYWluIGNvbnRlbnQgb2YgeW91ciBwYWdlIHdoaWNoIGFwcGxpZXMgcGFkZGluZ1xuLy8gICAgICAgICAgICB0byB0aGUgdG9wIC8gYm90dG9tIC0tPlxuLy8gICA8L2Rpdj5cbi8vIDwvZGl2PlxuLy9cbi8vIEV4YW1wbGUgdXNhZ2Ugd2l0aG91dCBCcmVhZGNydW1icywgcGhhc2UgYmFubmVycywgYmFjayBsaW5rczpcbi8vIDxkaXYgY2xhc3M9XCJnb3Z1ay13aWR0aC1jb250YWluZXJcIj5cbi8vICAgPGRpdiBjbGFzcz1cImdvdnVrLW1haW4td3JhcHBlciBnb3Z1ay1tYWluLXdyYXBwZXItLWxcIj5cbi8vICAgICAgIDwhLS0gV3JhcHBlciBmb3IgdGhlIG1haW4gY29udGVudCBvZiB5b3VyIHBhZ2Ugd2hpY2ggYXBwbGllcyBwYWRkaW5nXG4vLyAgICAgICAgICAgIHRvIHRoZSB0b3AgLyBib3R0b20gLS0+XG4vLyAgIDwvZGl2PlxuLy8gPC9kaXY+XG5cblxuQG1peGluIGdvdnVrLW1haW4td3JhcHBlciB7XG4gIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtcGFkZGluZyg2LCBcInRvcFwiKTtcbiAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1wYWRkaW5nKDYsIFwiYm90dG9tXCIpO1xuICAvLyBJbiBJRTExIHRoZSBgbWFpbmAgZWxlbWVudCBjYW4gYmUgdXNlZCwgYnV0IGlzIG5vdCByZWNvZ25pemVkICDigJNcbiAgLy8gbWVhbmluZyBpdCdzIG5vdCBkZWZpbmVkIGluIElFJ3MgZGVmYXVsdCBzdHlsZSBzaGVldCxcbiAgLy8gc28gaXQgdXNlcyBDU1MgaW5pdGlhbCB2YWx1ZSwgd2hpY2ggaXMgaW5saW5lLlxuICBkaXNwbGF5OiBibG9jaztcbn1cblxuLy8gVXNlIGdvdnVrLW1haW4td3JhcHBlci0tbCB3aGVuIHlvdSBwYWdlIGRvZXMgbm90IGhhdmUgQnJlYWRjcnVtYnMsIHBoYXNlIGJhbm5lcnMgb3IgYmFjayBsaW5rc1xuQG1peGluIGdvdnVrLW1haW4td3JhcHBlci0tbCB7XG4gIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtcGFkZGluZyg4LCBcInRvcFwiKTtcbn1cblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL29iamVjdHMvbWFpbi13cmFwcGVyXCIpIHtcbiAgLmdvdnVrLW1haW4td3JhcHBlciB7XG4gICAgQGluY2x1ZGUgZ292dWstbWFpbi13cmFwcGVyO1xuICB9XG5cbiAgLmdvdnVrLW1haW4td3JhcHBlci0tbCB7XG4gICAgQGluY2x1ZGUgZ292dWstbWFpbi13cmFwcGVyLS1sO1xuICB9XG59XG4iLCJAbWl4aW4gZ292dWstd2lkdGgtY29udGFpbmVyIHtcbiAgLy8gTGltaXQgdGhlIHdpZHRoIG9mIHRoZSBjb250YWluZXIgdG8gdGhlIHBhZ2Ugd2lkdGhcbiAgbWF4LXdpZHRoOiAkZ292dWstcGFnZS13aWR0aDtcblxuICBAaW5jbHVkZSBnb3Z1ay1pZi1pZTgge1xuICAgIHdpZHRoOiAkZ292dWstcGFnZS13aWR0aDtcbiAgfVxuXG4gIC8vIE9uIG1vYmlsZSwgYWRkIGhhbGYgd2lkdGggZ3V0dGVyc1xuICBtYXJnaW46IDAgJGdvdnVrLWd1dHRlci1oYWxmO1xuXG4gIC8vIE9uIHRhYmxldCwgYWRkIGZ1bGwgd2lkdGggZ3V0dGVyc1xuICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogdGFibGV0KSB7XG4gICAgbWFyZ2luOiAwICRnb3Z1ay1ndXR0ZXI7XG4gIH1cblxuICAvLyBBcyBzb29uIGFzIHRoZSB2aWV3cG9ydCBpcyBncmVhdGVyIHRoYW4gdGhlIHdpZHRoIG9mIHRoZSBwYWdlIHBsdXMgdGhlXG4gIC8vIGd1dHRlcnMsIGp1c3QgY2VudHJlIHRoZSBjb250ZW50IGluc3RlYWQgb2YgYWRkaW5nIGd1dHRlcnMuXG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRhbmQ6IFwiKG1pbi13aWR0aDogI3soJGdvdnVrLXBhZ2Utd2lkdGggKyAkZ292dWstZ3V0dGVyICogMil9KVwiKSB7XG4gICAgbWFyZ2luOiAwIGF1dG87XG4gIH1cbn1cblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL29iamVjdHMvd2lkdGgtY29udGFpbmVyXCIpIHtcbiAgLmdvdnVrLXdpZHRoLWNvbnRhaW5lciB7XG4gICAgQGluY2x1ZGUgZ292dWstd2lkdGgtY29udGFpbmVyO1xuICB9XG59XG4iLCJAaW1wb3J0IFwiYmFjay1saW5rL2JhY2stbGlua1wiO1xuQGltcG9ydCBcImJyZWFkY3J1bWJzL2JyZWFkY3J1bWJzXCI7XG5AaW1wb3J0IFwiYnV0dG9uL2J1dHRvblwiO1xuQGltcG9ydCBcImNoZWNrYm94ZXMvY2hlY2tib3hlc1wiO1xuQGltcG9ydCBcImRhdGUtaW5wdXQvZGF0ZS1pbnB1dFwiO1xuQGltcG9ydCBcImRldGFpbHMvZGV0YWlsc1wiO1xuQGltcG9ydCBcImVycm9yLW1lc3NhZ2UvZXJyb3ItbWVzc2FnZVwiO1xuQGltcG9ydCBcImVycm9yLXN1bW1hcnkvZXJyb3Itc3VtbWFyeVwiO1xuQGltcG9ydCBcImZpZWxkc2V0L2ZpZWxkc2V0XCI7XG5AaW1wb3J0IFwiZmlsZS11cGxvYWQvZmlsZS11cGxvYWRcIjtcbkBpbXBvcnQgXCJmb290ZXIvZm9vdGVyXCI7XG5AaW1wb3J0IFwiaGludC9oaW50XCI7XG5AaW1wb3J0IFwiaGVhZGVyL2hlYWRlclwiO1xuQGltcG9ydCBcImlucHV0L2lucHV0XCI7XG5AaW1wb3J0IFwiaW5zZXQtdGV4dC9pbnNldC10ZXh0XCI7XG5AaW1wb3J0IFwibGFiZWwvbGFiZWxcIjtcbkBpbXBvcnQgXCJwYW5lbC9wYW5lbFwiO1xuQGltcG9ydCBcInBoYXNlLWJhbm5lci9waGFzZS1iYW5uZXJcIjtcbkBpbXBvcnQgXCJ0YWJzL3RhYnNcIjtcbkBpbXBvcnQgXCJ0YWcvdGFnXCI7XG5AaW1wb3J0IFwicmFkaW9zL3JhZGlvc1wiO1xuQGltcG9ydCBcInNlbGVjdC9zZWxlY3RcIjtcbkBpbXBvcnQgXCJza2lwLWxpbmsvc2tpcC1saW5rXCI7XG5AaW1wb3J0IFwidGFibGUvdGFibGVcIjtcbkBpbXBvcnQgXCJ0ZXh0YXJlYS90ZXh0YXJlYVwiO1xuQGltcG9ydCBcIndhcm5pbmctdGV4dC93YXJuaW5nLXRleHRcIjtcbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2JhY2stbGlua1wiKSB7XG5cbiAgLmdvdnVrLWJhY2stbGluayB7XG4gICAgQGluY2x1ZGUgZ292dWstdHlwb2dyYXBoeS1yZXNwb25zaXZlKCRzaXplOiAxNik7XG4gICAgQGluY2x1ZGUgZ292dWstbGluay1jb21tb247XG4gICAgQGluY2x1ZGUgZ292dWstbGluay1zdHlsZS10ZXh0O1xuXG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcblxuICAgIG1hcmdpbi10b3A6IGdvdnVrLXNwYWNpbmcoMyk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygzKTtcblxuICAgIC8vIEFsbG93IHNwYWNlIGZvciB0aGUgYXJyb3dcbiAgICBwYWRkaW5nLWxlZnQ6IDE0cHg7XG5cbiAgICAvLyBVc2UgYm9yZGVyLWJvdHRvbSByYXRoZXIgdGhhbiB0ZXh0LWRlY29yYXRpb24gc28gdGhhdCB0aGUgYXJyb3cgaXNcbiAgICAvLyB1bmRlcmxpbmVkIGFzIHdlbGwuXG4gICAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkIGdvdnVrLWNvbG91cihcImJsYWNrXCIpO1xuXG4gICAgLy8gVW5kZXJsaW5lIGlzIHByb3ZpZGVkIGJ5IGEgYm90dG9tIGJvcmRlclxuICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcblxuICAgIC8vIFByZXBlbmQgbGVmdCBwb2ludGluZyBhcnJvd1xuICAgICY6YmVmb3JlIHtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLXNoYXBlLWFycm93KCRkaXJlY3Rpb246IGxlZnQsICRiYXNlOiAxMHB4LCAkaGVpZ2h0OiA2cHgpO1xuXG4gICAgICBjb250ZW50OiBcIlwiO1xuXG4gICAgICAvLyBWZXJ0aWNhbGx5IGFsaWduIHdpdGggdGhlIHBhcmVudCBlbGVtZW50XG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG5cbiAgICAgIHRvcDogLTFweDtcbiAgICAgIGJvdHRvbTogMXB4O1xuICAgICAgbGVmdDogMDtcblxuICAgICAgbWFyZ2luOiBhdXRvO1xuICAgIH1cbiAgfVxuXG4gIC8vIEJlZ2luIGFkanVzdG1lbnRzIGZvciBmb250IGJhc2VsaW5lIG9mZnNldFxuICAvLyBUaGVzZSBzaG91bGQgYmUgcmVtb3ZlZCB3aGVuIHRoZSBmb250IGlzIHVwZGF0ZWQgd2l0aCB0aGUgY29ycmVjdCBiYXNlbGluZVxuXG4gIC5nb3Z1ay1iYWNrLWxpbms6YmVmb3JlIHtcbiAgICAkb2Zmc2V0OiAxcHg7XG5cbiAgICB0b3A6ICRvZmZzZXQgKiAtMTtcbiAgICBib3R0b206ICRvZmZzZXQ7XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2JyZWFkY3J1bWJzXCIpIHtcblxuICAvLyBTaXplIG9mIGNoZXZyb24gKGV4Y2x1ZGluZyBib3JkZXIpXG4gICRjaGV2cm9uLXNpemU6IDdweDtcblxuICAvLyBTaXplIG9mIGNoZXZyb24gYm9yZGVyXG4gICRjaGV2cm9uLWJvcmRlci13aWR0aDogMXB4O1xuXG4gIC8vIENvbG91ciBvZiBjaGV2cm9uXG4gICRjaGV2cm9uLWJvcmRlci1jb2xvdXI6ICRnb3Z1ay1zZWNvbmRhcnktdGV4dC1jb2xvdXI7XG5cbiAgLy8gQ2FsY3VsYXRlZCBhbHRpdHVkZSAo4paz4oaVKSBvZiB0aGUgcmlnaHQtYW5nbGVkIGlzb3NjZWxlcyBjaGV2cm9uIHdpdGggc2lkZXNcbiAgLy8gb2YgbGVuZ3RoIDggKDdweCArIDFweCBib3JkZXIpOlxuICAvL1xuICAvLyDiiJooOMKyICsgOMKyKSAqIDAuNSDiiYUgNS42NTVcbiAgJGNoZXZyb24tYWx0aXR1ZGUtY2FsY3VsYXRlZDogNS42NTVweDtcblxuICAuZ292dWstYnJlYWRjcnVtYnMge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE2KTtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcblxuICAgIG1hcmdpbi10b3A6IGdvdnVrLXNwYWNpbmcoMyk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygyKTtcbiAgfVxuXG4gIC5nb3Z1ay1icmVhZGNydW1ic19fbGlzdCB7XG4gICAgQGluY2x1ZGUgZ292dWstY2xlYXJmaXg7XG5cbiAgICBtYXJnaW46IDA7XG4gICAgcGFkZGluZzogMDtcbiAgICBsaXN0LXN0eWxlLXR5cGU6IG5vbmU7XG4gIH1cblxuICAuZ292dWstYnJlYWRjcnVtYnNfX2xpc3QtaXRlbSB7XG5cbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuXG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygxKTtcblxuICAgIC8vIEFkZCBib3RoIG1hcmdpbiBhbmQgcGFkZGluZyBzdWNoIHRoYXQgdGhlIGNoZXZyb24gYXBwZWFycyBjZW50cmFsbHlcbiAgICAvLyBiZXR3ZWVuIGVhY2ggYnJlYWRjcnVtYiBpdGVtXG4gICAgbWFyZ2luLWxlZnQ6IGdvdnVrLXNwYWNpbmcoMik7XG4gICAgcGFkZGluZy1sZWZ0OiBnb3Z1ay1zcGFjaW5nKDIpICsgJGNoZXZyb24tYWx0aXR1ZGUtY2FsY3VsYXRlZDtcblxuICAgIGZsb2F0OiBsZWZ0O1xuXG4gICAgLy8gQ3JlYXRlIGEgY2hldnJvbiB1c2luZyBhIGJveCB3aXRoIGJvcmRlcnMgb24gdHdvIHNpZGVzLCByb3RhdGVkIDQ1ZGVnLlxuICAgICY6YmVmb3JlIHtcbiAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICBkaXNwbGF5OiBibG9jaztcblxuICAgICAgcG9zaXRpb246IGFic29sdXRlO1xuXG4gICAgICAvLyBCZWdpbiBhZGp1c3RtZW50cyBmb3IgZm9udCBiYXNlbGluZSBvZmZzZXRcbiAgICAgIC8vIFRoZXNlIHNob3VsZCBiZSByZXZlcnRlZCB3aGVuIHRoZSBmb250IGlzIHVwZGF0ZWQgd2l0aCB0aGUgY29ycmVjdFxuICAgICAgLy8gYmFzZWxpbmVcblxuICAgICAgLy8gdG9wOiAwO1xuICAgICAgLy8gYm90dG9tOiAwO1xuXG4gICAgICB0b3A6IC0xcHg7XG4gICAgICBib3R0b206IDFweDtcblxuICAgICAgLy8gRW5kIGFkanVzdG1lbnRzIGZvciBmb250IGJhc2VsaW5lIG9mZnNldFxuXG4gICAgICAvLyBPZmZzZXQgYnkgdGhlIGRpZmZlcmVuY2UgYmV0d2VlbiB0aGUgd2lkdGggb2YgdGhlIG5vbi1yb3RhdGVkIHNxdWFyZVxuICAgICAgLy8gYW5kIGl0cyB3aWR0aCB3aGVuIHJvdGF0ZWRcbiAgICAgIGxlZnQ6ICgoJGNoZXZyb24tYWx0aXR1ZGUtY2FsY3VsYXRlZCAqIC0yKSArICRjaGV2cm9uLXNpemUgKyAkY2hldnJvbi1ib3JkZXItd2lkdGgpO1xuXG4gICAgICB3aWR0aDogJGNoZXZyb24tc2l6ZTtcbiAgICAgIGhlaWdodDogJGNoZXZyb24tc2l6ZTtcblxuICAgICAgbWFyZ2luOiBhdXRvIDA7XG5cbiAgICAgIC13ZWJraXQtdHJhbnNmb3JtOiByb3RhdGUoNDVkZWcpO1xuXG4gICAgICAgICAgLW1zLXRyYW5zZm9ybTogcm90YXRlKDQ1ZGVnKTtcblxuICAgICAgICAgICAgICB0cmFuc2Zvcm06IHJvdGF0ZSg0NWRlZyk7XG5cbiAgICAgIGJvcmRlcjogc29saWQ7XG4gICAgICBib3JkZXItd2lkdGg6ICRjaGV2cm9uLWJvcmRlci13aWR0aCAkY2hldnJvbi1ib3JkZXItd2lkdGggMCAwO1xuICAgICAgYm9yZGVyLWNvbG9yOiAkY2hldnJvbi1ib3JkZXItY29sb3VyO1xuXG4gICAgICAvLyBGYWxsIGJhY2sgdG8gYSBncmVhdGVyIHRoYW4gc2lnbiBmb3IgSUU4XG4gICAgICBAaW5jbHVkZSBnb3Z1ay1pZi1pZTgge1xuICAgICAgICBjb250ZW50OiBcIlxcMDAzZVwiOyAvLyBHcmVhdGVyIHRoYW4gc2lnbiAoPilcbiAgICAgICAgd2lkdGg6IGF1dG87XG4gICAgICAgIGhlaWdodDogYXV0bztcbiAgICAgICAgYm9yZGVyOiAwO1xuICAgICAgICBjb2xvcjogJGNoZXZyb24tYm9yZGVyLWNvbG91cjtcblxuICAgICAgICAvLyBJRTggZG9lc24ndCBzZWVtIHRvIGxpa2UgcmVuZGVyaW5nIHBzZXVkby1lbGVtZW50cyB1c2luZyBAZm9udC1mYWNlcyxcbiAgICAgICAgLy8gc28gZmFsbCBiYWNrIHRvIHVzaW5nIGFub3RoZXIgc2Fucy1zZXJpZiBmb250IHRvIHJlbmRlciB0aGUgY2hldnJvbi5cbiAgICAgICAgZm9udC1mYW1pbHk6IEFyaWFsLCBzYW5zLXNlcmlmO1xuICAgICAgfVxuICAgIH1cblxuICAgICY6Zmlyc3QtY2hpbGQge1xuICAgICAgbWFyZ2luLWxlZnQ6IDA7XG4gICAgICBwYWRkaW5nLWxlZnQ6IDA7XG5cbiAgICAgICY6YmVmb3JlIHtcbiAgICAgICAgY29udGVudDogbm9uZTtcbiAgICAgICAgZGlzcGxheTogbm9uZTtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAuZ292dWstYnJlYWRjcnVtYnNfX2xpbmsge1xuICAgIEBpbmNsdWRlIGdvdnVrLWxpbmstY29tbW9uO1xuICAgIEBpbmNsdWRlIGdvdnVrLWxpbmstc3R5bGUtdGV4dDtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvYnV0dG9uXCIpIHtcblxuICAkZ292dWstYnV0dG9uLWNvbG91cjogIzAwODIzYjtcbiAgJGdvdnVrLWJ1dHRvbi1ob3Zlci1jb2xvdXI6IGRhcmtlbigkZ292dWstYnV0dG9uLWNvbG91ciwgNSUpO1xuICAkZ292dWstYnV0dG9uLXNoYWRvdy1jb2xvdXI6IGRhcmtlbigkZ292dWstYnV0dG9uLWNvbG91ciwgMTUlKTtcbiAgJGdvdnVrLWJ1dHRvbi10ZXh0LWNvbG91cjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG5cbiAgLy8gQmVjYXVzZSB0aGUgc2hhZG93IChzMCkgaXMgdmlzdWFsbHkgJ3BhcnQgb2YnIHRoZSBidXR0b24sIHdlIG5lZWQgdG8gcmVkdWNlXG4gIC8vIHRoZSBoZWlnaHQgb2YgdGhlIGJ1dHRvbiB0byBjb21wZW5zYXRlIGJ5IGFkanVzdGluZyBpdHMgcGFkZGluZyAoczEpIGFuZFxuICAvLyBpbmNyZWFzZSB0aGUgYm90dG9tIG1hcmdpbiB0byBpbmNsdWRlIGl0IChzMikuXG4gICRidXR0b24tc2hhZG93LXNpemU6ICRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50O1xuXG4gIC5nb3Z1ay1idXR0b24ge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5LCAkbGluZS1oZWlnaHQ6IDE5cHgpO1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvY3VzYWJsZTtcblxuICAgIC13ZWJraXQtYm94LXNpemluZzogYm9yZGVyLWJveDtcblxuICAgICAgICAgICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIG1hcmdpbi10b3A6IDA7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNiwgXCJib3R0b21cIiwgJGFkanVzdG1lbnQ6ICRidXR0b24tc2hhZG93LXNpemUpOyAvLyBzMlxuICAgIHBhZGRpbmc6IChnb3Z1ay1zcGFjaW5nKDIpIC0gJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQgLSAoJGJ1dHRvbi1zaGFkb3ctc2l6ZSAvIDIpKSBnb3Z1ay1zcGFjaW5nKDIpOyAvLyBzMVxuICAgIGJvcmRlcjogJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQgc29saWQgdHJhbnNwYXJlbnQ7XG4gICAgYm9yZGVyLXJhZGl1czogMDtcbiAgICBjb2xvcjogJGdvdnVrLWJ1dHRvbi10ZXh0LWNvbG91cjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZ292dWstYnV0dG9uLWNvbG91cjtcbiAgICAtd2Via2l0LWJveC1zaGFkb3c6IDAgJGJ1dHRvbi1zaGFkb3ctc2l6ZSAwICRnb3Z1ay1idXR0b24tc2hhZG93LWNvbG91cjtcbiAgICAgICAgICAgIGJveC1zaGFkb3c6IDAgJGJ1dHRvbi1zaGFkb3ctc2l6ZSAwICRnb3Z1ay1idXR0b24tc2hhZG93LWNvbG91cjsgLy8gczBcbiAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gICAgdmVydGljYWwtYWxpZ246IHRvcDtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgLXdlYmtpdC1hcHBlYXJhbmNlOiBub25lO1xuXG4gICAgQGluY2x1ZGUgZ292dWstaWYtaWU4IHtcbiAgICAgIGJvcmRlci1ib3R0b206ICRidXR0b24tc2hhZG93LXNpemUgc29saWQgJGdvdnVrLWJ1dHRvbi1zaGFkb3ctY29sb3VyO1xuICAgIH1cblxuICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiB0YWJsZXQpIHtcbiAgICAgIHdpZHRoOiBhdXRvO1xuICAgIH1cblxuICAgIC8vIEVuc3VyZSB0aGF0IGFueSBnbG9iYWwgbGluayBzdHlsZXMgYXJlIG92ZXJyaWRkZW5cbiAgICAmOmxpbmssXG4gICAgJjp2aXNpdGVkLFxuICAgICY6YWN0aXZlLFxuICAgICY6aG92ZXIge1xuICAgICAgY29sb3I6ICRnb3Z1ay1idXR0b24tdGV4dC1jb2xvdXI7XG4gICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgfVxuXG4gICAgLy8gYWxwaGFnb3YvZ292dWtfdGVtcGxhdGUgaW5jbHVkZXMgYSBzcGVjaWZpYyBhOmxpbms6Zm9jdXMgc2VsZWN0b3JcbiAgICAvLyBkZXNpZ25lZCB0byBtYWtlIHVudmlzaXRlZCBsaW5rcyBhIHNsaWdodGx5IGRhcmtlciBibHVlIHdoZW4gZm9jdXNzZWQsIHNvXG4gICAgLy8gd2UgbmVlZCB0byBvdmVycmlkZSB0aGUgdGV4dCBjb2xvdXIgZm9yIHRoYXQgY29tYmluYXRpb24gb2Ygc2VsZWN0b3JzIHNvXG4gICAgLy8gc28gdGhhdCB1bnZpc2l0ZWQgbGlua3Mgc3R5bGVkIGFzIGJ1dHRvbnMgZG8gbm90IGVuZCB1cCB3aXRoIGRhcmsgYmx1ZVxuICAgIC8vIHRleHQgd2hlbiBmb2N1c3NlZC5cbiAgICBAaW5jbHVkZSBnb3Z1ay1jb21wYXRpYmlsaXR5KGdvdnVrX3RlbXBsYXRlKSB7XG4gICAgICAmOmxpbms6Zm9jdXMge1xuICAgICAgICBjb2xvcjogJGdvdnVrLWJ1dHRvbi10ZXh0LWNvbG91cjtcbiAgICAgIH1cbiAgICB9XG5cbiAgICAvLyBGaXggdW53YW50ZWQgYnV0dG9uIHBhZGRpbmcgaW4gRmlyZWZveFxuICAgICY6Oi1tb3otZm9jdXMtaW5uZXIge1xuICAgICAgcGFkZGluZzogMDtcbiAgICAgIGJvcmRlcjogMDtcbiAgICB9XG5cbiAgICAmOmhvdmVyLFxuICAgICY6Zm9jdXMge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGdvdnVrLWJ1dHRvbi1ob3Zlci1jb2xvdXI7XG4gICAgfVxuXG4gICAgJjphY3RpdmUge1xuICAgICAgdG9wOiAkYnV0dG9uLXNoYWRvdy1zaXplO1xuICAgICAgLXdlYmtpdC1ib3gtc2hhZG93OiBub25lO1xuICAgICAgICAgICAgICBib3gtc2hhZG93OiBub25lO1xuXG4gICAgICBAaW5jbHVkZSBnb3Z1ay1pZi1pZTgge1xuICAgICAgICBib3JkZXItYm90dG9tLXdpZHRoOiAwO1xuICAgICAgfVxuICAgIH1cblxuICAgIC8vIFRoZSBmb2xsb3dpbmcgYWRqdXN0bWVudHMgZG8gbm90IHdvcmsgZm9yIDxpbnB1dCB0eXBlPVwiYnV0dG9uXCI+IGFzXG4gICAgLy8gbm9uLWNvbnRhaW5lciBlbGVtZW50cyBjYW5ub3QgaW5jbHVkZSBwc2V1ZG8gZWxlbWVudHMgKGkuZS4gOjpiZWZvcmUpLlxuXG4gICAgLy8gVXNlIGEgcHNldWRvIGVsZW1lbnQgdG8gZXhwYW5kIHRoZSBjbGljayB0YXJnZXQgYXJlYSB0byBpbmNsdWRlIHRoZVxuICAgIC8vIGJ1dHRvbidzIHNoYWRvdyBhcyB3ZWxsLCBpbiBjYXNlIHVzZXJzIHRyeSB0byBjbGljayBpdC5cbiAgICAmOjpiZWZvcmUge1xuICAgICAgY29udGVudDogXCJcIjtcbiAgICAgIGRpc3BsYXk6IGJsb2NrO1xuXG4gICAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG5cbiAgICAgIHRvcDogLSRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50O1xuICAgICAgcmlnaHQ6IC0kZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudDtcbiAgICAgIGJvdHRvbTogLSgkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudCArICRidXR0b24tc2hhZG93LXNpemUpO1xuICAgICAgbGVmdDogLSRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50O1xuXG4gICAgICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgICB9XG5cbiAgICAvLyBXaGVuIHRoZSBidXR0b24gaXMgYWN0aXZlIGl0IGlzIHNoaWZ0ZWQgZG93biBieSAkYnV0dG9uLXNoYWRvdy1zaXplIHRvXG4gICAgLy8gZGVub3RlIGEgJ3ByZXNzZWQnIHN0YXRlLiBJZiB0aGUgdXNlciBoYXBwZW5lZCB0byBjbGljayBhdCB0aGUgdmVyeSB0b3BcbiAgICAvLyBvZiB0aGUgYnV0dG9uLCB0aGVpciBtb3VzZSBpcyBubyBsb25nZXIgb3ZlciB0aGUgYnV0dG9uIChiZWNhdXNlIGl0IGhhc1xuICAgIC8vICdtb3ZlZCBiZW5lYXRoIHRoZW0nKSBhbmQgc28gdGhlIGNsaWNrIGV2ZW50IGlzIG5vdCBmaXJlZC5cbiAgICAvL1xuICAgIC8vIFRoaXMgY29ycmVjdHMgdGhhdCBieSBzaGlmdGluZyB0aGUgdG9wIG9mIHRoZSBwc2V1ZG8gZWxlbWVudCBzbyB0aGF0IGl0XG4gICAgLy8gY29udGludWVzIHRvIGNvdmVyIHRoZSBhcmVhIHRoYXQgdGhlIHVzZXIgb3JpZ2luYWxseSBjbGlja2VkLCB3aGljaCBtZWFuc1xuICAgIC8vIHRoZSBjbGljayBldmVudCBpcyBzdGlsbCBmaXJlZC5cbiAgICAvL1xuICAgIC8vIPCfjolcbiAgICAmOmFjdGl2ZTo6YmVmb3JlIHtcbiAgICAgIHRvcDogLSgkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudCArICRidXR0b24tc2hhZG93LXNpemUpO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1idXR0b24tLWRpc2FibGVkLFxuICAuZ292dWstYnV0dG9uW2Rpc2FibGVkPVwiZGlzYWJsZWRcIl0sXG4gIC5nb3Z1ay1idXR0b25bZGlzYWJsZWRdIHtcbiAgICBvcGFjaXR5OiAoLjUpO1xuICAgIGJhY2tncm91bmQ6ICRnb3Z1ay1idXR0b24tY29sb3VyO1xuXG4gICAgJjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAkZ292dWstYnV0dG9uLWNvbG91cjtcbiAgICAgIGN1cnNvcjogZGVmYXVsdDtcbiAgICB9XG5cbiAgICAmOmZvY3VzIHtcbiAgICAgIG91dGxpbmU6IG5vbmU7XG4gICAgfVxuXG4gICAgJjphY3RpdmUge1xuICAgICAgdG9wOiAwO1xuICAgICAgLXdlYmtpdC1ib3gtc2hhZG93OiAwICRidXR0b24tc2hhZG93LXNpemUgMCAkZ292dWstYnV0dG9uLXNoYWRvdy1jb2xvdXI7XG4gICAgICAgICAgICAgIGJveC1zaGFkb3c6IDAgJGJ1dHRvbi1zaGFkb3ctc2l6ZSAwICRnb3Z1ay1idXR0b24tc2hhZG93LWNvbG91cjsgLy8gczBcbiAgICAgIEBpbmNsdWRlIGdvdnVrLWlmLWllOCB7XG4gICAgICAgIGJvcmRlci1ib3R0b206ICRidXR0b24tc2hhZG93LXNpemUgc29saWQgJGdvdnVrLWJ1dHRvbi1zaGFkb3ctY29sb3VyOyAvLyBzMFxuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1idXR0b24tLXN0YXJ0IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay10eXBvZ3JhcGh5LXdlaWdodC1ib2xkO1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktcmVzcG9uc2l2ZSgkc2l6ZTogMjQsICRvdmVycmlkZS1saW5lLWhlaWdodDogMSk7XG5cbiAgICBtaW4taGVpZ2h0OiBhdXRvO1xuICAgIHBhZGRpbmctdG9wOiBnb3Z1ay1zcGFjaW5nKDIpIC0gJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQ7XG4gICAgcGFkZGluZy1yaWdodDogZ292dWstc3BhY2luZyg3KTtcbiAgICBwYWRkaW5nLWJvdHRvbTogZ292dWstc3BhY2luZygyKSAtICRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50O1xuICAgIHBhZGRpbmctbGVmdDogZ292dWstc3BhY2luZygzKTtcblxuICAgIGJhY2tncm91bmQtaW1hZ2U6IGdvdnVrLWltYWdlLXVybChcImljb24tcG9pbnRlci5wbmdcIik7XG4gICAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiAxMDAlIDUwJTtcblxuICAgIEBpbmNsdWRlIGdvdnVrLWRldmljZS1waXhlbC1yYXRpbyB7XG4gICAgICBiYWNrZ3JvdW5kLWltYWdlOiBnb3Z1ay1pbWFnZS11cmwoXCJpY29uLXBvaW50ZXItMngucG5nXCIpO1xuICAgICAgYmFja2dyb3VuZC1zaXplOiAzMHB4IDE5cHg7XG4gICAgfVxuICB9XG5cbiAgLy8gQmVnaW4gYWRqdXN0bWVudHMgZm9yIGZvbnQgYmFzZWxpbmUgb2Zmc2V0XG4gIC8vIFRoZXNlIHNob3VsZCBiZSByZW1vdmVkIHdoZW4gdGhlIGZvbnQgaXMgdXBkYXRlZCB3aXRoIHRoZSBjb3JyZWN0IGJhc2VsaW5lXG4gIC8vIEZvciB0aGUgMXB4IGFkZGl0aW9uIHBsZWFzZSBzZWUgaHR0cHM6Ly9naXRodWIuY29tL2FscGhhZ292L2dvdnVrLWZyb250ZW5kL3B1bGwvMzY1I2Rpc2N1c3Npb25fcjE1NDM0OTQyOFxuXG4gICRvZmZzZXQ6IDI7XG5cbiAgLmdvdnVrLWJ1dHRvbiB7XG4gICAgcGFkZGluZy10b3A6IChnb3Z1ay1zcGFjaW5nKDIpIC0gJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQgLSAoJGJ1dHRvbi1zaGFkb3ctc2l6ZSAvIDIpICsgJG9mZnNldCk7IC8vIHMxXG4gICAgcGFkZGluZy1ib3R0b206IChnb3Z1ay1zcGFjaW5nKDIpIC0gJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQgLSAoJGJ1dHRvbi1zaGFkb3ctc2l6ZSAvIDIpIC0gJG9mZnNldCArIDEpOyAvLyBzMVxuICB9XG5cbiAgLmdvdnVrLWJ1dHRvbi0tc3RhcnQge1xuICAgIHBhZGRpbmctdG9wOiAoZ292dWstc3BhY2luZygyKSAtICRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50IC0gKCRidXR0b24tc2hhZG93LXNpemUgLyAyKSArICRvZmZzZXQpOyAvLyBzMVxuICAgIHBhZGRpbmctYm90dG9tOiAoZ292dWstc3BhY2luZygyKSAtICRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50IC0gKCRidXR0b24tc2hhZG93LXNpemUgLyAyKSAtICRvZmZzZXQgKyAxKTsgLy8gczFcbiAgfVxuXG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGltcG9ydCBcIi4uL2Vycm9yLW1lc3NhZ2UvZXJyb3ItbWVzc2FnZVwiO1xuQGltcG9ydCBcIi4uL2ZpZWxkc2V0L2ZpZWxkc2V0XCI7XG5AaW1wb3J0IFwiLi4vaGludC9oaW50XCI7XG5AaW1wb3J0IFwiLi4vbGFiZWwvbGFiZWxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC9jaGVja2JveGVzXCIpIHtcbiAgJGdvdnVrLWNoZWNrYm94ZXMtc2l6ZTogZ292dWstc3BhY2luZyg3KTtcbiAgJGdvdnVrLWNoZWNrYm94ZXMtbGFiZWwtcGFkZGluZy1sZWZ0LXJpZ2h0OiBnb3Z1ay1zcGFjaW5nKDMpO1xuXG4gIC5nb3Z1ay1jaGVja2JveGVzX19pdGVtIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG5cbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG5cbiAgICBtaW4taGVpZ2h0OiAkZ292dWstY2hlY2tib3hlcy1zaXplO1xuXG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygyKTtcbiAgICBwYWRkaW5nOiAwIDAgMCAkZ292dWstY2hlY2tib3hlcy1zaXplO1xuXG4gICAgY2xlYXI6IGxlZnQ7XG4gIH1cblxuICAuZ292dWstY2hlY2tib3hlc19faXRlbTpsYXN0LWNoaWxkLFxuICAuZ292dWstY2hlY2tib3hlc19faXRlbTpsYXN0LW9mLXR5cGUge1xuICAgIG1hcmdpbi1ib3R0b206IDA7XG4gIH1cblxuICAuZ292dWstY2hlY2tib3hlc19faW5wdXQge1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcblxuICAgIHotaW5kZXg6IDE7XG4gICAgdG9wOiAwO1xuICAgIGxlZnQ6IDA7XG5cbiAgICB3aWR0aDogJGdvdnVrLWNoZWNrYm94ZXMtc2l6ZTtcbiAgICBoZWlnaHQ6ICRnb3Z1ay1jaGVja2JveGVzLXNpemU7XG5cbiAgICBjdXJzb3I6IHBvaW50ZXI7XG5cbiAgICAvLyBJRTggZG9lc27igJl0IHN1cHBvcnQgcHNldWRvZWxlbWVudHMsIHNvIHdlIGRvbuKAmXQgd2FudCB0byBoaWRlIG5hdGl2ZSBlbGVtZW50cyB0aGVyZS5cbiAgICBAaW5jbHVkZSBnb3Z1ay1ub3QtaWU4IHtcbiAgICAgIG1hcmdpbjogMDtcbiAgICAgIG9wYWNpdHk6IDA7XG4gICAgfVxuXG4gICAgLy8gYWRkIGZvY3VzIG91dGxpbmUgdG8gaW5wdXQgZWxlbWVudCBmb3IgSUU4XG4gICAgQGluY2x1ZGUgZ292dWstaWYtaWU4IHtcbiAgICAgICY6Zm9jdXMge1xuICAgICAgICBvdXRsaW5lOiAkZ292dWstZm9jdXMtd2lkdGggc29saWQgJGdvdnVrLWZvY3VzLWNvbG91cjtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAuZ292dWstY2hlY2tib3hlc19fbGFiZWwge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgIHBhZGRpbmc6IDhweCAkZ292dWstY2hlY2tib3hlcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQgZ292dWstc3BhY2luZygxKTtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgLy8gcmVtb3ZlIDMwMG1zIHBhdXNlIG9uIG1vYmlsZVxuICAgIC1tcy10b3VjaC1hY3Rpb246IG1hbmlwdWxhdGlvbjtcbiAgICB0b3VjaC1hY3Rpb246IG1hbmlwdWxhdGlvbjtcbiAgfVxuXG4gIC5nb3Z1ay1jaGVja2JveGVzX19oaW50IHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBwYWRkaW5nLXJpZ2h0OiAkZ292dWstY2hlY2tib3hlcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQ7XG4gICAgcGFkZGluZy1sZWZ0OiAkZ292dWstY2hlY2tib3hlcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQ7XG4gIH1cblxuICAuZ292dWstY2hlY2tib3hlc19faW5wdXQgKyAuZ292dWstY2hlY2tib3hlc19fbGFiZWw6OmJlZm9yZSB7XG4gICAgY29udGVudDogXCJcIjtcbiAgICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IDA7XG4gICAgbGVmdDogMDtcbiAgICB3aWR0aDogJGdvdnVrLWNoZWNrYm94ZXMtc2l6ZTtcbiAgICBoZWlnaHQ6ICRnb3Z1ay1jaGVja2JveGVzLXNpemU7XG4gICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudCBzb2xpZCBjdXJyZW50Q29sb3I7XG4gICAgYmFja2dyb3VuZDogdHJhbnNwYXJlbnQ7XG5cbiAgICAvLyBwYWRkaW5nLWJvdHRvbTogMXB4O1xuICB9XG5cbiAgLmdvdnVrLWNoZWNrYm94ZXNfX2lucHV0ICsgLmdvdnVrLWNoZWNrYm94ZXNfX2xhYmVsOjphZnRlciB7XG4gICAgY29udGVudDogXCJcIjtcblxuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICB0b3A6IDExcHg7XG4gICAgbGVmdDogOXB4O1xuICAgIHdpZHRoOiAxOHB4O1xuICAgIGhlaWdodDogN3B4O1xuXG4gICAgLXdlYmtpdC10cmFuc2Zvcm06IHJvdGF0ZSgtNDVkZWcpO1xuXG4gICAgICAgIC1tcy10cmFuc2Zvcm06IHJvdGF0ZSgtNDVkZWcpO1xuXG4gICAgICAgICAgICB0cmFuc2Zvcm06IHJvdGF0ZSgtNDVkZWcpO1xuICAgIGJvcmRlcjogc29saWQ7XG4gICAgYm9yZGVyLXdpZHRoOiAwIDAgJGdvdnVrLWJvcmRlci13aWR0aCAkZ292dWstYm9yZGVyLXdpZHRoO1xuICAgIC8vIEZpeCBidWcgaW4gSUUxMSBjYXVzZWQgYnkgdHJhbnNmb3JtIHJvdGF0ZSAoLTQ1ZGVnKS5cbiAgICAvLyBTZWU6IGFscGhhZ292L2dvdnVrX2VsZW1lbnRzL2lzc3Vlcy81MThcbiAgICBib3JkZXItdG9wLWNvbG9yOiB0cmFuc3BhcmVudDtcblxuICAgIG9wYWNpdHk6IDA7XG5cbiAgICBiYWNrZ3JvdW5kOiB0cmFuc3BhcmVudDtcbiAgfVxuXG4gIC8vIEZvY3VzZWQgc3RhdGVcbiAgLmdvdnVrLWNoZWNrYm94ZXNfX2lucHV0OmZvY3VzICsgLmdvdnVrLWNoZWNrYm94ZXNfX2xhYmVsOjpiZWZvcmUge1xuICAgIC8vIFNpbmNlIGJveC1zaGFkb3dzIGFyZSByZW1vdmVkIHdoZW4gdXNlcnMgY3VzdG9taXNlIHRoZWlyIGNvbG91cnNcbiAgICAvLyBXZSBzZXQgYSB0cmFuc3BhcmVudCBvdXRsaW5lIHRoYXQgaXMgc2hvd24gaW5zdGVhZC5cbiAgICAvLyBodHRwczovL2FjY2Vzc2liaWxpdHkuYmxvZy5nb3YudWsvMjAxNy8wMy8yNy9ob3ctdXNlcnMtY2hhbmdlLWNvbG91cnMtb24td2Vic2l0ZXMvXG4gICAgb3V0bGluZTogJGdvdnVrLWZvY3VzLXdpZHRoIHNvbGlkIHRyYW5zcGFyZW50O1xuICAgIG91dGxpbmUtb2Zmc2V0OiAkZ292dWstZm9jdXMtd2lkdGg7XG4gICAgLXdlYmtpdC1ib3gtc2hhZG93OiAwIDAgMCAkZ292dWstZm9jdXMtd2lkdGggJGdvdnVrLWZvY3VzLWNvbG91cjtcbiAgICAgICAgICAgIGJveC1zaGFkb3c6IDAgMCAwICRnb3Z1ay1mb2N1cy13aWR0aCAkZ292dWstZm9jdXMtY29sb3VyO1xuICB9XG5cbiAgLy8gU2VsZWN0ZWQgc3RhdGVcbiAgLmdvdnVrLWNoZWNrYm94ZXNfX2lucHV0OmNoZWNrZWQgKyAuZ292dWstY2hlY2tib3hlc19fbGFiZWw6OmFmdGVyIHtcbiAgICBvcGFjaXR5OiAxO1xuICB9XG5cbiAgLy8gRGlzYWJsZWQgc3RhdGVcbiAgLmdvdnVrLWNoZWNrYm94ZXNfX2lucHV0OmRpc2FibGVkLFxuICAuZ292dWstY2hlY2tib3hlc19faW5wdXQ6ZGlzYWJsZWQgKyAuZ292dWstY2hlY2tib3hlc19fbGFiZWwge1xuICAgIGN1cnNvcjogZGVmYXVsdDtcbiAgfVxuXG4gIC5nb3Z1ay1jaGVja2JveGVzX19pbnB1dDpkaXNhYmxlZCArIC5nb3Z1ay1jaGVja2JveGVzX19sYWJlbCB7XG4gICAgb3BhY2l0eTogLjU7XG4gIH1cblxuICAkY29uZGl0aW9uYWwtYm9yZGVyLXdpZHRoOiAkZ292dWstYm9yZGVyLXdpZHRoLW1vYmlsZTtcbiAgLy8gQ2FsY3VsYXRlIHRoZSBhbW91bnQgb2YgcGFkZGluZyBuZWVkZWQgdG8ga2VlcCB0aGUgYm9yZGVyIGNlbnRlcmVkIGFnYWluc3QgdGhlIGNoZWNrYm94LlxuICAkY29uZGl0aW9uYWwtYm9yZGVyLXBhZGRpbmc6ICgkZ292dWstY2hlY2tib3hlcy1zaXplIC8gMikgLSAoJGNvbmRpdGlvbmFsLWJvcmRlci13aWR0aCAvIDIpO1xuICAvLyBNb3ZlIHRoZSBib3JkZXIgY2VudGVyZWQgd2l0aCB0aGUgY2hlY2tib3hcbiAgJGNvbmRpdGlvbmFsLW1hcmdpbi1sZWZ0OiAkY29uZGl0aW9uYWwtYm9yZGVyLXBhZGRpbmc7XG4gIC8vIE1vdmUgdGhlIGNvbnRlbnRzIG9mIHRoZSBjb25kaXRpb25hbCBpbmxpbmUgd2l0aCB0aGUgbGFiZWxcbiAgJGNvbmRpdGlvbmFsLXBhZGRpbmctbGVmdDogJGNvbmRpdGlvbmFsLWJvcmRlci1wYWRkaW5nICsgJGdvdnVrLWNoZWNrYm94ZXMtbGFiZWwtcGFkZGluZy1sZWZ0LXJpZ2h0O1xuXG4gIC5nb3Z1ay1jaGVja2JveGVzX19jb25kaXRpb25hbCB7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNCwgXCJib3R0b21cIik7XG4gICAgbWFyZ2luLWxlZnQ6ICRjb25kaXRpb25hbC1tYXJnaW4tbGVmdDtcbiAgICBwYWRkaW5nLWxlZnQ6ICRjb25kaXRpb25hbC1wYWRkaW5nLWxlZnQ7XG4gICAgYm9yZGVyLWxlZnQ6ICRjb25kaXRpb25hbC1ib3JkZXItd2lkdGggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG5cbiAgICAuanMtZW5hYmxlZCAmLS1oaWRkZW4ge1xuICAgICAgZGlzcGxheTogbm9uZTtcbiAgICB9XG5cbiAgICAmID4gOmxhc3QtY2hpbGQge1xuICAgICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICB9XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2Vycm9yLW1lc3NhZ2VcIikge1xuICAuZ292dWstZXJyb3ItbWVzc2FnZSB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTksICR3ZWlnaHQ6IGJvbGQpO1xuXG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygzKTtcbiAgICBjbGVhcjogYm90aDtcblxuICAgIGNvbG9yOiAkZ292dWstZXJyb3ItY29sb3VyO1xuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC9maWVsZHNldFwiKSB7XG4gIC5nb3Z1ay1maWVsZHNldCB7XG4gICAgbWFyZ2luOiAwO1xuICAgIHBhZGRpbmc6IDA7XG4gICAgYm9yZGVyOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLWNsZWFyZml4O1xuICB9XG5cbiAgLmdvdnVrLWZpZWxkc2V0X19sZWdlbmQge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcblxuICAgIC8vIEZpeCBsZWdlbmQgdGV4dCB3cmFwcGluZyBpbiBFZGdlIGFuZCBJRVxuICAgIC8vIDEuIElFOS0xMSAmIEVkZ2UgMTItMTNcbiAgICAvLyAyLiBJRTgtMTFcbiAgICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94OyAvLyAxXG4gICAgZGlzcGxheTogdGFibGU7ICAgICAgICAgLy8gMlxuICAgIG1heC13aWR0aDogMTAwJTsgICAgICAgIC8vIDFcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAgIHBhZGRpbmc6IDA7XG4gICAgLy8gSGFjayB0byBsZXQgbGVnZW5kcyBvciBlbGVtZW50cyB3aXRoaW4gbGVnZW5kcyBoYXZlIG1hcmdpbnMgaW4gd2Via2l0IGJyb3dzZXJzXG4gICAgb3ZlcmZsb3c6IGhpZGRlbjtcblxuICAgIHdoaXRlLXNwYWNlOiBub3JtYWw7ICAgIC8vIDFcbiAgfVxuXG4gIC8vIE1vZGlmaWVycyB0aGF0IG1ha2UgbGVnZW5kcyBsb29rIG1vcmUgbGlrZSB0aGVpciBlcXVpdmFsZW50IGhlYWRpbmdzXG5cbiAgLmdvdnVrLWZpZWxkc2V0X19sZWdlbmQtLXhsIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiA0OCwgJHdlaWdodDogYm9sZCk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygzKTtcbiAgfVxuXG4gIC5nb3Z1ay1maWVsZHNldF9fbGVnZW5kLS1sIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAzNiwgJHdlaWdodDogYm9sZCk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygzKTtcbiAgfVxuXG4gIC5nb3Z1ay1maWVsZHNldF9fbGVnZW5kLS1tIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAyNCwgJHdlaWdodDogYm9sZCk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygzKTtcbiAgfVxuXG4gIC5nb3Z1ay1maWVsZHNldF9fbGVnZW5kLS1zIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSwgJHdlaWdodDogYm9sZCk7XG4gIH1cblxuICAvLyBXaGVuIHRoZSBsZWdlbmQgY29udGFpbnMgYW4gSDEsIHdlIHdhbnQgdGhlIEgxIHRvIGluaGVyaXQgYWxsIHN0eWxlcyBmcm9tXG4gIC8vIHRoZSBsZWdlbmQuIEVmZmVjdGl2ZWx5IHdlIHdhbnQgdG8gYmUgYWJsZSB0byB0cmVhdCB0aGUgaGVhZGluZyBhcyBpZiBpdCBpc1xuICAvLyBub3QgdGhlcmUuXG4gIC5nb3Z1ay1maWVsZHNldF9faGVhZGluZyB7XG4gICAgbWFyZ2luOiAwO1xuICAgIGZvbnQtc2l6ZTogaW5oZXJpdDtcbiAgICBmb250LXdlaWdodDogaW5oZXJpdDtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvaGludFwiKSB7XG4gIC5nb3Z1ay1oaW50IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG5cbiAgICBkaXNwbGF5OiBibG9jaztcblxuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMyk7XG5cbiAgICBjb2xvcjogJGdvdnVrLXNlY29uZGFyeS10ZXh0LWNvbG91cjtcbiAgfVxuXG4gIC8vIFJlZHVjZXMgbWFyZ2luLWJvdHRvbSBvZiBoaW50IHdoZW4gdXNlZCBhZnRlciB0aGUgZGVmYXVsdCBsYWJlbCAobm8gY2xhc3MpXG4gIC8vIG9yIGdvdnVrLWxhYmVsLS1zIGZvciBiZXR0ZXIgdmVydGljYWwgYWxpZ25tZW50LlxuXG4gIC8vIFRoaXMgYWRqdXN0bWVudCB3aWxsIG5vdCB3b3JrIHdoZW4gdGhlIGxhYmVsIGlzIGluc2lkZSB0aGUgPGgxPiwgaG93ZXZlciBpdFxuICAvLyBpcyB1bmxpa2VseSB0aGF0IHRoZSBkZWZhdWx0IG9yIGdvdnVrLWxhYmVsLS1zIGNsYXNzIHdvdWxkIGJlIHVzZWQgaW4gdGhpc1xuICAvLyBjYXNlLlxuXG4gIC8vIFRoaXMgYWRqdXN0bWVudCB3aWxsIG5vdCB3b3JrIGluIGJyb3dzZXJzIHRoYXQgZG8gbm90IHN1cHBvcnQgOm5vdCgpLiBcbiAgLy8gVXNlcnMgd2l0aCB0aGVzZSBicm93c2VycyB3aWxsIHNlZSB0aGUgZGVmYXVsdCBzaXplIG1hcmdpbiAoNXB4IGxhcmdlcikuXG5cbiAgLmdvdnVrLWxhYmVsOm5vdCguZ292dWstbGFiZWwtLW0pOm5vdCguZ292dWstbGFiZWwtLWwpOm5vdCguZ292dWstbGFiZWwtLXhsKSArIC5nb3Z1ay1oaW50IHtcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICB9XG5cbiAgLy8gUmVkdWNlcyBtYXJnaW4tYm90dG9tIG9mIGhpbnQgd2hlbiB1c2VkIGFmdGVyIHRoZSBkZWZhdWx0IGxlZ2VuZCAobm8gY2xhc3MpXG4gIC8vIG9yIGdvdnVrLWZpZWxkc2V0X19sZWdlbmQtLXMgZm9yIGJldHRlciB2ZXJ0aWNhbCBhbGlnbm1lbnQuXG5cbiAgLy8gVGhpcyBhZGp1c3RtZW50IHdpbGwgbm90IHdvcmsgd2hlbiB0aGUgbGVnZW5kIGlzIG91dHNpZGUgdGhlIDxoMT4sIGhvd2V2ZXJcbiAgLy8gaXQgaXMgdW5saWtlbHkgdGhhdCB0aGUgZGVmYXVsdCBvciBnb3Z1ay1maWVsZHNldF9fbGVnZW5kLS1zIGNsYXNzIHdvdWxkIGJlXG4gIC8vIHVzZWQgaW4gdGhpcyBjYXNlLlxuXG4gIC8vIFRoaXMgYWRqdXN0bWVudCB3aWxsIG5vdCB3b3JrIGluIGJyb3dzZXJzIHRoYXQgZG8gbm90IHN1cHBvcnQgOm5vdCgpLiBcbiAgLy8gVXNlcnMgd2l0aCB0aGVzZSBicm93c2VycyB3aWxsIHNlZSB0aGUgZGVmYXVsdCBzaXplIG1hcmdpbiAoNXB4IGxhcmdlcikuXG5cbiAgLmdvdnVrLWZpZWxkc2V0X19sZWdlbmQ6bm90KC5nb3Z1ay1maWVsZHNldF9fbGVnZW5kLS1tKTpub3QoLmdvdnVrLWZpZWxkc2V0X19sZWdlbmQtLWwpOm5vdCguZ292dWstZmllbGRzZXRfX2xlZ2VuZC0teGwpICsgLmdvdnVrLWhpbnQge1xuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMik7XG4gIH1cblxuICAvLyBSZWR1Y2VzIHZpc3VhbCBzcGFjaW5nIG9mIGxlZ2VuZCB3aGVuIHRoZXJlIGlzIGEgaGludFxuXG4gIC5nb3Z1ay1maWVsZHNldF9fbGVnZW5kICsgLmdvdnVrLWhpbnQsXG4gIC5nb3Z1ay1maWVsZHNldF9fbGVnZW5kICsgLmdvdnVrLWhpbnQge1xuICAgIG1hcmdpbi10b3A6IC0oZ292dWstc3BhY2luZygxKSk7XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2xhYmVsXCIpIHtcbiAgLmdvdnVrLWxhYmVsIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG5cbiAgICBkaXNwbGF5OiBibG9jaztcblxuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMSk7XG4gIH1cblxuICAvLyBNb2RpZmllcnMgdGhhdCBtYWtlIGxhYmVscyBsb29rIG1vcmUgbGlrZSB0aGVpciBlcXVpdmFsZW50IGhlYWRpbmdzXG5cbiAgLmdvdnVrLWxhYmVsLS14bCB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogNDgsICR3ZWlnaHQ6IGJvbGQpO1xuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMyk7XG4gIH1cblxuICAuZ292dWstbGFiZWwtLWwge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDM2LCAkd2VpZ2h0OiBib2xkKTtcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDMpO1xuICB9XG5cbiAgLmdvdnVrLWxhYmVsLS1tIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAyNCwgJHdlaWdodDogYm9sZCk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygyKTtcbiAgfVxuXG4gIC5nb3Z1ay1sYWJlbC0tcyB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTksICR3ZWlnaHQ6IGJvbGQpO1xuICB9XG5cbiAgLy8gV2hlbiB0aGUgbGFiZWwgaXMgbmVzdGVkIGluc2lkZSBhIGhlYWRpbmcsIG92ZXJyaWRlIHRoZSBoZWFkaW5nIHNvIHRoYXQgaXRcbiAgLy8gZG9lcyBub3QgaGF2ZSBhIG1hcmdpbi4gRWZmZWN0aXZlbHkgd2Ugd2FudCB0byBiZSBhYmxlIHRvIHRyZWF0IHRoZSBoZWFkaW5nXG4gIC8vIGFzIGlmIGl0IGlzIG5vdCB0aGVyZS5cbiAgLy9cbiAgLy8gVGhpcyBicmVha3MgQkVNIGNvbnZlbnRpb25zIGJlY2F1c2UgaXQgZXhpc3RzIGFzIGEgcGFyZW50IG9mIHRoZSAnYmxvY2snLFxuICAvLyBzbyB3ZSBjYW4ndCByZWFsbHkgY29uc2lkZXIgYW4gZWxlbWVudC5cbiAgLmdvdnVrLWxhYmVsLXdyYXBwZXIge1xuICAgIG1hcmdpbjogMDtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbXBvcnQgXCIuLi9lcnJvci1tZXNzYWdlL2Vycm9yLW1lc3NhZ2VcIjtcbkBpbXBvcnQgXCIuLi9pbnB1dC9pbnB1dFwiO1xuQGltcG9ydCBcIi4uL2hpbnQvaGludFwiO1xuQGltcG9ydCBcIi4uL2xhYmVsL2xhYmVsXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvZGF0ZS1pbnB1dFwiKSB7XG4gIC5nb3Z1ay1kYXRlLWlucHV0IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1jbGVhcmZpeDtcbiAgICAvLyBmb250LXNpemU6IDAgcmVtb3ZlcyB3aGl0ZXNwYWNlIGNhdXNlZCBieSBpbmxpbmUtYmxvY2tcbiAgICBmb250LXNpemU6IDA7XG4gIH1cblxuICAuZ292dWstZGF0ZS1pbnB1dF9faXRlbSB7XG4gICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgIG1hcmdpbi1yaWdodDogZ292dWstc3BhY2luZyg0KTtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICB9XG5cbiAgLmdvdnVrLWRhdGUtaW5wdXRfX2xhYmVsIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgfVxuXG4gIC5nb3Z1ay1kYXRlLWlucHV0X19pbnB1dCB7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbXBvcnQgXCIuLi9lcnJvci1tZXNzYWdlL2Vycm9yLW1lc3NhZ2VcIjtcbkBpbXBvcnQgXCIuLi9oaW50L2hpbnRcIjtcbkBpbXBvcnQgXCIuLi9sYWJlbC9sYWJlbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2lucHV0XCIpIHtcbiAgLmdvdnVrLWlucHV0IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlO1xuXG4gICAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuXG4gICAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIGhlaWdodDogNDBweDtcbiAgICBtYXJnaW4tdG9wOiAwO1xuXG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygxKTtcbiAgICAvLyBzZXR0aW5nIGFueSBiYWNrZ3JvdW5kLWNvbG9yIG1ha2VzIHRleHQgaW52aXNpYmxlIHdoZW4gY2hhbmdpbmcgY29sb3VycyB0byBkYXJrIGJhY2tncm91bmRzIGluIEZpcmVmb3ggKGh0dHBzOi8vYnVnemlsbGEubW96aWxsYS5vcmcvc2hvd19idWcuY2dpP2lkPTEzMzU0NzYpXG4gICAgLy8gYXMgYmFja2dyb3VuZC1jb2xvciBhbmQgY29sb3IgbmVlZCB0byBhbHdheXMgYmUgc2V0IHRvZ2V0aGVyLCBjb2xvciBzaG91bGQgbm90IGJlIHNldCBlaXRoZXJcbiAgICBib3JkZXI6ICRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50IHNvbGlkICRnb3Z1ay1pbnB1dC1ib3JkZXItY29sb3VyO1xuICAgIGJvcmRlci1yYWRpdXM6IDA7XG5cbiAgICAvLyBEaXNhYmxlIGlubmVyIHNoYWRvdyBhbmQgcmVtb3ZlIHJvdW5kZWQgY29ybmVyc1xuICAgIC13ZWJraXQtYXBwZWFyYW5jZTogbm9uZTtcbiAgICAgICAtbW96LWFwcGVhcmFuY2U6IG5vbmU7XG4gICAgICAgICAgICBhcHBlYXJhbmNlOiBub25lO1xuICB9XG5cbiAgLmdvdnVrLWlucHV0Ojotd2Via2l0LW91dGVyLXNwaW4tYnV0dG9uLFxuICAuZ292dWstaW5wdXQ6Oi13ZWJraXQtaW5uZXItc3Bpbi1idXR0b24ge1xuICAgIG1hcmdpbjogMDtcbiAgICAtd2Via2l0LWFwcGVhcmFuY2U6IG5vbmU7XG4gIH1cblxuICAuZ292dWstaW5wdXRbdHlwZT1cIm51bWJlclwiXSB7XG4gICAgLW1vei1hcHBlYXJhbmNlOiB0ZXh0ZmllbGQ7XG4gIH1cblxuICAuZ292dWstaW5wdXQtLWVycm9yIHtcbiAgICBib3JkZXI6ICRnb3Z1ay1ib3JkZXItd2lkdGgtZm9ybS1lbGVtZW50LWVycm9yIHNvbGlkICRnb3Z1ay1lcnJvci1jb2xvdXI7XG4gIH1cblxuICAvLyBUaGUgZXggbWVhc3VyZW1lbnRzIGFyZSBiYXNlZCBvbiB0aGUgbnVtYmVyIG9mIFcncyB0aGF0IGNhbiBmaXQgaW5zaWRlIHRoZSBpbnB1dFxuICAvLyBFeHRyYSBzcGFjZSBpcyBsZWZ0IG9uIHRoZSByaWdodCBoYW5kIHNpZGUgdG8gYWxsb3cgZm9yIHRoZSBTYWZhcmkgcHJlZmlsbCBpY29uXG4gIC8vIExpbmVhciByZWdyZXNzaW9uIGVzdGltYXRpb24gYmFzZWQgb24gdmlzdWFsIHRlc3RzOiB5ID0gMS43NiArIDEuODF4XG5cbiAgLmdvdnVrLWlucHV0LS13aWR0aC0zMCB7XG4gICAgbWF4LXdpZHRoOiA1NmV4ICsgM2V4O1xuICB9XG5cbiAgLmdvdnVrLWlucHV0LS13aWR0aC0yMCB7XG4gICAgbWF4LXdpZHRoOiAzOGV4ICsgM2V4O1xuICB9XG5cbiAgLmdvdnVrLWlucHV0LS13aWR0aC0xMCB7XG4gICAgbWF4LXdpZHRoOiAyMGV4ICsgM2V4O1xuICB9XG5cbiAgLmdvdnVrLWlucHV0LS13aWR0aC01IHtcbiAgICBtYXgtd2lkdGg6IDEwLjhleDtcbiAgfVxuXG4gIC5nb3Z1ay1pbnB1dC0td2lkdGgtNCB7XG4gICAgbWF4LXdpZHRoOiA5ZXg7XG4gIH1cblxuICAuZ292dWstaW5wdXQtLXdpZHRoLTMge1xuICAgIG1heC13aWR0aDogNy4yZXg7XG4gIH1cblxuICAuZ292dWstaW5wdXQtLXdpZHRoLTIge1xuICAgIG1heC13aWR0aDogNS40ZXg7XG4gIH1cblxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvZGV0YWlsc1wiKSB7XG5cbiAgLmdvdnVrLWRldGFpbHMge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig2LCBcImJvdHRvbVwiKTtcblxuICAgIGRpc3BsYXk6IGJsb2NrO1xuICB9XG5cbiAgLmdvdnVrLWRldGFpbHNfX3N1bW1hcnkge1xuICAgIC8vIE1ha2UgdGhlIGZvY3VzIG91dGxpbmUgc2hyaW5rLXdyYXAgdGhlIHRleHQgY29udGVudCBvZiB0aGUgc3VtbWFyeVxuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcblxuICAgIC8vIEFic29sdXRlbHkgcG9zaXRpb24gdGhlIG1hcmtlciBhZ2FpbnN0IHRoaXMgZWxlbWVudFxuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcblxuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMSk7XG5cbiAgICAvLyBBbGxvdyBmb3IgYWJzb2x1dGVseSBwb3NpdGlvbmVkIG1hcmtlciBhbmQgYWxpZ24gd2l0aCBkaXNjbG9zZWQgdGV4dFxuICAgIHBhZGRpbmctbGVmdDogZ292dWstc3BhY2luZyg0KSArICRnb3Z1ay1ib3JkZXItd2lkdGg7XG5cbiAgICAvLyBTdHlsZSB0aGUgc3VtbWFyeSB0byBsb29rIGxpa2UgYSBsaW5rLi4uXG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWNvbG91cjtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gIH1cblxuICAvLyAuLi5idXQgb25seSB1bmRlcmxpbmUgdGhlIHRleHQsIG5vdCB0aGUgYXJyb3dcbiAgLmdvdnVrLWRldGFpbHNfX3N1bW1hcnktdGV4dCB7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiB1bmRlcmxpbmU7XG4gIH1cblxuICAuZ292dWstZGV0YWlsc19fc3VtbWFyeTpob3ZlciB7XG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWhvdmVyLWNvbG91cjtcbiAgfVxuXG4gIC5nb3Z1ay1kZXRhaWxzX19zdW1tYXJ5OmZvY3VzIHtcbiAgICAvLyAtMXB4IG9mZnNldCBmaXhlcyBnYXAgYmV0d2VlbiBiYWNrZ3JvdW5kIGFuZCBvdXRsaW5lIGluIEZpcmVmb3hcbiAgICBvdXRsaW5lOiAoJGdvdnVrLWZvY3VzLXdpZHRoICsgMXB4KSBzb2xpZCAkZ292dWstZm9jdXMtY29sb3VyO1xuICAgIG91dGxpbmUtb2Zmc2V0OiAtMXB4O1xuICAgIGJhY2tncm91bmQ6ICRnb3Z1ay1mb2N1cy1jb2xvdXI7XG4gIH1cblxuICAvLyBSZW1vdmUgdGhlIGRlZmF1bHQgZGV0YWlscyBtYXJrZXIgc28gd2UgY2FuIHN0eWxlIG91ciBvd24gY29uc2lzdGVudGx5IGFuZFxuICAvLyBlbnN1cmUgaXQgZGlzcGxheXMgaW4gRmlyZWZveCAoc2VlIGltcGxlbWVudGF0aW9uLm1kIGZvciBkZXRhaWxzKVxuICAuZ292dWstZGV0YWlsc19fc3VtbWFyeTo6LXdlYmtpdC1kZXRhaWxzLW1hcmtlciB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgfVxuXG4gIC8vIEFwcGVuZCBvdXIgb3duIG9wZW4gLyBjbG9zZWQgbWFya2VyIHVzaW5nIGEgcHNldWRvLWVsZW1lbnRcbiAgLmdvdnVrLWRldGFpbHNfX3N1bW1hcnk6YmVmb3JlIHtcbiAgICBjb250ZW50OiBcIlwiO1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcblxuICAgIHRvcDogMDtcbiAgICBib3R0b206IDA7XG4gICAgbGVmdDogMDtcblxuICAgIG1hcmdpbjogYXV0bztcblxuICAgIEBpbmNsdWRlIGdvdnVrLXNoYXBlLWFycm93KCRkaXJlY3Rpb246IHJpZ2h0LCAkYmFzZTogMTRweCk7XG5cbiAgICAuZ292dWstZGV0YWlsc1tvcGVuXSA+ICYge1xuICAgICAgQGluY2x1ZGUgZ292dWstc2hhcGUtYXJyb3coJGRpcmVjdGlvbjogZG93biwgJGJhc2U6IDE0cHgpO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1kZXRhaWxzX190ZXh0IHtcbiAgICBwYWRkaW5nOiBnb3Z1ay1zcGFjaW5nKDMpO1xuICAgIHBhZGRpbmctbGVmdDogZ292dWstc3BhY2luZyg0KTtcbiAgICBib3JkZXItbGVmdDogJGdvdnVrLWJvcmRlci13aWR0aCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbiAgfVxuXG4gIC5nb3Z1ay1kZXRhaWxzX190ZXh0IHAge1xuICAgIG1hcmdpbi10b3A6IDA7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZyg0KTtcbiAgfVxuXG4gIC5nb3Z1ay1kZXRhaWxzX190ZXh0ID4gOmxhc3QtY2hpbGQge1xuICAgIG1hcmdpbi1ib3R0b206IDA7XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW1wb3J0IFwiLi4vLi4vY29yZS9saXN0c1wiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2Vycm9yLXN1bW1hcnlcIikge1xuXG4gIC5nb3Z1ay1lcnJvci1zdW1tYXJ5IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLXBhZGRpbmcoNCk7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oOCwgXCJib3R0b21cIik7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlO1xuXG4gICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoLW1vYmlsZSBzb2xpZCAkZ292dWstZXJyb3ItY29sb3VyO1xuXG4gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoIHNvbGlkICRnb3Z1ay1lcnJvci1jb2xvdXI7XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLWVycm9yLXN1bW1hcnlfX3RpdGxlIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAyNCwgJHdlaWdodDogYm9sZCk7XG5cbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLmdvdnVrLWVycm9yLXN1bW1hcnlfX2JvZHkge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcblxuICAgIHAge1xuICAgICAgbWFyZ2luLXRvcDogMDtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICAgIH1cbiAgfVxuXG4gIC8vIENyb3NzLWNvbXBvbmVudCBjbGFzcyAtIGFkanVzdHMgc3R5bGluZyBvZiBsaXN0IGNvbXBvbmVudFxuICAuZ292dWstZXJyb3Itc3VtbWFyeV9fbGlzdCB7XG4gICAgbWFyZ2luLXRvcDogMDtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICB9XG5cbiAgLmdvdnVrLWVycm9yLXN1bW1hcnlfX2xpc3QgYSB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlLWZpbGw7XG4gICAgQGluY2x1ZGUgZ292dWstdHlwb2dyYXBoeS13ZWlnaHQtYm9sZDtcblxuICAgIC8vIE92ZXJyaWRlIGRlZmF1bHQgbGluayBzdHlsaW5nIHRvIHVzZSBlcnJvciBjb2xvdXJcbiAgICAmOmxpbmssXG4gICAgJjp2aXNpdGVkLFxuICAgICY6aG92ZXIsXG4gICAgJjphY3RpdmUsXG4gICAgJjpmb2N1cyB7XG4gICAgICBjb2xvcjogJGdvdnVrLWVycm9yLWNvbG91cjtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogdW5kZXJsaW5lO1xuICAgIH1cblxuICAgIC8vIGFscGhhZ292L2dvdnVrX3RlbXBsYXRlIGluY2x1ZGVzIGEgc3BlY2lmaWMgYTpsaW5rOmZvY3VzIHNlbGVjdG9yXG4gICAgLy8gZGVzaWduZWQgdG8gbWFrZSB1bnZpc2l0ZWQgbGlua3MgYSBzbGlnaHRseSBkYXJrZXIgYmx1ZSB3aGVuIGZvY3Vzc2VkLCBzb1xuICAgIC8vIHdlIG5lZWQgdG8gb3ZlcnJpZGUgdGhlIHRleHQgY29sb3VyIGZvciB0aGF0IGNvbWJpbmF0aW9uIG9mIHNlbGVjdG9ycy5cbiAgICBAaW5jbHVkZSBnb3Z1ay1jb21wYXRpYmlsaXR5KGdvdnVrX3RlbXBsYXRlKSB7XG4gICAgICAmOmxpbms6Zm9jdXMge1xuICAgICAgICBjb2xvcjogJGdvdnVrLWVycm9yLWNvbG91cjtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbXBvcnQgXCIuLi9lcnJvci1tZXNzYWdlL2Vycm9yLW1lc3NhZ2VcIjtcbkBpbXBvcnQgXCIuLi9oaW50L2hpbnRcIjtcbkBpbXBvcnQgXCIuLi9sYWJlbC9sYWJlbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2ZpbGUtdXBsb2FkXCIpIHtcbiAgLmdvdnVrLWZpbGUtdXBsb2FkIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlO1xuICB9XG5cbiAgLmdvdnVrLWZpbGUtdXBsb2FkLS1lcnJvciB7XG4gICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudC1lcnJvciBzb2xpZCAkZ292dWstZXJyb3ItY29sb3VyO1xuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvdHlwb2dyYXBoeVwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2Zvb3RlclwiKSB7XG5cbiAgJGdvdnVrLWZvb3Rlci1iYWNrZ3JvdW5kOiAkZ292dWstY2FudmFzLWJhY2tncm91bmQtY29sb3VyO1xuICAkZ292dWstZm9vdGVyLWJvcmRlci10b3A6ICNhMWFjYjI7XG4gICRnb3Z1ay1mb290ZXItYm9yZGVyOiBnb3Z1ay1jb2xvdXIoXCJncmV5LTJcIik7XG4gICRnb3Z1ay1mb290ZXItdGV4dDogIzQ1NGE0YztcbiAgJGdvdnVrLWZvb3Rlci1saW5rOiAkZ292dWstZm9vdGVyLXRleHQ7XG4gICRnb3Z1ay1mb290ZXItbGluay1ob3ZlcjogIzE3MTgxOTtcblxuICAvLyBCYXNlZCBvbiB0aGUgZ292dWstY3Jlc3QtMngucG5nIGltYWdlIGRpbWVuc2lvbnMuXG4gICRnb3Z1ay1mb290ZXItY3Jlc3QtaW1hZ2Utd2lkdGgtMng6IDI1MHB4O1xuICAkZ292dWstZm9vdGVyLWNyZXN0LWltYWdlLWhlaWdodC0yeDogMjA0cHg7XG4gIC8vIEhhbGYgdGhlIDJ4IGltYWdlIHNvIHRoYXQgaXQgZml0cyB0aGUgcmVndWxhciAxeCBzaXplLlxuICAkZ292dWstZm9vdGVyLWNyZXN0LWltYWdlLXdpZHRoOiAoJGdvdnVrLWZvb3Rlci1jcmVzdC1pbWFnZS13aWR0aC0yeCAvIDIpO1xuICAkZ292dWstZm9vdGVyLWNyZXN0LWltYWdlLWhlaWdodDogKCRnb3Z1ay1mb290ZXItY3Jlc3QtaW1hZ2UtaGVpZ2h0LTJ4IC8gMik7XG5cbiAgLmdvdnVrLWZvb3RlciB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTYpO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtcGFkZGluZyg3LCBcInRvcFwiKTtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLXBhZGRpbmcoNSwgXCJib3R0b21cIik7XG5cbiAgICBib3JkZXItdG9wOiAxcHggc29saWQgJGdvdnVrLWZvb3Rlci1ib3JkZXItdG9wO1xuICAgIGNvbG9yOiAkZ292dWstZm9vdGVyLXRleHQ7XG4gICAgYmFja2dyb3VuZDogJGdvdnVrLWZvb3Rlci1iYWNrZ3JvdW5kO1xuICB9XG5cbiAgLmdvdnVrLWZvb3Rlcl9fbGluayB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlLWZpbGw7XG5cbiAgICAmOmxpbmssXG4gICAgJjp2aXNpdGVkIHtcbiAgICAgIGNvbG9yOiAkZ292dWstZm9vdGVyLWxpbms7XG4gICAgfVxuXG4gICAgJjpob3ZlcixcbiAgICAmOmFjdGl2ZSB7XG4gICAgICBjb2xvcjogJGdvdnVrLWZvb3Rlci1saW5rLWhvdmVyO1xuICAgIH1cblxuICAgIC8vIFVzZSB0ZXh0IGNvbG91ciB3aGVuIGZvY3Vzc2VkXG4gICAgJjpmb2N1cyB7XG4gICAgICBjb2xvcjogJGdvdnVrLXRleHQtY29sb3VyO1xuICAgIH1cblxuICAgIC8vIGFscGhhZ292L2dvdnVrX3RlbXBsYXRlIGluY2x1ZGVzIGEgc3BlY2lmaWMgYTpsaW5rOmZvY3VzIHNlbGVjdG9yXG4gICAgLy8gZGVzaWduZWQgdG8gbWFrZSB1bnZpc2l0ZWQgbGlua3MgYSBzbGlnaHRseSBkYXJrZXIgYmx1ZSB3aGVuIGZvY3Vzc2VkLCBzb1xuICAgIC8vIHdlIG5lZWQgdG8gb3ZlcnJpZGUgdGhlIHRleHQgY29sb3VyIGZvciB0aGF0IGNvbWJpbmF0aW9uIG9mIHNlbGVjdG9ycy5cbiAgICBAaW5jbHVkZSBnb3Z1ay1jb21wYXRpYmlsaXR5KGdvdnVrX3RlbXBsYXRlKSB7XG4gICAgICAmOmxpbms6Zm9jdXMge1xuICAgICAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAuZ292dWstZm9vdGVyX19zZWN0aW9uLWJyZWFrIHtcbiAgICBtYXJnaW46IDA7IC8vIFJlc2V0IGA8aHI+YCBkZWZhdWx0IG1hcmdpbnNcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig4LCBcImJvdHRvbVwiKTtcbiAgICBib3JkZXI6IDA7IC8vIFJlc2V0IGA8aHI+YCBkZWZhdWx0IGJvcmRlcnNcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWZvb3Rlci1ib3JkZXI7XG4gIH1cblxuICAuZ292dWstZm9vdGVyX19tZXRhIHtcbiAgICBkaXNwbGF5OiAtd2Via2l0LWJveDtcbiAgICBkaXNwbGF5OiAtbXMtZmxleGJveDtcbiAgICBkaXNwbGF5OiBmbGV4OyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gICAgbWFyZ2luLXJpZ2h0OiAtJGdvdnVrLWd1dHRlci1oYWxmO1xuICAgIG1hcmdpbi1sZWZ0OiAtJGdvdnVrLWd1dHRlci1oYWxmO1xuICAgIC1tcy1mbGV4LXdyYXA6IHdyYXA7XG4gICAgICAgIGZsZXgtd3JhcDogd3JhcDsgLy8gU3VwcG9ydDogRmxleGJveFxuICAgIC13ZWJraXQtYm94LWFsaWduOiBlbmQ7XG4gICAgICAgIC1tcy1mbGV4LWFsaWduOiBlbmQ7XG4gICAgICAgICAgICBhbGlnbi1pdGVtczogZmxleC1lbmQ7IC8vIFN1cHBvcnQ6IEZsZXhib3hcbiAgICAtd2Via2l0LWJveC1wYWNrOiBjZW50ZXI7XG4gICAgICAgIC1tcy1mbGV4LXBhY2s6IGNlbnRlcjtcbiAgICAgICAgICAgIGp1c3RpZnktY29udGVudDogY2VudGVyOyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gIH1cblxuICAuZ292dWstZm9vdGVyX19tZXRhLWl0ZW0ge1xuICAgIG1hcmdpbi1yaWdodDogJGdvdnVrLWd1dHRlci1oYWxmO1xuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoNSk7XG4gICAgbWFyZ2luLWxlZnQ6ICRnb3Z1ay1ndXR0ZXItaGFsZjtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX21ldGEtaXRlbS0tZ3JvdyB7XG4gICAgLXdlYmtpdC1ib3gtZmxleDogMTtcbiAgICAgICAgLW1zLWZsZXg6IDE7XG4gICAgICAgICAgICBmbGV4OiAxOyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gICAgQGluY2x1ZGUgbXEgKCR1bnRpbDogdGFibGV0KSB7XG4gICAgICAtbXMtZmxleC1wcmVmZXJyZWQtc2l6ZTogMzIwcHg7XG4gICAgICAgICAgZmxleC1iYXNpczogMzIwcHg7IC8vIFN1cHBvcnQ6IEZsZXhib3hcbiAgICB9XG4gIH1cblxuICAuZ292dWstZm9vdGVyX19saWNlbmNlLWxvZ28ge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMik7XG4gICAgQGluY2x1ZGUgbXEgKCR1bnRpbDogZGVza3RvcCkge1xuICAgICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygzKTtcbiAgICB9XG4gICAgdmVydGljYWwtYWxpZ246IHRvcDtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX2xpY2VuY2UtZGVzY3JpcHRpb24ge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX2NvcHlyaWdodC1sb2dvIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgbWluLXdpZHRoOiAkZ292dWstZm9vdGVyLWNyZXN0LWltYWdlLXdpZHRoO1xuICAgIHBhZGRpbmctdG9wOiAoJGdvdnVrLWZvb3Rlci1jcmVzdC1pbWFnZS1oZWlnaHQgKyBnb3Z1ay1zcGFjaW5nKDIpKTtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiBnb3Z1ay1pbWFnZS11cmwoXCJnb3Z1ay1jcmVzdC5wbmdcIik7XG4gICAgQGluY2x1ZGUgZ292dWstZGV2aWNlLXBpeGVsLXJhdGlvIHtcbiAgICAgIGJhY2tncm91bmQtaW1hZ2U6IGdvdnVrLWltYWdlLXVybChcImdvdnVrLWNyZXN0LTJ4LnBuZ1wiKTtcbiAgICB9XG4gICAgYmFja2dyb3VuZC1yZXBlYXQ6IG5vLXJlcGVhdDtcbiAgICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiA1MCUgMCU7XG4gICAgYmFja2dyb3VuZC1zaXplOiAkZ292dWstZm9vdGVyLWNyZXN0LWltYWdlLXdpZHRoICRnb3Z1ay1mb290ZXItY3Jlc3QtaW1hZ2UtaGVpZ2h0O1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgd2hpdGUtc3BhY2U6IG5vd3JhcDtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX2lubGluZS1saXN0IHtcbiAgICBtYXJnaW4tdG9wOiAwO1xuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMyk7XG4gICAgcGFkZGluZzogMDtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX2lubGluZS1saXN0LWl0ZW0ge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMyk7XG4gICAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygxKTtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX2hlYWRpbmcge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDcsIFwiYm90dG9tXCIpO1xuICAgIHBhZGRpbmctYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDQpO1xuICAgIEBpbmNsdWRlIG1xICgkdW50aWw6IHRhYmxldCkge1xuICAgICAgcGFkZGluZy1ib3R0b206IGdvdnVrLXNwYWNpbmcoMik7XG4gICAgfVxuICAgIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCAkZ292dWstZm9vdGVyLWJvcmRlcjtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX25hdmlnYXRpb24ge1xuICAgIGRpc3BsYXk6IC13ZWJraXQtYm94O1xuICAgIGRpc3BsYXk6IC1tcy1mbGV4Ym94O1xuICAgIGRpc3BsYXk6IGZsZXg7IC8vIFN1cHBvcnQ6IEZsZXhib3hcbiAgICBtYXJnaW4tcmlnaHQ6IC0kZ292dWstZ3V0dGVyLWhhbGY7XG4gICAgbWFyZ2luLWxlZnQ6IC0kZ292dWstZ3V0dGVyLWhhbGY7XG4gICAgLW1zLWZsZXgtd3JhcDogd3JhcDtcbiAgICAgICAgZmxleC13cmFwOiB3cmFwOyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gIH1cblxuICAuZ292dWstZm9vdGVyX19zZWN0aW9uIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgbWFyZ2luLXJpZ2h0OiAkZ292dWstZ3V0dGVyLWhhbGY7XG4gICAgbWFyZ2luLWJvdHRvbTogJGdvdnVrLWd1dHRlcjtcbiAgICBtYXJnaW4tbGVmdDogJGdvdnVrLWd1dHRlci1oYWxmO1xuICAgIHZlcnRpY2FsLWFsaWduOiB0b3A7XG4gICAgLy8gRW5zdXJlIGNvbHVtbnMgdGFrZSB1cCBlcXVhbCB3aWR0aCAodHlwaWNhbGx5IG9uZS1oYWxmOm9uZS1oYWxmKVxuICAgIC13ZWJraXQtYm94LWZsZXg6IDE7XG4gICAgICAgIC1tcy1mbGV4LXBvc2l0aXZlOiAxO1xuICAgICAgICAgICAgZmxleC1ncm93OiAxOyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gICAgLW1zLWZsZXgtbmVnYXRpdmU6IDE7XG4gICAgICAgIGZsZXgtc2hyaW5rOiAxOyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gICAgQGluY2x1ZGUgbXEgKCR1bnRpbDogZGVza3RvcCkge1xuICAgICAgLy8gTWFrZSBzdXJlIGNvbHVtbnMgZG8gbm90IGRyb3AgYmVsb3cgMjAwcHggaW4gd2lkdGhcbiAgICAgIC8vIFdpbGwgdHlwaWNhbGx5IHJlc3VsdCBpbiB3cmFwcGluZywgYW5kIGVuZCB1cCBpbiBhIHNpbmdsZSBjb2x1bW4gb24gc21hbGxlciBzY3JlZW5zLlxuICAgICAgLW1zLWZsZXgtcHJlZmVycmVkLXNpemU6IDIwMHB4O1xuICAgICAgICAgIGZsZXgtYmFzaXM6IDIwMHB4OyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gICAgfVxuICB9XG5cbiAgLy8gU2VjdGlvbnMgdHdvLXRoaXJkOm9uZS10aGlyZCBvbiBkZXNrdG9wXG4gIEBpbmNsdWRlIG1xICgkZnJvbTogZGVza3RvcCkge1xuICAgIC5nb3Z1ay1mb290ZXJfX3NlY3Rpb246Zmlyc3QtY2hpbGQge1xuICAgICAgLXdlYmtpdC1ib3gtZmxleDogMjtcbiAgICAgICAgICAtbXMtZmxleC1wb3NpdGl2ZTogMjtcbiAgICAgICAgICAgICAgZmxleC1ncm93OiAyOyAvLyBTdXBwb3J0OiBGbGV4Ym94XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLWZvb3Rlcl9fbGlzdCB7XG4gICAgbWFyZ2luOiAwO1xuICAgIHBhZGRpbmc6IDA7XG4gICAgbGlzdC1zdHlsZTogbm9uZTtcbiAgICAtd2Via2l0LWNvbHVtbi1nYXA6ICRnb3Z1ay1ndXR0ZXI7XG4gICAgICAgICAgICBjb2x1bW4tZ2FwOiAkZ292dWstZ3V0dGVyOyAvLyBTdXBwb3J0OiBDb2x1bW5zXG4gIH1cblxuICBAaW5jbHVkZSBtcSAoJGZyb206IGRlc2t0b3ApIHtcbiAgICAuZ292dWstZm9vdGVyX19saXN0LS1jb2x1bW5zLTIge1xuICAgICAgLXdlYmtpdC1jb2x1bW4tY291bnQ6IDI7XG4gICAgICAgICAgICAgIGNvbHVtbi1jb3VudDogMjsgLy8gU3VwcG9ydDogQ29sdW1uc1xuICAgIH1cblxuICAgIC5nb3Z1ay1mb290ZXJfX2xpc3QtLWNvbHVtbnMtMyB7XG4gICAgICAtd2Via2l0LWNvbHVtbi1jb3VudDogMztcbiAgICAgICAgICAgICAgY29sdW1uLWNvdW50OiAzOyAvLyBTdXBwb3J0OiBDb2x1bW5zXG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLWZvb3Rlcl9fbGlzdC1pdGVtIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig0LCBcImJvdHRvbVwiKTtcbiAgfVxuXG4gIC5nb3Z1ay1mb290ZXJfX2xpc3QtaXRlbTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvdHlwb2dyYXBoeVwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L2hlYWRlclwiKSB7XG5cbiAgJGdvdnVrLWhlYWRlci1iYWNrZ3JvdW5kOiBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgJGdvdnVrLWhlYWRlci1ib3JkZXItY29sb3I6ICRnb3Z1ay1icmFuZC1jb2xvdXI7XG4gICRnb3Z1ay1oZWFkZXItYm9yZGVyLXdpZHRoOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAkZ292dWstaGVhZGVyLXRleHQ6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICAkZ292dWstaGVhZGVyLWxpbms6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICAkZ292dWstaGVhZGVyLWxpbmstaG92ZXI6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICAkZ292dWstaGVhZGVyLWxpbmstYWN0aXZlOiAjMWQ4ZmViO1xuICAkZ292dWstaGVhZGVyLW5hdi1pdGVtLWJvcmRlci1jb2xvcjogIzJlMzEzMztcblxuICAuZ292dWstaGVhZGVyIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxNik7XG5cbiAgICBib3JkZXItYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDIpIHNvbGlkIGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICAgIGNvbG9yOiAkZ292dWstaGVhZGVyLXRleHQ7XG4gICAgYmFja2dyb3VuZDogJGdvdnVrLWhlYWRlci1iYWNrZ3JvdW5kO1xuXG4gIH1cblxuICAuZ292dWstaGVhZGVyX19jb250YWluZXItLWZ1bGwtd2lkdGgge1xuICAgIHBhZGRpbmc6IDAgZ292dWstc3BhY2luZygzKTtcbiAgICBib3JkZXItY29sb3I6ICRnb3Z1ay1oZWFkZXItYm9yZGVyLWNvbG9yO1xuXG4gICAgLmdvdnVrLWhlYWRlcl9fbWVudS1idXR0b24ge1xuICAgICAgcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMyk7XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLWhlYWRlcl9fY29udGFpbmVyIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1jbGVhcmZpeDtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgbWFyZ2luLWJvdHRvbTogLSRnb3Z1ay1oZWFkZXItYm9yZGVyLXdpZHRoO1xuICAgIHBhZGRpbmctdG9wOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAgIGJvcmRlci1ib3R0b206ICRnb3Z1ay1oZWFkZXItYm9yZGVyLXdpZHRoIHNvbGlkICRnb3Z1ay1oZWFkZXItYm9yZGVyLWNvbG9yO1xuICB9XG5cbiAgLmdvdnVrLWhlYWRlcl9fbG9nb3R5cGUge1xuICAgIG1hcmdpbi1yaWdodDogZ292dWstc3BhY2luZygxKTtcbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX2xvZ290eXBlLWNyb3duIHtcbiAgICBtYXJnaW4tcmlnaHQ6IDFweDtcbiAgICBmaWxsOiBjdXJyZW50Q29sb3I7XG4gICAgdmVydGljYWwtYWxpZ246IG1pZGRsZTtcbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX2xvZ290eXBlLWNyb3duLWZhbGxiYWNrLWltYWdlIHtcbiAgICB3aWR0aDogMzZweDtcbiAgICBoZWlnaHQ6IDMycHg7XG4gICAgYm9yZGVyOiAwO1xuICAgIHZlcnRpY2FsLWFsaWduOiBtaWRkbGU7XG4gIH1cblxuICAuZ292dWstaGVhZGVyX19wcm9kdWN0LW5hbWUge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDI0KTtcbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX2xpbmsge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvY3VzYWJsZS1maWxsO1xuXG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuXG4gICAgJjpsaW5rLFxuICAgICY6dmlzaXRlZCB7XG4gICAgICBjb2xvcjogJGdvdnVrLWhlYWRlci1saW5rO1xuICAgIH1cblxuICAgICY6aG92ZXIge1xuICAgICAgdGV4dC1kZWNvcmF0aW9uOiB1bmRlcmxpbmU7XG4gICAgfVxuXG4gICAgJjpmb2N1cyB7XG4gICAgICBjb2xvcjogZ292dWstY29sb3VyKFwiYmxhY2tcIik7XG4gICAgfVxuXG4gICAgLy8gYWxwaGFnb3YvZ292dWtfdGVtcGxhdGUgaW5jbHVkZXMgYSBzcGVjaWZpYyBhOmxpbms6Zm9jdXMgc2VsZWN0b3JcbiAgICAvLyBkZXNpZ25lZCB0byBtYWtlIHVudmlzaXRlZCBsaW5rcyBhIHNsaWdodGx5IGRhcmtlciBibHVlIHdoZW4gZm9jdXNzZWQsIHNvXG4gICAgLy8gd2UgbmVlZCB0byBvdmVycmlkZSB0aGUgdGV4dCBjb2xvdXIgZm9yIHRoYXQgY29tYmluYXRpb24gb2Ygc2VsZWN0b3JzLlxuICAgIEBpbmNsdWRlIGdvdnVrLWNvbXBhdGliaWxpdHkoZ292dWtfdGVtcGxhdGUpIHtcbiAgICAgICY6bGluazpmb2N1cyB7XG4gICAgICAgIEBpbmNsdWRlIGdvdnVrLXRleHQtY29sb3VyO1xuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX2xpbmstLWhvbWVwYWdlIHtcbiAgICAvLyBGb250IHNpemUgbmVlZHMgdG8gYmUgc2V0IG9uIHRoZSBsaW5rIHNvIHRoYXQgdGhlIGJveCBzaXppbmcgaXMgY29ycmVjdFxuICAgIC8vIGluIEZpcmVmb3hcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiBmYWxzZSwgJHdlaWdodDogYm9sZCk7XG5cbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgZm9udC1zaXplOiAzMHB4OyAvLyBXZSBkb24ndCBoYXZlIGEgbWl4aW4gdGhhdCBwcm9kdWNlcyAzMHB4IGZvbnQgc2l6ZVxuICAgIGxpbmUtaGVpZ2h0OiAzMHB4O1xuXG4gICAgJjpsaW5rLFxuICAgICY6dmlzaXRlZCB7XG4gICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgfVxuXG4gICAgJjpob3ZlcixcbiAgICAmOmFjdGl2ZSB7XG4gICAgICAvLyBOZWdhdGUgdGhlIGFkZGVkIGJvcmRlclxuICAgICAgbWFyZ2luLWJvdHRvbTogLTFweDtcbiAgICAgIC8vIE9taXR0aW5nIGNvbG91ciB3aWxsIHVzZSBkZWZhdWx0IHZhbHVlIG9mIGN1cnJlbnRDb2xvciDigJMgaWYgd2VcbiAgICAgIC8vIHNwZWNpZmllZCBjdXJyZW50Q29sb3IgZXhwbGljaXRseSBJRTggd291bGQgaWdub3JlIHRoaXMgcnVsZS5cbiAgICAgIGJvcmRlci1ib3R0b206IDFweCBzb2xpZDtcbiAgICB9XG4gIH1cblxuICAuZ292dWstaGVhZGVyX19saW5rLS1zZXJ2aWNlLW5hbWUge1xuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDI0LCAkd2VpZ2h0OiBib2xkKTtcbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX2xvZ28ge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDIsIFwiYm90dG9tXCIpO1xuICAgIHBhZGRpbmctcmlnaHQ6IGdvdnVrLXNwYWNpbmcoOCk7XG5cbiAgICBAaW5jbHVkZSBtcSAoJGZyb206IGRlc2t0b3ApIHtcbiAgICAgIHdpZHRoOiAzMy4zMyU7XG4gICAgICBwYWRkaW5nLXJpZ2h0OiAwO1xuICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICB2ZXJ0aWNhbC1hbGlnbjogdG9wO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX2NvbnRlbnQge1xuICAgIEBpbmNsdWRlIG1xICgkZnJvbTogZGVza3RvcCkge1xuICAgICAgd2lkdGg6IDY2LjY2JTtcbiAgICAgIGZsb2F0OiBsZWZ0O1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX21lbnUtYnV0dG9uIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxNik7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgdG9wOiBnb3Z1ay1zcGFjaW5nKDQpO1xuICAgIHJpZ2h0OiAwO1xuICAgIG1hcmdpbjogMDtcbiAgICBwYWRkaW5nOiAwO1xuICAgIGJvcmRlcjogMDtcbiAgICBjb2xvcjogJGdvdnVrLWhlYWRlci1saW5rO1xuICAgIGJhY2tncm91bmQ6IG5vbmU7XG5cbiAgICAmOmhvdmVyIHtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogdW5kZXJsaW5lO1xuICAgIH1cblxuICAgICY6OmFmdGVyIHtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLXNoYXBlLWFycm93KCRkaXJlY3Rpb246IGRvd24sICRiYXNlOiAxMHB4LCAkZGlzcGxheTogaW5saW5lLWJsb2NrKTtcbiAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICBtYXJnaW4tbGVmdDogZ292dWstc3BhY2luZygxKTtcbiAgICB9XG5cbiAgICBAaW5jbHVkZSBnb3Z1ay1mb2N1c2FibGU7XG5cbiAgICBAaW5jbHVkZSBtcSAoJGZyb206IHRhYmxldCkge1xuICAgICAgdG9wOiBnb3Z1ay1zcGFjaW5nKDMpO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX21lbnUtYnV0dG9uLS1vcGVuIHtcbiAgICAmOjphZnRlciB7XG4gICAgICBAaW5jbHVkZSBnb3Z1ay1zaGFwZS1hcnJvdygkZGlyZWN0aW9uOiB1cCwgJGJhc2U6IDEwcHgsICRkaXNwbGF5OiBpbmxpbmUtYmxvY2spO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX25hdmlnYXRpb24ge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDIsIFwiYm90dG9tXCIpO1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIG1hcmdpbjogMDtcbiAgICBwYWRkaW5nOiAwO1xuICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gIH1cblxuICAuanMtZW5hYmxlZCB7XG4gICAgLmdvdnVrLWhlYWRlcl9fbWVudS1idXR0b24ge1xuICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgICBAaW5jbHVkZSBtcSAoJGZyb206IGRlc2t0b3ApIHtcbiAgICAgICAgZGlzcGxheTogbm9uZTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICAuZ292dWstaGVhZGVyX19uYXZpZ2F0aW9uIHtcbiAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgICBAaW5jbHVkZSBtcSAoJGZyb206IGRlc2t0b3ApIHtcbiAgICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgICB9XG4gICAgfVxuXG4gICAgLmdvdnVrLWhlYWRlcl9fbmF2aWdhdGlvbi0tb3BlbiB7XG4gICAgICBkaXNwbGF5OiBibG9jaztcbiAgICB9XG4gIH1cblxuXG4gIC5nb3Z1ay1oZWFkZXJfX25hdmlnYXRpb24tLWVuZCB7XG4gICAgQGluY2x1ZGUgbXEgKCRmcm9tOiBkZXNrdG9wKSB7XG4gICAgICBtYXJnaW46IDA7XG4gICAgICBwYWRkaW5nOiBnb3Z1ay1zcGFjaW5nKDEpIDA7XG4gICAgICB0ZXh0LWFsaWduOiByaWdodDtcbiAgICB9XG4gIH1cblxuICAuZ292dWstaGVhZGVyX19uYXZpZ2F0aW9uLS1uby1zZXJ2aWNlLW5hbWUge1xuICAgIHBhZGRpbmctdG9wOiBnb3Z1ay1zcGFjaW5nKDcpO1xuICB9XG5cbiAgLmdvdnVrLWhlYWRlcl9fbmF2aWdhdGlvbi1pdGVtIHtcbiAgICBwYWRkaW5nOiBnb3Z1ay1zcGFjaW5nKDIpIDA7XG4gICAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkICRnb3Z1ay1oZWFkZXItbmF2LWl0ZW0tYm9yZGVyLWNvbG9yO1xuXG4gICAgQGluY2x1ZGUgbXEgKCRmcm9tOiBkZXNrdG9wKSB7XG4gICAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgICBtYXJnaW4tcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMyk7XG4gICAgICBwYWRkaW5nOiBnb3Z1ay1zcGFjaW5nKDEpIDA7XG4gICAgICBib3JkZXI6IDA7XG4gICAgfVxuXG4gICAgYSB7XG4gICAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxNiwgJHdlaWdodDogYm9sZCk7XG4gICAgICB3aGl0ZS1zcGFjZTogbm93cmFwO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1oZWFkZXJfX25hdmlnYXRpb24taXRlbS0tYWN0aXZlIHtcbiAgICBhIHtcbiAgICAgICY6bGluayxcbiAgICAgICY6aG92ZXIsXG4gICAgICAmOnZpc2l0ZWQge1xuICAgICAgICBjb2xvcjogJGdvdnVrLWhlYWRlci1saW5rLWFjdGl2ZTtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAuZ292dWstaGVhZGVyX19uYXZpZ2F0aW9uLWl0ZW06bGFzdC1jaGlsZCB7XG4gICAgbWFyZ2luLXJpZ2h0OiAwO1xuICB9XG5cbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJG1lZGlhLXR5cGU6IHByaW50KSB7XG4gICAgLmdvdnVrLWhlYWRlciB7XG4gICAgICBib3JkZXItYm90dG9tLXdpZHRoOiAwO1xuICAgICAgY29sb3I6IGdvdnVrLWNvbG91cihcImJsYWNrXCIpO1xuICAgICAgYmFja2dyb3VuZDogdHJhbnNwYXJlbnQ7XG4gICAgfVxuXG4gICAgLy8gSGlkZSB0aGUgaW52ZXJ0ZWQgY3Jvd24gd2hlbiBwcmludGluZyBpbiBicm93c2VycyB0aGF0IGRvbid0IHN1cHBvcnQgU1ZHLlxuICAgIC5nb3Z1ay1oZWFkZXJfX2xvZ290eXBlLWNyb3duLWZhbGxiYWNrLWltYWdlIHtcbiAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgfVxuXG4gICAgLmdvdnVrLWhlYWRlcl9fbGluayB7XG4gICAgICAmOmxpbmssXG4gICAgICAmOnZpc2l0ZWQge1xuICAgICAgICBjb2xvcjogZ292dWstY29sb3VyKFwiYmxhY2tcIik7XG4gICAgICB9XG5cbiAgICAgIC8vIERvIG5vdCBhcHBlbmQgbGluayBocmVmIHRvIEdPVi5VSyBsaW5rIHdoZW4gcHJpbnRpbmcgKGUuZy4gJygvKScpXG4gICAgICAmOmFmdGVyIHtcbiAgICAgICAgZGlzcGxheTogbm9uZTtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAvLyBCZWdpbiBhZGp1c3RtZW50cyBmb3IgZm9udCBiYXNlbGluZSBvZmZzZXRcbiAgLy8gVGhlc2Ugc2hvdWxkIGJlIHJlbW92ZWQgd2hlbiB0aGUgZm9udCBpcyB1cGRhdGVkIHdpdGggdGhlIGNvcnJlY3QgYmFzZWxpbmVcbiAgLmdvdnVrLWhlYWRlcl9fbG9nb3R5cGUtY3Jvd24sXG4gIC5nb3Z1ay1oZWFkZXJfX2xvZ290eXBlLWNyb3duLWZhbGxiYWNrLWltYWdlIHtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgdG9wOiAtNHB4O1xuICB9XG5cbiAgLmdvdnVrLWhlYWRlciB7XG4gICAgJG9mZnNldDogM3B4O1xuICAgIHBhZGRpbmctdG9wOiAkb2Zmc2V0O1xuICB9XG4gIC8vIEVuZCBhZGp1c3RtZW50c1xuXG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC9pbnNldC10ZXh0XCIpIHtcbiAgLmdvdnVrLWluc2V0LXRleHQge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcbiAgICBAaW5jbHVkZSBnb3Z1ay10ZXh0LWNvbG91cjtcbiAgICBwYWRkaW5nOiBnb3Z1ay1zcGFjaW5nKDMpO1xuICAgIC8vIE1hcmdpbiB0b3AgaW50ZW5kZWQgdG8gY29sbGFwc2VcbiAgICAvLyBUaGlzIGFkZHMgYW4gYWRkaXRpb25hbCAxMHB4IHRvIHRoZSBwYXJhZ3JhcGggYWJvdmVcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig2LCBcInRvcFwiKTtcbiAgICBAaW5jbHVkZSBnb3Z1ay1yZXNwb25zaXZlLW1hcmdpbig2LCBcImJvdHRvbVwiKTtcblxuICAgIGNsZWFyOiBib3RoO1xuXG4gICAgYm9yZGVyLWxlZnQ6ICRnb3Z1ay1ib3JkZXItd2lkdGgtd2lkZSBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcblxuICAgIDpmaXJzdC1jaGlsZCB7XG4gICAgICBtYXJnaW4tdG9wOiAwO1xuICAgIH1cblxuICAgIDpvbmx5LWNoaWxkLFxuICAgIDpsYXN0LWNoaWxkIHtcbiAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgfVxuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC9wYW5lbFwiKSB7XG5cbiAgLmdvdnVrLXBhbmVsIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG5cbiAgICAtd2Via2l0LWJveC1zaXppbmc6IGJvcmRlci1ib3g7XG5cbiAgICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG5cbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDMpO1xuICAgIHBhZGRpbmc6IGdvdnVrLXNwYWNpbmcoNykgLSAkZ292dWstYm9yZGVyLXdpZHRoO1xuXG4gICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoIHNvbGlkIHRyYW5zcGFyZW50O1xuXG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuXG4gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJHVudGlsOiB0YWJsZXQpIHtcbiAgICAgIHBhZGRpbmc6IGdvdnVrLXNwYWNpbmcoNikgLSAkZ292dWstYm9yZGVyLXdpZHRoO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1wYW5lbC0tY29uZmlybWF0aW9uIHtcbiAgICBjb2xvcjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG4gICAgYmFja2dyb3VuZDogZ292dWstY29sb3VyKFwidHVycXVvaXNlXCIpO1xuICB9XG5cbiAgLmdvdnVrLXBhbmVsX190aXRsZSB7XG4gICAgbWFyZ2luLXRvcDogMDtcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDYpO1xuXG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogNDgsICR3ZWlnaHQ6IGJvbGQpO1xuICB9XG5cbiAgLmdvdnVrLXBhbmVsX190aXRsZTpsYXN0LWNoaWxkIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICB9XG5cbiAgLmdvdnVrLXBhbmVsX19ib2R5IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAzNik7XG4gIH1cblxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbXBvcnQgXCIuLi90YWcvdGFnXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvcGhhc2UtYmFubmVyXCIpIHtcbiAgLmdvdnVrLXBoYXNlLWJhbm5lciB7XG4gICAgcGFkZGluZy10b3A6IGdvdnVrLXNwYWNpbmcoMik7XG4gICAgcGFkZGluZy1ib3R0b206IGdvdnVrLXNwYWNpbmcoMik7XG5cbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gIH1cblxuICAuZ292dWstcGhhc2UtYmFubmVyX19jb250ZW50IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxNik7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG5cbiAgICBkaXNwbGF5OiB0YWJsZTtcbiAgICBtYXJnaW46IDA7XG4gIH1cblxuICAuZ292dWstcGhhc2UtYmFubmVyX19jb250ZW50X190YWcge1xuICAgIG1hcmdpbi1yaWdodDogZ292dWstc3BhY2luZygyKTtcbiAgfVxuXG4gIC5nb3Z1ay1waGFzZS1iYW5uZXJfX3RleHQge1xuICAgIGRpc3BsYXk6IHRhYmxlLWNlbGw7XG4gICAgdmVydGljYWwtYWxpZ246IGJhc2VsaW5lO1xuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC90YWdcIikge1xuICAuZ292dWstdGFnIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxNiwgJHdlaWdodDogYm9sZCwgJGxpbmUtaGVpZ2h0OiAxLjI1KTtcblxuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBwYWRkaW5nOiA0cHggOHB4O1xuICAgIC8vIFNpbmNlIE5ldyBUcmFuc3BvcnQgc2l0cyBzbGlnaHRseSBoaWdoZXIgdGhhbiBvdGhlciBjb21tb24gZm9udHMuXG4gICAgLy8gV2UgdXNlIGludGVudGlvbmFsbHkgdW5ldmVuIHBhZGRpbmcgdG8gbWFrZSBpdCBiYWxhbmNlZCwgdGhpcyBjYW4gYmVcbiAgICAvLyByZW1vdmVkIHVzaW5nIHRoZSB2ZXJzaW9uIG9mIHRoZSBmb250IHRoYXQgaGFzIGEgbW9yZSBjb21tb24gdmVydGljYWwgc3BhY2luZy5cbiAgICBwYWRkaW5nLWJvdHRvbTogMXB4O1xuXG4gICAgLy8gV2hlbiBhIHVzZXIgY3VzdG9taXNlcyB0aGVpciBjb2xvdXJzIG9mdGVuIHRoZSBiYWNrZ3JvdW5kIGlzIHJlbW92ZWQsXG4gICAgLy8gYnkgYWRkaW5nIGEgb3V0bGluZSB3ZSBlbnN1cmUgdGhhdCB0aGUgdGFnIGNvbXBvbmVudCBzdGlsbCBrZWVwcyBpdCdzIG1lYW5pbmcuXG4gICAgLy8gaHR0cHM6Ly9hY2Nlc3NpYmlsaXR5LmJsb2cuZ292LnVrLzIwMTcvMDMvMjcvaG93LXVzZXJzLWNoYW5nZS1jb2xvdXJzLW9uLXdlYnNpdGVzL1xuICAgIG91dGxpbmU6IDJweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgICBvdXRsaW5lLW9mZnNldDogLTJweDtcblxuICAgIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJibHVlXCIpO1xuICAgIGxldHRlci1zcGFjaW5nOiAxcHg7XG5cbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgdGV4dC10cmFuc2Zvcm06IHVwcGVyY2FzZTtcbiAgfVxuXG4gIC5nb3Z1ay10YWctLWluYWN0aXZlIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJncmV5LTFcIik7XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L3RhYnNcIikge1xuXG4gIC5nb3Z1ay10YWJzIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oMSwgXCJ0b3BcIik7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNiwgXCJib3R0b21cIik7XG4gIH1cblxuICAuZ292dWstdGFic19fdGl0bGUge1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDEpO1xuICB9XG5cbiAgLmdvdnVrLXRhYnNfX2xpc3Qge1xuICAgIG1hcmdpbjogMDtcbiAgICBwYWRkaW5nOiAwO1xuICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgQGluY2x1ZGUgbXEoJHVudGlsOiB0YWJsZXQpIHtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDYsIFwiYm90dG9tXCIpO1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay10YWJzX19saXN0LWl0ZW0ge1xuICAgIG1hcmdpbi1sZWZ0OiBnb3Z1ay1zcGFjaW5nKDUpO1xuXG4gICAgJjo6YmVmb3JlIHtcbiAgICAgIGNvbnRlbnQ6IFwi4oCUIFwiO1xuICAgICAgbWFyZ2luLWxlZnQ6IC0gZ292dWstc3BhY2luZyg1KTtcbiAgICAgIHBhZGRpbmctcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMSk7XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLXRhYnNfX3RhYiB7XG4gICAgQGluY2x1ZGUgZ292dWstbGluay1jb21tb247XG4gICAgQGluY2x1ZGUgZ292dWstbGluay1zdHlsZS1kZWZhdWx0O1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcblxuICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICBwYWRkaW5nLXRvcDogZ292dWstc3BhY2luZygyKTtcbiAgICBwYWRkaW5nLWJvdHRvbTogZ292dWstc3BhY2luZygyKTtcblxuICAgICZbYXJpYS1jdXJyZW50ID0gXCJ0cnVlXCJdIHtcbiAgICAgIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICB9XG4gIH1cblxuICAuZ292dWstdGFic19fcGFuZWwge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDgsIFwiYm90dG9tXCIpO1xuICB9XG5cbiAgLy8gSmF2YVNjcmlwdCBlbmFibGVkXG4gIC5qcy1lbmFibGVkIHtcblxuICAgIEBpbmNsdWRlIG1xKCRmcm9tOiB0YWJsZXQpIHtcblxuICAgICAgLmdvdnVrLXRhYnNfX2xpc3Qge1xuICAgICAgICBAaW5jbHVkZSBnb3Z1ay1jbGVhcmZpeDtcbiAgICAgICAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkICRnb3Z1ay1ib3JkZXItY29sb3VyO1xuICAgICAgfVxuXG4gICAgICAuZ292dWstdGFic19fbGlzdC1pdGVtIHtcbiAgICAgICAgbWFyZ2luLWxlZnQ6IDA7XG5cbiAgICAgICAgJjo6YmVmb3JlIHtcbiAgICAgICAgICBjb250ZW50OiBub25lO1xuICAgICAgICB9XG4gICAgICB9XG5cbiAgICAgIC5nb3Z1ay10YWJzX190aXRsZSB7XG4gICAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgICB9XG5cbiAgICAgIC5nb3Z1ay10YWJzX190YWIge1xuICAgICAgICBtYXJnaW4tcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMSk7XG4gICAgICAgIHBhZGRpbmctcmlnaHQ6IGdvdnVrLXNwYWNpbmcoNCk7XG4gICAgICAgIHBhZGRpbmctbGVmdDogZ292dWstc3BhY2luZyg0KTtcbiAgICAgICAgZmxvYXQ6IGxlZnQ7XG4gICAgICAgIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwiZ3JleS00XCIpO1xuICAgICAgICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gICAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcblxuICAgICAgICAmW2FyaWEtc2VsZWN0ZWQ9IFwidHJ1ZVwiXSB7XG4gICAgICAgICAgbWFyZ2luLXRvcDogLSBnb3Z1ay1zcGFjaW5nKDEpO1xuICAgICAgICAgIG1hcmdpbi1ib3R0b206IC0xcHg7XG5cbiAgICAgICAgICAvLyAxcHggaXMgY29tcGVuc2F0aW9uIGZvciBib3JkZXIgKG90aGVyd2lzZSB3ZSBnZXQgYSAxcHggc2hpZnQpXG4gICAgICAgICAgcGFkZGluZy10b3A6IGdvdnVrLXNwYWNpbmcoMykgLSAxcHg7XG4gICAgICAgICAgcGFkZGluZy1yaWdodDogZ292dWstc3BhY2luZyg0KSAtIDFweDtcbiAgICAgICAgICBwYWRkaW5nLWJvdHRvbTogZ292dWstc3BhY2luZygzKSArIDFweDtcbiAgICAgICAgICBwYWRkaW5nLWxlZnQ6IGdvdnVrLXNwYWNpbmcoNCkgLSAxcHg7XG5cbiAgICAgICAgICBib3JkZXI6IDFweCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbiAgICAgICAgICBib3JkZXItYm90dG9tOiAwO1xuICAgICAgICAgIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgICAgICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcblxuICAgICAgICAgICY6Zm9jdXMge1xuICAgICAgICAgICAgYmFja2dyb3VuZC1jb2xvcjogdHJhbnNwYXJlbnQ7XG4gICAgICAgICAgfVxuICAgICAgICB9XG4gICAgICB9XG5cbiAgICAgIC5nb3Z1ay10YWJzX19wYW5lbCB7XG4gICAgICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDAsIFwiYm90dG9tXCIpO1xuICAgICAgICBwYWRkaW5nLXRvcDogZ292dWstc3BhY2luZyg2KTtcbiAgICAgICAgcGFkZGluZy1yaWdodDogZ292dWstc3BhY2luZyg0KTtcbiAgICAgICAgcGFkZGluZy1ib3R0b206IGdvdnVrLXNwYWNpbmcoNik7XG4gICAgICAgIHBhZGRpbmctbGVmdDogZ292dWstc3BhY2luZyg0KTtcbiAgICAgICAgYm9yZGVyOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gICAgICAgIGJvcmRlci10b3A6IDA7XG5cbiAgICAgICAgJi0taGlkZGVuIHtcbiAgICAgICAgICBkaXNwbGF5OiBub25lO1xuICAgICAgICB9XG5cbiAgICAgICAgJiA+IDpsYXN0LWNoaWxkIHtcbiAgICAgICAgICBtYXJnaW4tYm90dG9tOiAwO1xuICAgICAgICB9XG4gICAgICB9XG4gICAgfVxuXG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW1wb3J0IFwiLi4vZXJyb3ItbWVzc2FnZS9lcnJvci1tZXNzYWdlXCI7XG5AaW1wb3J0IFwiLi4vZmllbGRzZXQvZmllbGRzZXRcIjtcbkBpbXBvcnQgXCIuLi9oaW50L2hpbnRcIjtcbkBpbXBvcnQgXCIuLi9sYWJlbC9sYWJlbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L3JhZGlvc1wiKSB7XG4gICRnb3Z1ay1yYWRpb3Mtc2l6ZTogZ292dWstc3BhY2luZyg3KTtcbiAgJGdvdnVrLXJhZGlvcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQ6IGdvdnVrLXNwYWNpbmcoMyk7XG4gIC8vIFdoZW4gdGhlIGRlZmF1bHQgZm9jdXMgd2lkdGggaXMgdXNlZCBvbiBhIGN1cnZlZCBlZGdlIGl0IGxvb2tzIHZpc3VhbGx5IHNtYWxsZXIuXG4gIC8vIFNvIGZvciB0aGUgY2lyY3VsYXIgcmFkaW9zIHdlIGJ1bXAgdGhlIGRlZmF1bHQgdG8gbWFrZSBpdCBsb29rIHZpc3VhbGx5IGNvbnNpc3RlbnQuXG4gICRnb3Z1ay1yYWRpb3MtZm9jdXMtd2lkdGg6ICRnb3Z1ay1mb2N1cy13aWR0aCArIDFweDtcblxuICAuZ292dWstcmFkaW9zX19pdGVtIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG5cbiAgICBkaXNwbGF5OiBibG9jaztcblxuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcblxuICAgIG1pbi1oZWlnaHQ6ICRnb3Z1ay1yYWRpb3Mtc2l6ZTtcblxuICAgIG1hcmdpbi1ib3R0b206IGdvdnVrLXNwYWNpbmcoMik7XG4gICAgcGFkZGluZzogMCAwIDAgJGdvdnVrLXJhZGlvcy1zaXplO1xuXG4gICAgY2xlYXI6IGxlZnQ7XG4gIH1cblxuICAuZ292dWstcmFkaW9zX19pdGVtOmxhc3QtY2hpbGQsXG4gIC5nb3Z1ay1yYWRpb3NfX2l0ZW06bGFzdC1vZi10eXBlIHtcbiAgICBtYXJnaW4tYm90dG9tOiAwO1xuICB9XG5cbiAgLmdvdnVrLXJhZGlvc19faW5wdXQge1xuICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcblxuICAgIHotaW5kZXg6IDE7XG4gICAgdG9wOiAwO1xuICAgIGxlZnQ6IDA7XG5cbiAgICB3aWR0aDogJGdvdnVrLXJhZGlvcy1zaXplO1xuICAgIGhlaWdodDogJGdvdnVrLXJhZGlvcy1zaXplO1xuXG4gICAgY3Vyc29yOiBwb2ludGVyO1xuXG4gICAgLy8gSUU4IGRvZXNu4oCZdCBzdXBwb3J0IHBzZXVkb2VsZW1lbnRzLCBzbyB3ZSBkb27igJl0IHdhbnQgdG8gaGlkZSBuYXRpdmUgZWxlbWVudHMgdGhlcmUuIERvdWJsZSBjb2xvbnMgZ2V0IG9tbWl0ZWQgYnkgSUU4LlxuICAgIEBpbmNsdWRlIGdvdnVrLW5vdC1pZTgge1xuICAgICAgbWFyZ2luOiAwO1xuICAgICAgb3BhY2l0eTogMDtcbiAgICB9XG5cbiAgICAvLyBhZGQgZm9jdXMgb3V0bGluZSB0byBpbnB1dCBlbGVtZW50IGZvciBJRThcbiAgICBAaW5jbHVkZSBnb3Z1ay1pZi1pZTgge1xuICAgICAgJjpmb2N1cyB7XG4gICAgICAgIG91dGxpbmU6ICRnb3Z1ay1mb2N1cy13aWR0aCBzb2xpZCAkZ292dWstZm9jdXMtY29sb3VyO1xuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1yYWRpb3NfX2xhYmVsIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICBwYWRkaW5nOiA4cHggJGdvdnVrLXJhZGlvcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQgZ292dWstc3BhY2luZygxKTtcbiAgICBjdXJzb3I6IHBvaW50ZXI7XG4gICAgLy8gcmVtb3ZlIDMwMG1zIHBhdXNlIG9uIG1vYmlsZVxuICAgIC1tcy10b3VjaC1hY3Rpb246IG1hbmlwdWxhdGlvbjtcbiAgICB0b3VjaC1hY3Rpb246IG1hbmlwdWxhdGlvbjtcbiAgfVxuXG4gIC5nb3Z1ay1yYWRpb3NfX2hpbnQge1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIHBhZGRpbmctcmlnaHQ6ICRnb3Z1ay1yYWRpb3MtbGFiZWwtcGFkZGluZy1sZWZ0LXJpZ2h0O1xuICAgIHBhZGRpbmctbGVmdDogJGdvdnVrLXJhZGlvcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQ7XG4gIH1cblxuICAuZ292dWstcmFkaW9zX19pbnB1dCArIC5nb3Z1ay1yYWRpb3NfX2xhYmVsOjpiZWZvcmUge1xuICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICAgICAgICAgICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgdG9wOiAwO1xuICAgIGxlZnQ6IDA7XG5cbiAgICB3aWR0aDogJGdvdnVrLXJhZGlvcy1zaXplO1xuICAgIGhlaWdodDogJGdvdnVrLXJhZGlvcy1zaXplO1xuXG4gICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudCBzb2xpZCBjdXJyZW50Q29sb3I7XG4gICAgYm9yZGVyLXJhZGl1czogNTAlO1xuICAgIGJhY2tncm91bmQ6IHRyYW5zcGFyZW50O1xuICB9XG5cbiAgLmdvdnVrLXJhZGlvc19faW5wdXQgKyAuZ292dWstcmFkaW9zX19sYWJlbDo6YWZ0ZXIge1xuICAgIGNvbnRlbnQ6IFwiXCI7XG5cbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgdG9wOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAgIGxlZnQ6IGdvdnVrLXNwYWNpbmcoMik7XG5cbiAgICB3aWR0aDogMDtcbiAgICBoZWlnaHQ6IDA7XG5cbiAgICBib3JkZXI6IGdvdnVrLXNwYWNpbmcoMikgc29saWQgY3VycmVudENvbG9yO1xuICAgIGJvcmRlci1yYWRpdXM6IDUwJTtcbiAgICBvcGFjaXR5OiAwO1xuICAgIGJhY2tncm91bmQ6IGN1cnJlbnRDb2xvcjtcbiAgfVxuXG4gIC8vIEZvY3VzZWQgc3RhdGVcbiAgLmdvdnVrLXJhZGlvc19faW5wdXQ6Zm9jdXMgKyAuZ292dWstcmFkaW9zX19sYWJlbDo6YmVmb3JlIHtcbiAgICAvLyBTaW5jZSBib3gtc2hhZG93cyBhcmUgcmVtb3ZlZCB3aGVuIHVzZXJzIGN1c3RvbWlzZSB0aGVpciBjb2xvdXJzXG4gICAgLy8gV2Ugc2V0IGEgdHJhbnNwYXJlbnQgb3V0bGluZSB0aGF0IGlzIHNob3duIGluc3RlYWQuXG4gICAgLy8gaHR0cHM6Ly9hY2Nlc3NpYmlsaXR5LmJsb2cuZ292LnVrLzIwMTcvMDMvMjcvaG93LXVzZXJzLWNoYW5nZS1jb2xvdXJzLW9uLXdlYnNpdGVzL1xuICAgIG91dGxpbmU6ICRnb3Z1ay1mb2N1cy13aWR0aCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgICBvdXRsaW5lLW9mZnNldDogJGdvdnVrLWZvY3VzLXdpZHRoO1xuICAgIC13ZWJraXQtYm94LXNoYWRvdzogMCAwIDAgJGdvdnVrLXJhZGlvcy1mb2N1cy13aWR0aCAkZ292dWstZm9jdXMtY29sb3VyO1xuICAgICAgICAgICAgYm94LXNoYWRvdzogMCAwIDAgJGdvdnVrLXJhZGlvcy1mb2N1cy13aWR0aCAkZ292dWstZm9jdXMtY29sb3VyO1xuICB9XG5cbiAgLy8gU2VsZWN0ZWQgc3RhdGVcbiAgLmdvdnVrLXJhZGlvc19faW5wdXQ6Y2hlY2tlZCArIC5nb3Z1ay1yYWRpb3NfX2xhYmVsOjphZnRlciB7XG4gICAgb3BhY2l0eTogMTtcbiAgfVxuXG4gIC8vIERpc2FibGVkIHN0YXRlXG4gIC5nb3Z1ay1yYWRpb3NfX2lucHV0OmRpc2FibGVkLFxuICAuZ292dWstcmFkaW9zX19pbnB1dDpkaXNhYmxlZCArIC5nb3Z1ay1yYWRpb3NfX2xhYmVsIHtcbiAgICBjdXJzb3I6IGRlZmF1bHQ7XG4gIH1cblxuICAuZ292dWstcmFkaW9zX19pbnB1dDpkaXNhYmxlZCArIC5nb3Z1ay1yYWRpb3NfX2xhYmVsIHtcbiAgICBvcGFjaXR5OiAuNTtcbiAgfVxuXG4gIC8vIElubGluZSB2YXJpYW50XG4gIC5nb3Z1ay1yYWRpb3MtLWlubGluZSB7XG4gICAgQGluY2x1ZGUgbXEgKCRmcm9tOiB0YWJsZXQpIHtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLWNsZWFyZml4O1xuXG4gICAgICAuZ292dWstcmFkaW9zX19pdGVtIHtcbiAgICAgICAgbWFyZ2luLXJpZ2h0OiBnb3Z1ay1zcGFjaW5nKDQpO1xuICAgICAgICBmbG9hdDogbGVmdDtcbiAgICAgICAgY2xlYXI6IG5vbmU7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLXJhZGlvc19fZGl2aWRlciB7XG4gICAgJGdvdnVrLWRpdmlkZXItc2l6ZTogJGdvdnVrLXJhZGlvcy1zaXplICFkZWZhdWx0O1xuICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcbiAgICB3aWR0aDogJGdvdnVrLWRpdmlkZXItc2l6ZTtcbiAgICBtYXJnaW4tYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgfVxuXG4gICRjb25kaXRpb25hbC1ib3JkZXItd2lkdGg6ICRnb3Z1ay1ib3JkZXItd2lkdGgtbW9iaWxlO1xuICAvLyBDYWxjdWxhdGUgdGhlIGFtb3VudCBvZiBwYWRkaW5nIG5lZWRlZCB0byBrZWVwIHRoZSBib3JkZXIgY2VudGVyZWQgYWdhaW5zdCB0aGUgcmFkaW9zLlxuICAkY29uZGl0aW9uYWwtYm9yZGVyLXBhZGRpbmc6ICgkZ292dWstcmFkaW9zLXNpemUgLyAyKSAtICgkY29uZGl0aW9uYWwtYm9yZGVyLXdpZHRoIC8gMik7XG4gIC8vIE1vdmUgdGhlIGJvcmRlciBjZW50ZXJlZCB3aXRoIHRoZSByYWRpb3NcbiAgJGNvbmRpdGlvbmFsLW1hcmdpbi1sZWZ0OiAkY29uZGl0aW9uYWwtYm9yZGVyLXBhZGRpbmc7XG4gIC8vIE1vdmUgdGhlIGNvbnRlbnRzIG9mIHRoZSBjb25kaXRpb25hbCBpbmxpbmUgd2l0aCB0aGUgbGFiZWxcbiAgJGNvbmRpdGlvbmFsLXBhZGRpbmctbGVmdDogJGNvbmRpdGlvbmFsLWJvcmRlci1wYWRkaW5nICsgJGdvdnVrLXJhZGlvcy1sYWJlbC1wYWRkaW5nLWxlZnQtcmlnaHQ7XG5cbiAgLmdvdnVrLXJhZGlvc19fY29uZGl0aW9uYWwge1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDQsIFwiYm90dG9tXCIpO1xuICAgIG1hcmdpbi1sZWZ0OiAkY29uZGl0aW9uYWwtbWFyZ2luLWxlZnQ7XG4gICAgcGFkZGluZy1sZWZ0OiAkY29uZGl0aW9uYWwtcGFkZGluZy1sZWZ0O1xuICAgIGJvcmRlci1sZWZ0OiAkY29uZGl0aW9uYWwtYm9yZGVyLXdpZHRoIHNvbGlkICRnb3Z1ay1ib3JkZXItY29sb3VyO1xuXG4gICAgLmpzLWVuYWJsZWQgJi0taGlkZGVuIHtcbiAgICAgIGRpc3BsYXk6IG5vbmU7XG4gICAgfVxuXG4gICAgJiA+IDpsYXN0LWNoaWxkIHtcbiAgICAgIG1hcmdpbi1ib3R0b206IDA7XG4gICAgfVxuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGltcG9ydCBcIi4uL2Vycm9yLW1lc3NhZ2UvZXJyb3ItbWVzc2FnZVwiO1xuQGltcG9ydCBcIi4uL2hpbnQvaGludFwiO1xuQGltcG9ydCBcIi4uL2xhYmVsL2xhYmVsXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvc2VsZWN0XCIpIHtcbiAgLmdvdnVrLXNlbGVjdCB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTksICRsaW5lLWhlaWdodDogMS4yNSk7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlO1xuXG4gICAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuXG4gICAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94OyAvLyBzaG91bGQgdGhpcyBiZSBnbG9iYWw/XG4gICAgd2lkdGg6IDEwMCU7XG4gICAgaGVpZ2h0OiA0MHB4O1xuXG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygxKTsgLy8gd2FzIDVweCA0cHggNHB4IC0gc2l6ZSBvZiBpdCBzaG91bGQgYmUgYWRqdXN0ZWQgdG8gbWF0Y2ggb3RoZXIgZm9ybSBlbGVtZW50c1xuICAgIGJvcmRlcjogJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQgc29saWQgJGdvdnVrLWlucHV0LWJvcmRlci1jb2xvdXI7XG4gIH1cblxuICAuZ292dWstc2VsZWN0IG9wdGlvbjphY3RpdmUsXG4gIC5nb3Z1ay1zZWxlY3Qgb3B0aW9uOmNoZWNrZWQsXG4gIC5nb3Z1ay1zZWxlY3Q6Zm9jdXM6Oi1tcy12YWx1ZSB7XG4gICAgY29sb3I6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICAgIGJhY2tncm91bmQtY29sb3I6IGdvdnVrLWNvbG91cihcImJsdWVcIik7XG4gIH1cblxuICAuZ292dWstc2VsZWN0LS1lcnJvciB7XG4gICAgYm9yZGVyOiAkZ292dWstYm9yZGVyLXdpZHRoLWZvcm0tZWxlbWVudC1lcnJvciBzb2xpZCAkZ292dWstZXJyb3ItY29sb3VyO1xuICB9XG5cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvY29tcG9uZW50L3NraXAtbGlua1wiKSB7XG4gIC5nb3Z1ay1za2lwLWxpbmsge1xuICAgIEBpbmNsdWRlIGdvdnVrLXZpc3VhbGx5LWhpZGRlbi1mb2N1c2FibGU7XG4gICAgQGluY2x1ZGUgZ292dWstbGluay1jb21tb247XG4gICAgQGluY2x1ZGUgZ292dWstbGluay1zdHlsZS10ZXh0O1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktcmVzcG9uc2l2ZSgkc2l6ZTogMTYpO1xuXG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygyKSBnb3Z1ay1zcGFjaW5nKDMpO1xuICB9XG59XG4iLCJAaW1wb3J0IFwiLi4vLi4vc2V0dGluZ3MvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vdG9vbHMvYWxsXCI7XG5AaW1wb3J0IFwiLi4vLi4vaGVscGVycy9hbGxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC90YWJsZVwiKSB7XG4gIC5nb3Z1ay10YWJsZSB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTkpO1xuICAgIEBpbmNsdWRlIGdvdnVrLXRleHQtY29sb3VyO1xuICAgIHdpZHRoOiAxMDAlO1xuICAgIEBpbmNsdWRlIGdvdnVrLXJlc3BvbnNpdmUtbWFyZ2luKDYsIFwiYm90dG9tXCIpO1xuXG4gICAgYm9yZGVyLXNwYWNpbmc6IDA7XG4gICAgYm9yZGVyLWNvbGxhcHNlOiBjb2xsYXBzZTtcbiAgfVxuXG4gIC5nb3Z1ay10YWJsZV9faGVhZGVyIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay10eXBvZ3JhcGh5LXdlaWdodC1ib2xkO1xuXG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygyKSBnb3Z1ay1zcGFjaW5nKDQpIGdvdnVrLXNwYWNpbmcoMikgMDtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgfVxuXG4gIC5nb3Z1ay10YWJsZV9fY2VsbCB7XG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygyKSBnb3Z1ay1zcGFjaW5nKDQpIGdvdnVrLXNwYWNpbmcoMikgMDtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgfVxuXG4gIC5nb3Z1ay10YWJsZV9fY2VsbC0tbnVtZXJpYyB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogZmFsc2UsICR0YWJ1bGFyOiB0cnVlKTtcbiAgfVxuXG4gIC5nb3Z1ay10YWJsZV9faGVhZGVyLS1udW1lcmljLFxuICAuZ292dWstdGFibGVfX2NlbGwtLW51bWVyaWMge1xuICAgIHRleHQtYWxpZ246IHJpZ2h0O1xuICB9XG5cbiAgLmdvdnVrLXRhYmxlX19oZWFkZXI6bGFzdC1jaGlsZCxcbiAgLmdvdnVrLXRhYmxlX19jZWxsOmxhc3QtY2hpbGQge1xuICAgIHBhZGRpbmctcmlnaHQ6IDA7XG4gIH1cblxuICAuZ292dWstdGFibGVfX2NhcHRpb24ge1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktd2VpZ2h0LWJvbGQ7XG5cbiAgICBkaXNwbGF5OiB0YWJsZS1jYXB0aW9uO1xuICAgIHRleHQtYWxpZ246IGxlZnQ7XG4gIH1cbn1cbiIsIkBpbXBvcnQgXCIuLi8uLi9zZXR0aW5ncy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi90b29scy9hbGxcIjtcbkBpbXBvcnQgXCIuLi8uLi9oZWxwZXJzL2FsbFwiO1xuXG5AaW1wb3J0IFwiLi4vZXJyb3ItbWVzc2FnZS9lcnJvci1tZXNzYWdlXCI7XG5AaW1wb3J0IFwiLi4vaGludC9oaW50XCI7XG5AaW1wb3J0IFwiLi4vbGFiZWwvbGFiZWxcIjtcblxuQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL2NvbXBvbmVudC90ZXh0YXJlYVwiKSB7XG4gIC5nb3Z1ay10ZXh0YXJlYSB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTksICRsaW5lLWhlaWdodDogMS4yNSk7XG4gICAgQGluY2x1ZGUgZ292dWstZm9jdXNhYmxlO1xuXG4gICAgLXdlYmtpdC1ib3gtc2l6aW5nOiBib3JkZXItYm94O1xuXG4gICAgICAgICAgICBib3gtc2l6aW5nOiBib3JkZXItYm94OyAvLyBzaG91bGQgdGhpcyBiZSBnbG9iYWw/XG4gICAgZGlzcGxheTogYmxvY2s7XG4gICAgd2lkdGg6IDEwMCU7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNiwgXCJib3R0b21cIik7XG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygxKTtcblxuICAgIGJvcmRlcjogJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQgc29saWQgJGdvdnVrLWlucHV0LWJvcmRlci1jb2xvdXI7XG4gICAgYm9yZGVyLXJhZGl1czogMDtcblxuICAgIC13ZWJraXQtYXBwZWFyYW5jZTogbm9uZTtcbiAgfVxuXG4gIC5nb3Z1ay10ZXh0YXJlYS0tZXJyb3Ige1xuICAgIGJvcmRlcjogJGdvdnVrLWJvcmRlci13aWR0aC1mb3JtLWVsZW1lbnQtZXJyb3Igc29saWQgJGdvdnVrLWVycm9yLWNvbG91cjtcbiAgfVxufVxuIiwiQGltcG9ydCBcIi4uLy4uL3NldHRpbmdzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL3Rvb2xzL2FsbFwiO1xuQGltcG9ydCBcIi4uLy4uL2hlbHBlcnMvYWxsXCI7XG5cbkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9jb21wb25lbnQvd2FybmluZy10ZXh0XCIpIHtcblxuICAuZ292dWstd2FybmluZy10ZXh0IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAxOSk7XG4gICAgQGluY2x1ZGUgZ292dWstdGV4dC1jb2xvdXI7XG5cbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgQGluY2x1ZGUgZ292dWstcmVzcG9uc2l2ZS1tYXJnaW4oNiwgXCJib3R0b21cIik7XG4gICAgcGFkZGluZzogZ292dWstc3BhY2luZygyKSAwO1xuICB9XG5cbiAgLmdvdnVrLXdhcm5pbmctdGV4dF9fYXNzaXN0aXZlIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay12aXN1YWxseS1oaWRkZW47XG4gIH1cblxuICAuZ292dWstd2FybmluZy10ZXh0X19pY29uIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiBmYWxzZSwgJHdlaWdodDogYm9sZCk7XG5cbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG5cbiAgICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gICAgdG9wOiA1MCU7XG4gICAgbGVmdDogMDtcblxuICAgIG1pbi13aWR0aDogMzJweDtcbiAgICBtaW4taGVpZ2h0OiAyOXB4O1xuICAgIG1hcmdpbi10b3A6IC0yMHB4OyAvLyBIYWxmIHRoZSBoZWlnaHQgb2YgdGhlIGNpcmNsZSAoYWRqdXN0ZWQgZm9yIE5UQSlcbiAgICBwYWRkaW5nLXRvcDogM3B4O1xuXG4gICAgLy8gV2hlbiBhIHVzZXIgY3VzdG9taXNlcyB0aGVpciBjb2xvdXJzIHRoZSBiYWNrZ3JvdW5kIGNvbG91ciB3aWxsIG9mdGVuIGJlIHJlbW92ZWQuXG4gICAgLy8gQWRkaW5nIGEgYm9yZGVyIHRvIHRoZSBjb21wb25lbnQga2VlcHMgaXQncyBzaGFwZSBhcyBhIGNpcmNsZS5cbiAgICBib3JkZXI6IDNweCBzb2xpZCBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgICBib3JkZXItcmFkaXVzOiA1MCU7XG5cbiAgICBjb2xvcjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG4gICAgYmFja2dyb3VuZDogZ292dWstY29sb3VyKFwiYmxhY2tcIik7XG5cbiAgICBmb250LXNpemU6IDEuNmVtO1xuICAgIGxpbmUtaGVpZ2h0OiAyOXB4O1xuXG4gICAgdGV4dC1hbGlnbjogY2VudGVyO1xuXG4gICAgLy8gUHJldmVudCB0aGUgZXhjbGFtYXRpb24gbWFyayBmcm9tIGJlaW5nIGluY2x1ZGVkIHdoZW4gdGhlIHdhcm5pbmcgdGV4dFxuICAgIC8vIGlzIGNvcGllZCwgZm9yIGV4YW1wbGUuXG4gICAgLXdlYmtpdC11c2VyLXNlbGVjdDogbm9uZTtcbiAgICAgICAtbW96LXVzZXItc2VsZWN0OiBub25lO1xuICAgICAgICAtbXMtdXNlci1zZWxlY3Q6IG5vbmU7XG4gICAgICAgICAgICB1c2VyLXNlbGVjdDogbm9uZTtcbiAgfVxuXG4gIC5nb3Z1ay13YXJuaW5nLXRleHRfX3RleHQge1xuICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIG1hcmdpbi1sZWZ0OiAtJGdvdnVrLWd1dHRlci1oYWxmO1xuICAgIHBhZGRpbmctbGVmdDogNjVweDtcbiAgfVxufVxuIiwiQGltcG9ydCBcImNsZWFyZml4XCI7XG5AaW1wb3J0IFwidmlzdWFsbHktaGlkZGVuXCI7XG4iLCJAaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvdXRpbGl0aWVzL2NsZWFyZml4XCIpIHtcbiAgLmdvdnVrLWNsZWFyZml4IHtcbiAgICBAaW5jbHVkZSBnb3Z1ay1jbGVhcmZpeDtcbiAgfVxufVxuIiwiQGluY2x1ZGUgZ292dWstZXhwb3J0cyhcImdvdnVrL3V0aWxpdGllcy92aXN1YWxseS1oaWRkZW5cIikge1xuICAuZ292dWstdmlzdWFsbHktaGlkZGVuIHtcbiAgICBAaW5jbHVkZSBnb3Z1ay12aXN1YWxseS1oaWRkZW47XG4gIH1cblxuICAvLy8gQGRlcHJlY2F0ZWQgRGVwcmVjYXRlZCBhcyBvZiByZWxlYXNlIDEuMSwgcmVwbGFjZWQgYnkgYC5nb3Z1ay12aXN1YWxseS1oaWRkZW4tZm9jdXNhYmxlYFxuICAuZ292dWstdmlzdWFsbHktaGlkZGVuLWZvY3Vzc2FibGUge1xuICAgIEBpbmNsdWRlIGdvdnVrLXZpc3VhbGx5LWhpZGRlbi1mb2N1c2FibGU7XG4gIH1cblxuICAuZ292dWstdmlzdWFsbHktaGlkZGVuLWZvY3VzYWJsZSB7XG4gICAgQGluY2x1ZGUgZ292dWstdmlzdWFsbHktaGlkZGVuLWZvY3VzYWJsZTtcbiAgfVxuXG59XG4iLCJAaW1wb3J0IFwiZGlzcGxheVwiO1xuQGltcG9ydCBcInNwYWNpbmdcIjtcbkBpbXBvcnQgXCJ0eXBvZ3JhcGh5XCI7XG5AaW1wb3J0IFwid2lkdGhcIjtcbiIsIkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9vdmVycmlkZXMvZGlzcGxheVwiKSB7XG5cbiAgLmdvdnVrLVxcIS1kaXNwbGF5LWlubGluZSB7XG4gICAgZGlzcGxheTogaW5saW5lICFpbXBvcnRhbnQ7XG4gIH1cblxuICAuZ292dWstXFwhLWRpc3BsYXktaW5saW5lLWJsb2NrIHtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2sgIWltcG9ydGFudDtcbiAgfVxuXG4gIC5nb3Z1ay1cXCEtZGlzcGxheS1ibG9jayB7XG4gICAgZGlzcGxheTogYmxvY2sgIWltcG9ydGFudDtcbiAgfVxufVxuIiwiLy8vL1xuLy8vIEBncm91cCBvdmVycmlkZXNcbi8vLy9cblxuLy8vIERpcmVjdGlvbnMgZm9yIHNwYWNpbmdcbi8vL1xuLy8vIEB0eXBlIE1hcFxuLy8vIEBhY2Nlc3MgcHJpdmF0ZVxuXG4kX3NwYWNpbmctZGlyZWN0aW9uczogKFxuICBcInRvcFwiLFxuICBcInJpZ2h0XCIsXG4gIFwiYm90dG9tXCIsXG4gIFwibGVmdFwiXG4pICFkZWZhdWx0O1xuXG4vLy8gU3BhY2luZyBvdmVycmlkZSBjbGFzc2VzXG4vLy9cbi8vLyBHZW5lcmF0ZSBzcGFjaW5nIG92ZXJyaWRlIGNsYXNzZXMgZm9yIHRoZSBnaXZlbiBwcm9wZXJ0eSAoZS5nLiBtYXJnaW4pXG4vLy8gZm9yIGVhY2ggcG9pbnQgaW4gdGhlIHNwYWNpbmcgc2NhbGUuXG4vLy9cbi8vLyBAcGFyYW0ge1N0cmluZ30gJHByb3BlcnR5IC0gUHJvcGVydHkgdG8gYWRkIHNwYWNpbmcgdG8gKGUuZy4gJ21hcmdpbicpXG4vLy9cbi8vLyBAZXhhbXBsZSBzY3NzXG4vLy8gICAuZ292dWstXFwhLW1hcmdpbi0wIHtcbi8vLyAgICAgIG1hcmdpbjogMDtcbi8vLyAgIH1cbi8vL1xuLy8vICAuZ292dWstXFwhLW1hcmdpbi10b3AtMSB7XG4vLy8gICAgIG1hcmdpbi10b3A6IFt3aGF0ZXZlciBzcGFjaW5nIHBvaW50IDEgaXMuLi5dXG4vLy8gICB9XG4vLy9cbi8vLyBAYWNjZXNzIHByaXZhdGVcblxuQG1peGluIF9nb3Z1ay1nZW5lcmF0ZS1zcGFjaW5nLW92ZXJyaWRlcygkcHJvcGVydHkpIHtcbiAgLy8gRm9yIGVhY2ggcG9pbnQgaW4gdGhlIHNwYWNpbmcgc2NhbGUgKGRlZmluZWQgaW4gc2V0dGluZ3MpLCBjcmVhdGUgYW5cbiAgLy8gb3ZlcnJpZGUgdGhhdCBhZmZlY3RzIGFsbCBkaXJlY3Rpb25zLi4uXG4gIEBlYWNoICRzY2FsZS1wb2ludCwgJHNjYWxlLW1hcCBpbiAkZ292dWstc3BhY2luZy1yZXNwb25zaXZlLXNjYWxlIHtcblxuICAgIC5nb3Z1ay1cXCEtI3skcHJvcGVydHl9LSN7JHNjYWxlLXBvaW50fSB7XG5cbiAgICAgIEBpbmNsdWRlIF9nb3Z1ay1yZXNwb25zaXZlLXNwYWNpbmcoJHNjYWxlLXBvaW50LCAkcHJvcGVydHksIFwiYWxsXCIsIHRydWUpO1xuICAgIH1cblxuICAgIC8vIC4uLiBhbmQgdGhlbiBhbiBvdmVycmlkZSBmb3IgZWFjaCBpbmRpdmlkdWFsIGRpcmVjdGlvblxuICAgIEBlYWNoICRkaXJlY3Rpb24gaW4gJF9zcGFjaW5nLWRpcmVjdGlvbnMge1xuXG4gICAgICAuZ292dWstXFwhLSN7JHByb3BlcnR5fS0jeyRkaXJlY3Rpb259LSN7JHNjYWxlLXBvaW50fSB7XG4gICAgICAgIEBpbmNsdWRlIF9nb3Z1ay1yZXNwb25zaXZlLXNwYWNpbmcoJHNjYWxlLXBvaW50LCAkcHJvcGVydHksICRkaXJlY3Rpb24sIHRydWUpO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG5AaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvb3ZlcnJpZGVzL3NwYWNpbmdcIikge1xuICBAaW5jbHVkZSBfZ292dWstZ2VuZXJhdGUtc3BhY2luZy1vdmVycmlkZXMoXCJtYXJnaW5cIik7XG4gIEBpbmNsdWRlIF9nb3Z1ay1nZW5lcmF0ZS1zcGFjaW5nLW92ZXJyaWRlcyhcInBhZGRpbmdcIik7XG59XG4iLCJAaW5jbHVkZSBnb3Z1ay1leHBvcnRzKFwiZ292dWsvb3ZlcnJpZGVzL3R5cG9ncmFwaHlcIikge1xuICAvLyBGb250IHNpemUgYW5kIGxpbmUgaGVpZ2h0XG5cbiAgLy8gR2VuZXJhdGUgdHlwb2dyYXBoeSBvdmVycmlkZSBjbGFzc2VzIGZvciBlYWNoIHJlc3BvbnNpdmUgZm9udCBtYXAgaW4gdGhlXG4gIC8vIHR5cG9ncmFwaHkgc2NhbGUgZWcgLmdvdnVrLVxcIS1mb250LXNpemUtODBcbiAgQGVhY2ggJHNpemUgaW4gbWFwLWtleXMoJGdvdnVrLXR5cG9ncmFwaHktc2NhbGUpIHtcbiAgICAuZ292dWstXFwhLWZvbnQtc2l6ZS0jeyRzaXplfSB7XG4gICAgICBAaW5jbHVkZSBnb3Z1ay10eXBvZ3JhcGh5LXJlc3BvbnNpdmUoJHNpemUsICRpbXBvcnRhbnQ6IHRydWUpO1xuICAgIH1cbiAgfVxuXG4gIC8vIFdlaWdodHNcblxuICAuZ292dWstXFwhLWZvbnQtd2VpZ2h0LXJlZ3VsYXIge1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktd2VpZ2h0LXJlZ3VsYXIoJGltcG9ydGFudDogdHJ1ZSk7XG4gIH1cblxuICAuZ292dWstXFwhLWZvbnQtd2VpZ2h0LWJvbGQge1xuICAgIEBpbmNsdWRlIGdvdnVrLXR5cG9ncmFwaHktd2VpZ2h0LWJvbGQoJGltcG9ydGFudDogdHJ1ZSk7XG4gIH1cbn1cbiIsIkBpbmNsdWRlIGdvdnVrLWV4cG9ydHMoXCJnb3Z1ay9vdmVycmlkZXMvd2lkdGhcIikge1xuICAuZ292dWstXFwhLXdpZHRoLXRocmVlLXF1YXJ0ZXJzIHtcbiAgICB3aWR0aDogMTAwJSAhaW1wb3J0YW50O1xuXG4gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgICAgd2lkdGg6IDc1JSAhaW1wb3J0YW50O1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1cXCEtd2lkdGgtdHdvLXRoaXJkcyB7XG4gICAgd2lkdGg6IDEwMCUgIWltcG9ydGFudDtcblxuICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiB0YWJsZXQpIHtcbiAgICAgIHdpZHRoOiA2Ni42NiUgIWltcG9ydGFudDtcbiAgICB9XG4gIH1cblxuICAuZ292dWstXFwhLXdpZHRoLW9uZS1oYWxmIHtcbiAgICB3aWR0aDogMTAwJSAhaW1wb3J0YW50O1xuXG4gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgICAgd2lkdGg6IDUwJSAhaW1wb3J0YW50O1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1cXCEtd2lkdGgtb25lLXRoaXJkIHtcbiAgICB3aWR0aDogMTAwJSAhaW1wb3J0YW50O1xuXG4gICAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgICAgd2lkdGg6IDMzLjMzJSAhaW1wb3J0YW50O1xuICAgIH1cbiAgfVxuXG4gIC5nb3Z1ay1cXCEtd2lkdGgtb25lLXF1YXJ0ZXIge1xuICAgIHdpZHRoOiAxMDAlICFpbXBvcnRhbnQ7XG5cbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogdGFibGV0KSB7XG4gICAgICB3aWR0aDogMjUlICFpbXBvcnRhbnQ7XG4gICAgfVxuICB9XG59XG4iLCIvLyBSZWNvbW1lbmRlZCAtIFVzZSB0aGVzZSBzdHlsZXMgZm9yIHRoZSBjaGVjayB5b3VyIGFuc3dlcnMgcGF0dGVyblxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnMge1xuXG4gIEBpbmNsdWRlIGdvdnVrLWZvbnQoMTkpO1xuXG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiBkZXNrdG9wKSB7XG4gICAgZGlzcGxheTogdGFibGU7XG4gIH1cbn1cblxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnMtLXNob3J0IHtcbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IGRlc2t0b3ApIHtcbiAgICAvLyB0byBtYWtlIGdyb3VwIG9mIHEmYSBsaW5lIHVwIGhvcml6b250YWxseSAodW5sZXNzIHRoZXJlIGlzIGp1c3Qgb25lIGdyb3VwKVxuICAgIHdpZHRoOiAxMDAlO1xuICAgIC8vIHJlY29tbWVuZGVkIGZvciBtb3N0bHkgc2hvcnQgcXVlc3Rpb25zXG4gICAgLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX3F1ZXN0aW9uIHtcbiAgICAgIHdpZHRoOiAzMCU7XG4gICAgfVxuICB9XG59XG5cbi5hcHAtY2hlY2steW91ci1hbnN3ZXJzLS1sb25nIHtcbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IGRlc2t0b3ApIHtcbiAgICAvLyB0byBtYWtlIGdyb3VwIG9mIHEmYSBsaW5lIHVwIGhvcml6b250YWxseSAodW5sZXNzIHRoZXJlIGlzIGp1c3Qgb25lIGdyb3VwKVxuICAgIHdpZHRoOiAxMDAlO1xuICAgIC8vIHJlY29tbWVuZGVkIGZvciBtb3N0bHkgbG9uZyBxdWVzdGlvbnNcbiAgICAuYXBwLWNoZWNrLXlvdXItYW5zd2Vyc19fcXVlc3Rpb24ge1xuICAgICAgd2lkdGg6IDUwJTtcbiAgICB9XG4gIH1cbn1cblxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX2NvbnRlbnRzIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG5cbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IGRlc2t0b3ApIHtcbiAgICBkaXNwbGF5OiB0YWJsZS1yb3c7XG4gICAgYm9yZGVyLWJvdHRvbS13aWR0aDogMDtcbiAgfVxufVxuXG4uYXBwLWNoZWNrLXlvdXItYW5zd2Vyc19fY29udGVudHM6Zmlyc3QtY2hpbGQgLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX3F1ZXN0aW9uLFxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX2NvbnRlbnRzOmZpcnN0LWNoaWxkIC5hcHAtY2hlY2steW91ci1hbnN3ZXJzX19hbnN3ZXIsXG4uYXBwLWNoZWNrLXlvdXItYW5zd2Vyc19fY29udGVudHM6Zmlyc3QtY2hpbGQgLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX2NoYW5nZSB7XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiBkZXNrdG9wKSB7XG4gICAgcGFkZGluZy10b3A6IDA7XG4gIH1cbn1cblxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX3F1ZXN0aW9uLFxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX2Fuc3dlcixcbi5hcHAtY2hlY2steW91ci1hbnN3ZXJzX19jaGFuZ2Uge1xuICBkaXNwbGF5OiBibG9jaztcbiAgbWFyZ2luOiAwO1xuICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogZGVza3RvcCkge1xuICAgIGRpc3BsYXk6IHRhYmxlLWNlbGw7XG4gICAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkICRnb3Z1ay1ib3JkZXItY29sb3VyO1xuICAgIHBhZGRpbmc6IGdvdnVrLWVtKDEyLCAxOSkgZ292dWstZW0oMjAsIDE5KSBnb3Z1ay1lbSg5LCAxOSkgMDtcbiAgfVxufVxuXG4uYXBwLWNoZWNrLXlvdXItYW5zd2Vyc19fcXVlc3Rpb24ge1xuICBmb250LXdlaWdodDogYm9sZDtcbiAgbWFyZ2luOiBnb3Z1ay1lbSgxMiwgMTkpIDRlbSBnb3Z1ay1lbSg0LDE5KSAwO1xuICAvLyB1c2luZyBtYXJnaW4gaW5zdGVhZCBvZiBwYWRkaW5nIGJlY2F1c2Ugb2YgZWFzaWVyIGFic29sdXRlbHkgcG9zaXRpb25pbmcgb2YgLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX2NoYW5nZVxufVxuXG4uYXBwLWNoZWNrLXlvdXItYW5zd2Vyc19fYW5zd2VyIHtcbiAgcGFkZGluZy1ib3R0b206IGdvdnVrLWVtKDksIDE5KTtcbn1cblxuLmFwcC1jaGVjay15b3VyLWFuc3dlcnNfX2NoYW5nZSB7XG4gIHRleHQtYWxpZ246IHJpZ2h0O1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHRvcDogMDtcbiAgcmlnaHQ6IDA7XG5cbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IGRlc2t0b3ApIHtcbiAgICBwb3NpdGlvbjogc3RhdGljO1xuICAgIHBhZGRpbmctcmlnaHQ6IDA7XG4gIH1cbn1cbiIsIi8vIFRhc2sgbGlzdCBwYXR0ZXJuXG5cbi8vIE92ZXJyaWRlIGNvbHVtbiB3aWR0aCBmb3IgdGFibGV0IGFuZCB1cFxuLmFwcC1jb2x1bW4tbWluaW11bSB7XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCRmcm9tOiB0YWJsZXQpIHtcbiAgICBtaW4td2lkdGg6IDYwMHB4O1xuICB9XG59XG5cbi8vIFNwYWNpbmcgdG8gdGhlIGxlZnQgb2YgdGhlIHRhc2sgbGlzdFxuJHRhc2stbGlzdC1pbmRlbnQ6IDM1cHg7XG5cbi5hcHAtdGFzay1saXN0IHtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgcGFkZGluZzogMDtcbiAgbWFyZ2luLXRvcDogJGdvdnVrLWd1dHRlcjtcbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgIG1hcmdpbi10b3A6ICgkZ292dWstZ3V0dGVyICogMik7XG4gIH1cbn1cblxuLmFwcC10YXNrLWxpc3RfX3NlY3Rpb24ge1xuICBkaXNwbGF5OiB0YWJsZTtcblxuICBAaW5jbHVkZSBnb3Z1ay1mb250KDI0LCAkd2VpZ2h0OiBib2xkKTtcbiAgbWFyZ2luOiAwO1xuICBwYWRkaW5nLWJvdHRvbTogKCRnb3Z1ay1ndXR0ZXIgLyA2KTtcbn1cblxuLmFwcC10YXNrLWxpc3RfX3NlY3Rpb24tbnVtYmVyIHtcbiAgZGlzcGxheTogdGFibGUtY2VsbDtcbiAgcGFkZGluZy1yaWdodDogKCRnb3Z1ay1ndXR0ZXIgLyA2KTtcblxuICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogdGFibGV0KSB7XG4gICAgbWluLXdpZHRoOiAkdGFzay1saXN0LWluZGVudDtcbiAgICBwYWRkaW5nLXJpZ2h0OiAwO1xuICB9XG59XG5cblxuLmFwcC10YXNrLWxpc3RfX2l0ZW1zIHtcbiAgbGlzdC1zdHlsZTogbm9uZTtcbiAgcGFkZGluZzogMDtcbiAgbWFyZ2luLWJvdHRvbTogJGdvdnVrLWd1dHRlcjtcbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJGZyb206IHRhYmxldCkge1xuICAgIG1hcmdpbi1ib3R0b206ICgkZ292dWstZ3V0dGVyICogMik7XG4gIH1cblxuICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkZnJvbTogdGFibGV0KSB7XG4gICAgcGFkZGluZy1sZWZ0OiAkdGFzay1saXN0LWluZGVudDtcbiAgfVxufVxuXG4uYXBwLXRhc2stbGlzdF9faXRlbSB7XG4gIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbiAgcGFkZGluZy10b3A6IGdvdnVrLXNwYWNpbmcoMik7XG4gIHBhZGRpbmctYm90dG9tOiBnb3Z1ay1zcGFjaW5nKDIpO1xuICBAaW5jbHVkZSBnb3Z1ay1jbGVhcmZpeFxufVxuXG4uYXBwLXRhc2stbGlzdF9faXRlbTpmaXJzdC1jaGlsZCB7XG4gIGJvcmRlci10b3A6IDFweCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbn1cblxuLmFwcC10YXNrLWxpc3RfX3Rhc2stbmFtZSB7XG4gIHdpZHRoOiAzMy4zJTtcbiAgZmxvYXQ6IGxlZnQ7XG59XG5cbi5hcHAtdGFzay1saXN0X190YXNrLWNvbXBsZXRlZCB7XG4gIGZsb2F0OiByaWdodDtcbn1cbiIsIi8vIFRoaXMgaXMgYSBHT1YuVUsgUHVibGlzaGluZyBzcGVjaWZpYyBjb21wb25lbnQgdGhhdFxuLy8gY2FuIGJlIHNlZW4gYXQgaHR0cDovL2dvdnVrLXN0YXRpYy5oZXJva3VhcHAuY29tL2NvbXBvbmVudC1ndWlkZS9yZWxhdGVkX2l0ZW1zXG5cbi5hcHAtcmVsYXRlZC1pdGVtcyB7XG4gIGJvcmRlci10b3A6IDEwcHggc29saWQgZ292dWstY29sb3VyKFwiYmx1ZVwiKTtcbiAgcGFkZGluZy10b3A6IGdvdnVrLXNwYWNpbmcoMik7XG59XG5cbi5hcHAtcmVsYXRlZC1pdGVtcyAuZ292dWstbGlzdCA+IGxpIHtcbiAgbWFyZ2luLWJvdHRvbTogZ292dWstc3BhY2luZygyKTtcbn1cbiIsIi8vIEFkZGl0aW9uYWwgc3R5bGVzIGZvciBDSCBhY2NvdW50c1xuJGVycm9yLWJ1dHRvbi1ob3ZlcjogIzhlMDUxMztcblxuLnR3by1jb2x1bW4tYWNjb3VudHMge1xuICBmb3JtLWNvbnRyb2wge1xuICAgIHRleHQtYWxpZ246IHJpZ2h0O1xuICB9XG5cbiAgLmdvdnVrLWZvcm0tZ3JvdXAge1xuICAgIG1hcmdpbi1ib3R0b206IC0yMHB4O1xuICB9XG5cbiAgI2FjY291bnRzLWhlYWRlciB7XG4gICAgZGlzcGxheTogbm9uZTtcbiAgICAvKkhpZGUgZnJvbSBtb2JpbGVzKi9cbiAgICAubGVmdCB7XG4gICAgICB0ZXh0LWFsaWduOiBsZWZ0O1xuICAgIH1cbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeShkZXNrdG9wKSB7XG4gICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICAgIG1hcmdpbjogMmVtIDA7XG4gICAgfVxuXG4gICAgLmdvdnVrLWhlYWRpbmctbSB7XG4gICAgICBtYXJnaW46IDA7XG4gICAgfVxuICB9XG5cbiAgLmVycm9yIHtcbiAgICBib3JkZXI6IG5vbmU7IC8vL2Vycm9ycyBvbiBCYWxhbmNlIHNoZWV0XG4gICAgcGFkZGluZy1sZWZ0OiAwO1xuXG4gICAgaW5wdXQge1xuICAgICAgYm9yZGVyOiA0cHggc29saWQgJGdvdnVrLWVycm9yLWNvbG91cjtcbiAgICB9XG4gIH1cblxuICAucmVhZC1vbmx5IHtcbiAgICBib3JkZXItY29sb3I6ICRnb3Z1ay1ib3JkZXItY29sb3VyO1xuICB9XG5cbiAgLm1vYmlsZS1vbmx5LWxhYmVsIHtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgb3ZlcmZsb3c6IHZpc2libGU7XG4gICAgLypWaXNpYmxlIG9uIG1vYmlsZXMqL1xuICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KGRlc2t0b3ApIHtcbiAgICAgIHBvc2l0aW9uOiBhYnNvbHV0ZTtcbiAgICAgIG92ZXJmbG93OiBoaWRkZW47XG4gICAgICBjbGlwOiByZWN0KDAgMCAwIDApO1xuICAgICAgaGVpZ2h0OiAxcHg7XG4gICAgICB3aWR0aDogMXB4O1xuICAgICAgbWFyZ2luOiAtMXB4O1xuICAgICAgcGFkZGluZzogMDtcbiAgICAgIGJvcmRlcjogMDtcbiAgICAgIC8qSGlkZGVuIG9uIGRlc2t0b3AsIGJ1dCBjYW4gYmUgcmVhZCBieSBzY3JlZW5yZWFkZXJzKi9cbiAgICB9XG4gIH1cblxuICAuY3lhLWRlc2t0b3Atb25seSB7XG4gICAgZGlzcGxheTogbm9uZTsgLy8gSGlkZSBmcm9tIG1vYmlsZXNcbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeShkZXNrdG9wKSB7XG4gICAgICBkaXNwbGF5OiB0YWJsZS1yb3c7IC8vIFNob3cgb24gZGVza3RvcFxuICAgIH1cbiAgfVxuXG4gIC5hY2NvdW50cy10b3RhbCB7XG4gICAgLmdvdnVrLWlucHV0IHtcbiAgICAgIGJvcmRlci1sZWZ0OiAwO1xuICAgICAgYm9yZGVyLXJpZ2h0OiAwO1xuICAgICAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgICB9XG5cbiAgICBkZXRhaWxzIHtcbiAgICAgIGZvbnQtd2VpZ2h0OiA3MDA7XG4gICAgfVxuXG4gICAgLm5vLWhlbHAge1xuICAgICAgbWFyZ2luLWxlZnQ6IDFlbTtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KG1vYmlsZSkge1xuICAgICAgICAvKlZpc2libGUgb24gbW9iaWxlcyovXG4gICAgICAgIG1hcmdpbi1sZWZ0OiAwO1xuICAgICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTkpO1xuICAgICAgICBmb250LXdlaWdodDogNzAwO1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwLjVlbTtcbiAgICAgIH1cbiAgICB9XG4gIH1cblxuICAuYWNjb3VudHMtcm93LXNwYWNlciB7XG4gICAgbWFyZ2luLXRvcDogMmVtO1xuICB9XG5cbiAgLmZvcm0tY29udHJvbCB7XG4gICAgd2lkdGg6IDEwMCU7XG4gIH1cblxuICAuZ292dWstaGVhZGluZy1zIHtcbiAgICBtYXJnaW46IDA7XG4gIH1cblxuICAuY3VycmVuY3ktaW5jbHVkZWQtd2l0aGluLWlucHV0cyBpbnB1dFt0eXBlPVwibnVtYmVyXCJdIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICB3aWR0aDogMTAwJTtcbiAgICBjbGVhcjogYm90aDtcbiAgICBtYXJnaW4tYm90dG9tOiAyLjJlbTtcbiAgICBwb3NpdGlvbjogc3RhdGljO1xuICB9XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KGRlc2t0b3ApIHtcbiAgICAuY3VycmVuY3ktaW5jbHVkZWQtd2l0aGluLWlucHV0cyBpbnB1dFt0eXBlPVwibnVtYmVyXCJdIHtcbiAgICAgIG1hcmdpbi1ib3R0b206IDAuNWVtO1xuICAgIH1cbiAgfVxuXG4gIC5jdXJyZW5jeS1pbmNsdWRlZC13aXRoaW4taW5wdXRzIC5nb3Z1ay1ncmlkLWNvbHVtbi1vbmUtaGFsZiB7XG4gICAgZGlzcGxheTogbm9uZTsgLy9oaWRlIGZyb20gbW9iaWxlc1xuICB9XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KGRlc2t0b3ApIHtcbiAgICAuY3VycmVuY3ktaW5jbHVkZWQtd2l0aGluLWlucHV0cyAuZ292dWstZ3JpZC1jb2x1bW4tb25lLWhhbGYge1xuICAgICAgZGlzcGxheTogaW5oZXJpdDsgLy9zaG93IG9uIGRlc2t0b3BcbiAgICB9XG5cbiAgICBpbnB1dFt0eXBlPVwibnVtYmVyXCJdIHtcbiAgICAgIHRleHQtYWxpZ246IHJpZ2h0O1xuICAgIH1cblxuICAgIC5jdXJyZW5jeS10eXBlIHtcbiAgICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICAgIGxlZnQ6IDEwcHg7XG4gICAgICBmb250LXdlaWdodDogYm9sZDtcbiAgICB9XG5cbiAgICAuY3VycmVuY3ktaW5jbHVkZWQtd2l0aGluLWlucHV0cyBpbnB1dFt0eXBlPVwibnVtYmVyXCJdIHtcbiAgICAgIHBvc2l0aW9uOiByZWxhdGl2ZSAhaW1wb3J0YW50O1xuICAgICAgdG9wOiAtNjBweDtcbiAgICAgIGxlZnQ6IC0xMHB4O1xuICAgICAgYmFja2dyb3VuZDogbm9uZTtcbiAgICB9XG5cbiAgICAuY3VycmVuY3ktaW5jbHVkZWQtd2l0aGluLWlucHV0cyAubW9iaWxlLW9ubHktbGFiZWwge1xuICAgICAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICAgICAgd2lkdGg6IDEwMCU7XG4gICAgICBjbGVhcjogYm90aDtcbiAgICAgIG1hcmdpbi1ib3R0b206IDEwcHg7XG4gICAgICBwb3NpdGlvbjogc3RhdGljO1xuICAgIH1cblxuICAgIC5jdXJyZW5jeS1pbmNsdWRlZC13aXRoaW4taW5wdXRzIC5jdXJyZW5jeS10eXBlIHtcbiAgICAgIGRpc3BsYXk6IGlubGluZTtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgY2xlYXI6IGJvdGg7XG4gICAgICBtYXJnaW4tYm90dG9tOiAxMHB4O1xuICAgICAgcG9zaXRpb246IHN0YXRpYztcbiAgICB9XG4gIH1cbiAgLy9DaGVjayB5b3VyIGFuc3dlcnNcbiAgI2V4cGFuZCB7fVxuICAvLyBFeHBhbmQgYWxsIGxpbmsvYnV0dG9uXG4gIHRhYmxlLmNoZWNrLXlvdXItYW5zd2VycyB7XG4gICAgdGhlYWQgdGgge1xuICAgICAgcGFkZGluZzogMmVtIDAgMWVtO1xuXG4gICAgICBoMi5nb3Z1ay1oZWFkaW5nLW0sXG4gICAgICBoMi5nb3Z1ay1oZWFkaW5nLXMge1xuICAgICAgICBtYXJnaW46IDA7XG4gICAgICB9XG4gICAgfVxuXG4gICAgdGguY2hlY2steW91ci1hbnN3ZXJzLXNlY3Rpb24ge1xuICAgICAgd2lkdGg6IDc1JTtcbiAgICB9XG5cbiAgICB0ZC5ub3RlLWNvbXBsZXRlZCB7XG4gICAgICB3aWR0aDogNSU7XG4gICAgICBwYWRkaW5nLXRvcDogMC4yZW07XG4gICAgICBwYWRkaW5nLWJvdHRvbTogMDtcbiAgICB9XG5cbiAgICB0ci50b3RhbCB0ZCB7XG4gICAgICBmb250LXdlaWdodDogNzAwO1xuICAgIH1cblxuICAgIHRkLm51bWVyaWMge1xuICAgICAgZm9udC1mYW1pbHk6IGluaGVyaXQ7XG4gICAgICBmb250LXNpemU6IGluaGVyaXQ7XG4gICAgICBwYWRkaW5nLXJpZ2h0OiAwO1xuICAgIH1cblxuICAgIHRkLm5vdGVzLFxuICAgIHRoLm5vdGVzIHtcbiAgICAgIHdpZHRoOiAxNSU7XG4gICAgfVxuXG4gICAgdGguY3VycmVudC15ZWFyLW5vdGUtdmFsdWUsXG4gICAgdGgucHJldmlvdXMteWVhci1ub3RlLXZhbHVlIHtcbiAgICAgIC8vICB0ZXh0LWFsaWduOiByaWdodDtcbiAgICB9XG5cbiAgICB0ZC5jb21wbGV0ZSxcbiAgICB0aC5jb21wbGV0ZSB7XG4gICAgICB3aWR0aDogNCU7XG4gICAgfVxuXG4gICAgdHIudG8tYmUtY29tcGxldGVkIHRkLFxuICAgIHRyLnRvLWJlLWNvbXBsZXRlZCB0aCB7XG4gICAgICBjb2xvcjogJGdvdnVrLXNlY29uZGFyeS10ZXh0LWNvbG91cjtcbiAgICB9XG5cbiAgICAuYWNjb3VudHMtc3VjY2VzcyB7XG4gICAgICBjb2xvcjogIzAwODIzYjsgLy8gY2FuJ3QgZ2V0IG1peGluIHdvdCB3b3JrIC0gZml4IGxhdGVyXG4gICAgICBkaXNwbGF5OiBibG9jaztcbiAgICAgIG1hcmdpbjogMCBhdXRvO1xuICAgICAgZm9udC1zaXplOiAxZW07XG4gICAgfVxuXG4gICAgLmFjY291bnRzLXVwZGF0ZSB7XG4gICAgICBjb2xvcjogJGdvdnVrLWZvY3VzLWNvbG91cjtcbiAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgbWFyZ2luOiAwIGF1dG87XG4gICAgICBmb250LXNpemU6IDEuOGVtO1xuICAgIH1cblxuICAgIC5yZXZpZXctcmV2ZWFsIHtcbiAgICAgIHBhZGRpbmc6IDAuNWVtIDAgMC4yZW0gMWVtO1xuXG4gICAgICAuY29sdW1uLW9uZS1oYWxmIHAge1xuICAgICAgICB0ZXh0LWFsaWduOiBsZWZ0O1xuICAgICAgfVxuXG4gICAgICAuY29sdW1uLW9uZS1xdWFydGVyIHAge1xuICAgICAgICB0ZXh0LWFsaWduOiByaWdodDtcbiAgICAgIH1cblxuICAgICAgLmNvbHVtbi1zaXh0aCBwIHtcbiAgICAgICAgdGV4dC1hbGlnbjogcmlnaHQ7XG4gICAgICB9XG5cbiAgICAgIC5jb2x1bW4tZmlmdGggcCB7XG4gICAgICAgIHRleHQtYWxpZ246IHJpZ2h0O1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkobW9iaWxlKSB7XG4gIC5yZXZpZXctcmV2ZWFsIHtcbiAgICAuY29sdW1uLW9uZS1oYWxmIHtcbiAgICAgIHdpZHRoOiA0NSU7XG4gICAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgfVxuXG4gICAgLmNvbHVtbi1vbmUtdGhpcmQge1xuICAgICAgd2lkdGg6IDMxJTtcbiAgICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICB9XG5cbiAgICAuY29sdW1uLW9uZS1xdWFydGVyIHtcbiAgICAgIHdpZHRoOiAyMiU7XG4gICAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgfVxuICB9XG59XG5cbnRhYmxlLmNoZWNrLXlvdXItYW5zd2Vycy1ub3RlcyB7XG4gIHRkLmNoYW5nZS1hbnN3ZXIge1xuICAgIGZvbnQtd2VpZ2h0OiBub3JtYWw7XG4gICAgd2lkdGg6IDM1JTtcbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeShtb2JpbGUpIHtcbiAgICAgIGEge1xuICAgICAgICBtYXJnaW4tYm90dG9tOiAwLjVlbTtcbiAgICAgICAgZmxvYXQ6IHJpZ2h0O1xuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIHRkLm5hbWUge1xuICAgIHdpZHRoOiAyMCU7XG4gIH1cbn1cblxuI2NvbnRlbnQtZGVsZXRlLXdhcm5pbmcge1xuICBtYXJnaW4tdG9wOiAwO1xufVxuXG4jZGVsZXRlLXN1bW1hcnkge1xuICBwYWRkaW5nLWJvdHRvbTogMDtcbiAgbWFyZ2luLXRvcDogMC41ZW07XG4gIGRpc3BsYXk6IGJsb2NrO1xuXG4gIHAge1xuICAgIGNvbG9yOiAkZ292dWstZXJyb3ItY29sb3VyO1xuICB9XG5cbiAgLmJ1dHRvbiB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogJGdvdnVrLWVycm9yLWNvbG91cjtcbiAgICBtYXJnaW4tYm90dG9tOiAxZW07XG5cbiAgICAmOmhvdmVyIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6ICRlcnJvci1idXR0b24taG92ZXI7XG4gICAgfVxuICB9XG5cbiAgLm5vLWRlbGV0ZSB7XG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWNvbG91cjtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICBib3gtc2hhZG93OiBub25lO1xuICAgIHRleHQtZGVjb3JhdGlvbjogdW5kZXJsaW5lO1xuXG4gICAgJjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiB0cmFuc3BhcmVudDtcbiAgICAgIGJveC1zaGFkb3c6IG5vbmU7XG4gICAgICBjb2xvcjogJGdvdnVrLWxpbmstaG92ZXItY29sb3VyO1xuICAgIH1cbiAgfVxufVxuQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkobW9iaWxlKSB7XG4gICNkZWxldGUtc3VtbWFyeSB7XG4gICAgLmJ1dHRvbiB7XG4gICAgICBtYXJnaW4tdG9wOiAwLjVlbTtcbiAgICAgIG1hcmdpbi1sZWZ0OiAwICFpbXBvcnRhbnQ7XG4gICAgfVxuICB9XG59XG4vL1lvdXIgZmlsaW5ncy8vXG5cbi55b3VyLWZpbGluZ3Mge1xuICB0YWJsZSNyZl90YWJsZSB7XG4gICAgbWFyZ2luLXRvcDogMWVtO1xuXG4gICAgdHIgdGQge1xuICAgICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTYpO1xuXG4gICAgICBzdHJvbmcuc3RhdHVzIHtcbiAgICAgICAgZm9udC13ZWlnaHQ6IDcwMDtcbiAgICAgICAgZm9udC1zaXplOiAxLjJlbTtcbiAgICAgIH1cblxuICAgICAgYSB7XG4gICAgICAgIGRpc3BsYXk6IGlubGluZS1ibG9jaztcbiAgICAgICAgZm9udC1zaXplOiAxLjFlbTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICB0ciB0aCB7XG4gICAgICBmb250LXdlaWdodDogbm9ybWFsO1xuICAgIH1cblxuICAgIHRyIHtcbiAgICAgIHRoLmRlc2NyaXB0aW9uIHtcbiAgICAgICAgd2lkdGg6IDY5JTtcbiAgICAgIH1cblxuICAgICAgdGguc3RhdHVzIHtcbiAgICAgICAgd2lkdGg6IDE4JTtcbiAgICAgICAgdGV4dC1hbGlnbjogbGVmdDtcbiAgICAgIH1cblxuICAgICAgdGguYWN0aW9ucyB7XG4gICAgICAgIHdpZHRoOiAxNSU7XG4gICAgICAgIHRleHQtYWxpZ246IGxlZnQ7XG4gICAgICB9XG5cbiAgICAgIHRkLnJlamVjdGVkLXR5cGUge1xuICAgICAgICBwYWRkaW5nLXJpZ2h0OiA0ZW07XG4gICAgICAgIC8vRW5zdXJlcyByZWplY3RlZCBzdGF0dXMgKHdoaWNoIGhhcyBpY29uKSBoYXMgdGV4dCBpbiBsaW5lIHdpdGggb3RoZXIgc3RhdHVzZXNcbiAgICAgIH1cblxuICAgICAgLm5vdGljZSB7XG4gICAgICAgIG1hcmdpbi1sZWZ0OiAtM2VtO1xuICAgICAgICAvL0Vuc3VyZXMgcmVqZWN0ZWQgc3RhdHVzICh3aGljaCBoYXMgaWNvbikgaGFzIHRleHQgaW4gbGluZSB3aXRoIG90aGVyIHN0YXR1c2VzXG4gICAgICB9XG5cbiAgICAgIC5yZWplY3RlZCB7XG4gICAgICAgIGNvbG9yOiAkZ292dWstZXJyb3ItY29sb3VyO1xuICAgICAgICBtYXJnaW4tbGVmdDogLTMuMWVtO1xuXG4gICAgICAgIC5pY29uLWltcG9ydGFudCB7XG4gICAgICAgICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiL3B1YmxpYy9pbWFnZXMvaWNvbi1pbXBvcnRhbnQtcmVkLnBuZ1wiKTtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIC5vbmUtZmlsaW5nIHtcbiAgICBtYXJnaW4tYm90dG9tOiAyZW07XG4gICAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwiZ3JleS00XCIpO1xuICAgIHBhZGRpbmc6IDFlbTtcbiAgICBjbGVhcjogYm90aDtcblxuICAgIC5nb3Z1ay1oZWFkaW5nLW0ge1xuICAgICAgbWFyZ2luLXRvcDogMDtcblxuICAgICAgc3BhbiB7XG4gICAgICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcbiAgICAgICAgZGlzcGxheTogYmxvY2s7XG4gICAgICB9XG4gICAgfVxuXG4gICAgJi5yZWplY3RlZCB7XG4gICAgICAubm90aWNlIHtcbiAgICAgICAgY29sb3I6ICRnb3Z1ay1lcnJvci1jb2xvdXI7XG5cbiAgICAgICAgLmljb24taW1wb3J0YW50IHtcbiAgICAgICAgICBiYWNrZ3JvdW5kLWltYWdlOiB1cmwoXCIvcHVibGljL2ltYWdlcy9pY29uLWltcG9ydGFudC1yZWQucG5nXCIpO1xuICAgICAgICB9XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgLmdvdnVrLWdyaWQtcm93IHtcbiAgICBzdHJvbmcge1xuICAgICAgZGlzcGxheTogYmxvY2s7XG5cbiAgICAgIGE6Zmlyc3Qtb2YtdHlwZSB7XG4gICAgICAgIHBhZGRpbmctcmlnaHQ6IDFlbTtcbiAgICAgIH1cbiAgICB9XG5cbiAgICAuYm9sZC1tZWRpdW0ge1xuICAgICAgZm9udC13ZWlnaHQ6IG5vcm1hbDtcbiAgICAgIG1hcmdpbi1ib3R0b206IDFlbTtcbiAgICAgIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE5KTtcblxuICAgICAgc3BhbiB7XG4gICAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgICAgICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAyNCk7XG4gICAgICAgIGZvbnQtd2VpZ2h0OiA3MDA7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgLm5vLXRhYmxlIHtcbiAgICAuY29sdW1uLWRlc2NyaXB0aW9uIHtcbiAgICAgIHdpZHRoOiAzMyU7XG4gICAgfVxuXG4gICAgLmNvbHVtbi1yZWZlcmVuY2Uge1xuICAgICAgd2lkdGg6IDMzJTtcbiAgICB9XG5cbiAgICAuY29sdW1uLXN0YXR1cyB7XG4gICAgICB3aWR0aDogMTclO1xuICAgIH1cblxuICAgIC5jb2x1bW4tYWN0aW9ucyB7XG4gICAgICB3aWR0aDogMTclO1xuXG4gICAgICBzdHJvbmcge1xuICAgICAgICBmb250LXdlaWdodDogbm9ybWFsO1xuICAgICAgICBmb250LXNpemU6IDAuOWVtO1xuXG4gICAgICAgIGE6Zmlyc3Qtb2YtdHlwZSB7XG4gICAgICAgICAgcGFkZGluZy1yaWdodDogMDtcbiAgICAgICAgfVxuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIGEuYWRtaW4tbGluayB7XG4gICAgZm9udC1zaXplOiAxNnB4ICFpbXBvcnRhbnQ7XG4gICAgY29sb3I6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICAgIGJhY2tncm91bmQtY29sb3I6ICRnb3Z1ay1saW5rLWNvbG91cjtcbiAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7XG4gICAgcGFkZGluZzogMnB4IDhweDtcbiAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgbWFyZ2luOiAwLjVlbSAwLjVlbSAwIDA7XG5cbiAgICAmOmZvY3VzLFxuICAgICY6aG92ZXIge1xuICAgICAgYmFja2dyb3VuZC1jb2xvcjogJGdvdnVrLWxpbmstaG92ZXItY29sb3VyO1xuICAgIH1cbiAgfVxufVxuLy9FTkQgWW91ciBmaWxpbmdzXG5cbmEuYnV0dG9uOjpiZWZvcmUge1xuICB3aWR0aDogYXV0bzsgLy8gVGhpcyBzdG9wcyB0aGUgZm9jdXMgaGlnaGxpZ2h0aW5nICh5ZWxsb3cpIG9mZiBsaW5rcyB3aXRoIGEgY2xhc3Mgb2YgXCJidXR0b25cIiBmcm9tIGdvaW5nIG9mZiB0aGUgbGVmdC1lZGdlIG9mIHRoZSBzY3JlZW5cbn1cblxuLmZvcm0tZ3JvdXAgLmlubGluZS1tdWx0aXBsZSBsYWJlbCB7XG4gIG1hcmdpbi1ib3R0b206IDAuNWVtO1xufVxuXG5wLmNvbXBhbnktZGV0YWlscyB7XG4gIGZvbnQtc2l6ZTogMC45ZW07XG59XG5cbi5ncm91cC10ZXh0YXJlYSB7XG4gIGRldGFpbHMge1xuICAgIG1hcmdpbjogLS41ZW0gMCAwLjVlbTtcblxuICAgIHN1bW1hcnkge1xuICAgICAgZm9udC13ZWlnaHQ6IG5vcm1hbDtcbiAgICB9XG4gIH1cbn1cblxuaDEgLmNpcmNsZSxcbmgyIC5jaXJjbGUsXG5oMyAuY2lyY2xlIHtcbiAgZm9udC1zaXplOiAyMXB4O1xuICBtYXJnaW4tcmlnaHQ6IDVweDtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB0b3A6IC0uNWVtO1xufVxuXG4uc3ViaGVhZGluZyB7XG4gIEBpbmNsdWRlIGdvdnVrLWZvbnQoJHNpemU6IDE2KTtcbiAgY29sb3I6ICRnb3Z1ay1zZWNvbmRhcnktdGV4dC1jb2xvdXI7XG4gIGRpc3BsYXk6IGJsb2NrO1xufVxuXG4uY2lyY2xlLXN1YmhlYWRpbmcge1xuICBAaW5jbHVkZSBnb3Z1ay1mb250KCRzaXplOiAyNyk7XG4gIGNvbG9yOiAkZ292dWstc2Vjb25kYXJ5LXRleHQtY29sb3VyO1xuICBkaXNwbGF5OiBibG9jaztcbiAgLy9tYXJnaW4tbGVmdDogMS41ZW07XG59XG5AaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeShtb2JpbGUpIHtcbiAgLypBZGp1c3QgbGF5b3V0IG9mIGhlYWRpbmcgc3R5bGVzIG9uIG1vYmlsZXMqL1xuICAudGV4dCAuZ292dWstaGVhZGluZy14bCB7XG4gICAgLy8gIGxpbmUtaGVpZ2h0OjAuOWVtO1xuICAgIC5jaXJjbGUtc3ViaGVhZGluZyB7XG4gICAgICBtYXJnaW46IDAuNWVtIDAgMDtcbiAgICB9XG4gIH1cbn1cblxuLndhcm5pbmctd2l0aC10cmlhbmdsZSB7XG4gIHRvcDogMjVweDtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiBsaWdodGVuKCRnb3Z1ay1mb2N1cy1jb2xvdXIsIDMwJSk7XG4gIGJvcmRlcjogM3B4IHNvbGlkICRnb3Z1ay1mb2N1cy1jb2xvdXI7XG4gIHdpZHRoOiBhdXRvO1xuICBoZWlnaHQ6IGF1dG87XG4gIHBhZGRpbmc6IDAuNWVtO1xuICBtYXJnaW4tYm90dG9tOiAxLjVlbTtcblxuICAmIHAge1xuICAgIG1hcmdpbjogMDtcbiAgfVxufVxuXG4ud2FybmluZy13aXRoLXRyaWFuZ2xlOmFmdGVyLFxuLndhcm5pbmctd2l0aC10cmlhbmdsZTpiZWZvcmUge1xuICBib3R0b206IDEwMCU7XG4gIGJvcmRlcjogc29saWQgdHJhbnNwYXJlbnQ7XG4gIGNvbnRlbnQ6IFwiIFwiO1xuICBoZWlnaHQ6IDA7XG4gIHdpZHRoOiAwO1xuICBwb3NpdGlvbjogYWJzb2x1dGU7XG4gIHBvaW50ZXItZXZlbnRzOiBub25lO1xufVxuXG4ud2FybmluZy13aXRoLXRyaWFuZ2xlOmFmdGVyIHtcbiAgYm9yZGVyLWNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDApO1xuICBib3JkZXItYm90dG9tLWNvbG9yOiBsaWdodGVuKCRnb3Z1ay1mb2N1cy1jb2xvdXIsIDMwJSk7XG4gIGJvcmRlci13aWR0aDogMTlweDtcbiAgbGVmdDogODAlO1xuICBtYXJnaW4tbGVmdDogLTE5cHg7XG59XG5cbi53YXJuaW5nLXdpdGgtdHJpYW5nbGU6YmVmb3JlIHtcbiAgYm9yZGVyLWNvbG9yOiByZ2JhKDExMywgMTU4LCAyMDYsIDApO1xuICBib3JkZXItYm90dG9tLWNvbG9yOiAkZ292dWstZm9jdXMtY29sb3VyO1xuICBib3JkZXItd2lkdGg6IDIzcHg7XG4gIGxlZnQ6IDgwJTtcbiAgbWFyZ2luLWxlZnQ6IC0yM3B4O1xufVxuXG4ud2FybmluZy1ub3RlIHtcbiAgYmFja2dyb3VuZC1jb2xvcjogJGdvdnVrLWxpbmstY29sb3VyO1xuICBwYWRkaW5nOiAwIDAuM2VtO1xuICBtYXJnaW4tbGVmdDogMC41ZW07XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcblxuICAmLndhcm5pbmctbm90ZS1sYXJnZSB7XG4gICAgcGFkZGluZzogMC43ZW07XG4gICAgbWFyZ2luLWxlZnQ6IDA7XG4gICAgbWFyZ2luLWJvdHRvbTogMWVtO1xuICB9XG59XG5cbmgxIHNwYW4uY2lyY2xlIHtcbiAgcG9zaXRpb246IHJlbGF0aXZlO1xuICB0b3A6IC0uNWVtO1xufVxuXG4uZXhhbXBsZS1pY29uLWxpc3Qgc3Bhbi5jaXJjbGUge1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIHRvcDogLS4yZW07XG59XG5cbi5pY29uLWltcG9ydGFudCB7XG4gIGJhY2tncm91bmQtaW1hZ2U6IHVybChcIi9wdWJsaWMvaW1hZ2VzL2ljb24taW1wb3J0YW50LnBuZ1wiKTsgLy8gSGF2aW5nIHRvIGFkZCB0aGlzIGhlcmUsIGZvciBzb21lIHJlYXNvbiBwcm90b3R5cGUga2l0IHN0eWxpbmcgZm9yIHRoaXMgZWxlbWVudCBub3Qgd29ya2luZy4gSG9wZWZ1bGx5IG5vdCBuZWVkZWQgb24gcHJvZHVjdGlvbiBzaXRlLlxufVxuXG4uaWNvbi1maWxlLWRvd25sb2FkIHtcbiAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiL3B1YmxpYy9pbWFnZXMvaWNvbi1maWxlLWRvd25sb2FkLnBuZ1wiKTsgLy8gSGF2aW5nIHRvIGFkZCB0aGlzIGhlcmUsIGZvciBzb21lIHJlYXNvbiBwcm90b3R5cGUga2l0IHN0eWxpbmcgZm9yIHRoaXMgZWxlbWVudCBub3Qgd29ya2luZy4gSG9wZWZ1bGx5IG5vdCBuZWVkZWQgb24gcHJvZHVjdGlvbiBzaXRlLlxufVxuXG4jYWNjb3VudHMtc3RhcnQtcGFnZSB7XG4gIC5nb3Z1ay1oaW50IHtcbiAgICBtYXJnaW46IDAgMCAxZW0gMmVtO1xuICB9XG5cbiAgbGkgc3BhbiB7XG4gICAgbWFyZ2luLXJpZ2h0OiAwLjllbTtcbiAgICBtYXJnaW4tYm90dG9tOiAxZW07XG4gIH1cbn1cbi8vSW5kZW50IC1cblxuLmxlZnQtaW5kZW50IHtcbiAgbWFyZ2luLWxlZnQ6IDIuOGVtO1xuXG4gIHRleHRhcmVhLmZvcm0tY29udHJvbCB7XG4gICAgd2lkdGg6IDEwMCU7XG4gIH1cbn1cbkBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KG1vYmlsZSkge1xuICAubGVmdC1pbmRlbnQge1xuICAgIG1hcmdpbi1sZWZ0OiAwICFpbXBvcnRhbnQ7XG4gIH1cbn1cbi8vQXV0b3NhdmUgYWxlcnRcblxuI2F1dG9zYXZlLWNvbnRhaW5lciB7XG4gIHBvc2l0aW9uOiBmaXhlZDtcbiAgYm90dG9tOiAwO1xuICBsZWZ0OiAwO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAkZ292dWstc2Vjb25kYXJ5LXRleHQtY29sb3VyO1xuICBjb2xvcjogZ292dWstcGFnZS1jb2xvdXI7XG4gIHdpZHRoOiAxMDAlO1xuICBwYWRkaW5nOiAwLjVlbSAwIDAuOGVtO1xuICBoZWlnaHQ6IDFlbTtcblxuICBkaXYge1xuICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgfVxufVxuLy9QYW5lbCBzdHlsZXMgd2l0aGluIG90aGVyIGVsZW1lbnRzXG5cbmgxIC5wYW5lbCB7XG4gIGZvbnQtc2l6ZTogMC41ZW07XG4gIG1hcmdpbjogMWVtIDA7XG59XG5cbnRoIC5wYW5lbCB7XG4gIGZvbnQtc2l6ZTogMC42ZW07XG4gIG1hcmdpbjogMWVtIDA7XG59XG5cbi5wYW5lbCAqOmxhc3QtY2hpbGQsXG4ucGFuZWwgKjpvbmx5LWNoaWxkIHtcbiAgLy9OZWVkZWQgZm9yIExvYW5zIHRvIERpcmVjdG9ycyBub3RlIChhZGRzIG1pc3NpbmcgYm90dG9tIG1hcmdpbiBvbiBmb3JtLWdyb3VwIGVsZW1lbnRzIHdpdGhpbiBhIHBhbmVsKVxuICAvLyAgbWFyZ2luLWJvdHRvbTogMTVweDtcbn1cblxuLnBhbmVsIC5ncmlkLXJvdyB7XG4gIC8vTmVlZGVkIGZvciBMb2FucyB0byBEaXJlY3RvcnMgbm90ZSAoYWRkcyBtaXNzaW5nIGJvdHRvbSBtYXJnaW4gb24gZm9ybS1ncm91cCBlbGVtZW50cyB3aXRoaW4gYSBwYW5lbClcbiAgbWFyZ2luLWJvdHRvbTogMTVweDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA2NDBweCkge1xuICBoMSAucGFuZWwge1xuICAgIGZvbnQtc2l6ZTogMC41ZW07XG4gIH1cblxuICB0aCAucGFuZWwge1xuICAgIGZvbnQtc2l6ZTogMC43ZW07XG4gIH1cbn1cbi8vU2F2ZSBtb2RhbFxuXG4jc2F2ZS1tb2RhbCB7XG4gIGJvcmRlcjogMnB4IHNvbGlkICRnb3Z1ay1ib3JkZXItY29sb3VyO1xuICBiYWNrZ3JvdW5kLWNvbG9yOiAkZ292dWstY2FudmFzLWJhY2tncm91bmQtY29sb3VyO1xuICBwYWRkaW5nOiAxZW07XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBtYXJnaW46IDAgYXV0byAyZW07XG5cbiAgaDIge1xuICAgIG1hcmdpbi10b3A6IDA7XG4gIH1cblxuICAuYnV0dG9uIHtcbiAgICBtYXJnaW46IDAgMWVtIDAgMDtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDY0MHB4KSB7XG4gICNzYXZlLW1vZGFsIHtcbiAgICAuYnV0dG9uOmZpcnN0LW9mLXR5cGUge1xuICAgICAgbWFyZ2luLWJvdHRvbTogMWVtO1xuICAgIH1cbiAgfVxufVxuLy9Ob3RpZmljYXRpb24gY291bnRlclxuXG4ubm90aWZpY2F0aW9uLWNvdW50ZXIge1xuICB0b3A6IC02cHg7XG4gIHJpZ2h0OiAtMXB4O1xuICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gIGJhY2tncm91bmQtY29sb3I6IGdvdnVrLWNvbG91cihcInllbGxvd1wiKTtcbiAgY29sb3I6IGdvdnVrLWNvbG91cihcImJsYWNrXCIpO1xuICBwYWRkaW5nOiAycHggN3B4IDA7XG4gIGJvcmRlci1yYWRpdXM6IDE1cHg7XG59XG5cbiNmaWxpbmctYWxlcnQge1xuICBiYWNrZ3JvdW5kOiBnb3Z1ay1jb2xvdXIoXCJ5ZWxsb3dcIik7XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgZGlzcGxheTogaW5saW5lLWJsb2NrO1xuICBmbG9hdDogcmlnaHQ7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgdG9wOiAwLjJlbTtcbiAgcmlnaHQ6IDE0ZW07XG4gIHdpZHRoOiBhdXRvO1xuICBwYWRkaW5nOiAwLjJlbSAwLjRlbTtcbiAgdGV4dC1hbGlnbjogY2VudGVyO1xufVxuXG4jZmlsaW5nLWFsZXJ0OmJlZm9yZSB7XG4gIGJvcmRlci10b3A6IDE1cHggc29saWQgZ292dWstY29sb3VyKFwieWVsbG93XCIpO1xuICBib3JkZXItbGVmdDogMTVweCBzb2xpZCB0cmFuc3BhcmVudDtcbiAgYm9yZGVyLXJpZ2h0OiAxNXB4IHNvbGlkIHRyYW5zcGFyZW50O1xuICBjb250ZW50OiBcIlwiO1xuICBoZWlnaHQ6IDA7XG4gIGxlZnQ6IDQ4JTtcbiAgcG9zaXRpb246IGFic29sdXRlO1xuICBib3R0b206IC0xNXB4O1xuICB3aWR0aDogMDtcbn1cbi8vQ29ycmVjdCBzcGFjaW5nIG9uIGRhdGUgc2VsZWN0aW9uIHJhZGlvIGJ1dHRvbnMgb24gY2hhbmdlIEFSRCBzY3JlZW5cblxuI2FjYy1yZWYtZGF0ZS1mb3JtLWdyb3VwIHtcbiAgbGFiZWwge1xuICAgIG1hcmdpbi1ib3R0b206IDAuNWVtO1xuICB9XG59XG4vL0VtYmVkZGVkIFBERlxuXG4uZW1iZWRkZWQtUERGIHtcbiAgaGVpZ2h0OiAxNjB2aDtcbiAgYm9yZGVyLWJvdHRvbTogMWVtIHNvbGlkICMzQzNDM0M7XG4gIG1hcmdpbjogMWVtIDA7XG59XG4vLyBNYXJnaW5zXG5cbi5tYXJnaW4tdG9wLTAge1xuICBtYXJnaW4tdG9wOiAwO1xufVxuLy9QYXltZW50IHNjcmVlbiAoQ0lDUyBvbmx5KSAtIFRvIGRvOiBtb2JpbGUgc3R5bGVzXG5cbi5wYXltZW50LXN1bW1hcnktc21hbGwge1xuICBiYWNrZ3JvdW5kLWNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJncmV5LTRcIik7XG4gIGJvcmRlcjogMTBweCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbiAgcGFkZGluZzogMWVtIDFlbSAwO1xuICBtYXJnaW4tdG9wOiAyZW07XG59XG5cbi5zdGlja3kge1xuICBwb3NpdGlvbjogLXdlYmtpdC1zdGlja3kgIWltcG9ydGFudDtcbiAgcG9zaXRpb246IHN0aWNreSAhaW1wb3J0YW50O1xuICB0b3A6IDA7XG59XG5cbi5jYXJkLWltYWdlcyB7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcblxuICBpbWcge1xuICAgIGhlaWdodDogMzVweDtcbiAgfVxuXG4gIC5vcmlnaW5hbC1hY2NlcHRlZCB7XG4gICAgbWFyZ2luLWJvdHRvbTogMDtcbiAgICBtYXJnaW4tdG9wOiAxMHB4O1xuICAgIG1heC13aWR0aDogMzQwcHg7XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIHotaW5kZXg6IDE7XG4gIH1cbn1cblxuaW1nLmNhcmQtaW1hZ2Uge1xuICBtYXJnaW4tbGVmdDogOHB4O1xuICBtYXJnaW4tdG9wOiAtNXB4O1xuICBtYXgtaGVpZ2h0OiAzOHB4O1xuICBwYWRkaW5nLXRvcDogMnB4O1xuICB2ZXJ0aWNhbC1hbGlnbjogbWlkZGxlO1xufVxuLy8gU21hbGwtRnVsbCBhY2NvdW50cyBzdHlsaW5nXG4vL0NvbHVtbiBzaXh0aCAoZm9yIGRldGFpbGVkIFRhbmdpYmxlIGFzc2V0IG5vdGVzKVxuXG4uY29sdW1uLW9uZS1zaXh0aCxcbi5jb2x1bW4tc2l4dGgge1xuICBib3gtc2l6aW5nOiBib3JkZXItYm94O1xuICBwYWRkaW5nOiAwIDhweDtcbn1cblxuLmNvbHVtbi1vbmUtc2l4dGgsXG4uY29sdW1uLXNpeHRoIHtcbiAgd2lkdGg6IDEwMCU7XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KGRlc2t0b3ApIHtcbiAgICB3aWR0aDogMTIuNSU7XG4gICAgZmxvYXQ6IGxlZnQ7XG4gIH1cbn1cbi8vQ29sdW1uIGZpZnRoIChmb3IgZGV0YWlsZWQgVGFuZ2libGUgYXNzZXQgbm90ZXMpXG5cbi5jb2x1bW4tZmlmdGgsXG4uY29sdW1uLW9uZS1maWZ0aCB7XG4gIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gIHBhZGRpbmc6IDAgMTVweDtcbn1cblxuLmNvbHVtbi1maWZ0aCxcbi5jb2x1bW4tb25lLWZpZnRoIHtcbiAgd2lkdGg6IDEwMCU7XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KGRlc2t0b3ApIHtcbiAgICB3aWR0aDogMTglO1xuICAgIGZsb2F0OiBsZWZ0O1xuICB9XG59XG5cbi5pbXBvcnRhbnQtbWVzc2FnZSB7XG4gIGJhY2tncm91bmQtY29sb3I6IGdvdnVrLWNvbG91cihcImJsdWVcIik7XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcbiAgcGFkZGluZzogMC45ZW0gMC45ZW0gMC4xZW07XG5cbiAgYSB7XG4gICAgY29sb3I6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICB9XG5cbiAgYTpmb2N1cyxcbiAgYTpob3ZlciB7XG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWhvdmVyLWNvbG91cjtcbiAgfVxufVxuLy9DSUNzLy9cblxuLmNpY3MtdGFzay1saXN0IHtcbiAgbGkudGFzay1saXN0LWl0ZW06Zmlyc3Qtb2YtdHlwZSB7XG4gICAgYm9yZGVyLXRvcDogbm9uZTtcbiAgfVxuXG4gIHNwYW4udGFzay1saXN0LXNlY3Rpb24tbnVtYmVyIHtcbiAgICB3aWR0aDogMzVweDtcbiAgfVxuXG4gIHN0cm9uZy50YXNrLWNvbXBsZXRlZCB7XG4gICAgZmxvYXQ6IHJpZ2h0O1xuICB9XG59XG4vLy8gaW50ZXJydXB0aW9uIGNhcmQgLy8vXG5cbi5jaXJjbGUtc3RlcC13aGl0ZSB7XG4gIGhlaWdodDogMS40ZW07XG4gIHdpZHRoOiAxLjRlbTtcbiAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJibGFja1wiKTtcbiAgYm9yZGVyLXJhZGl1czogNTAlO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHBhZGRpbmc6IDAuNWVtO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIGZvbnQtd2VpZ2h0OiBib2xkO1xuICBtYXJnaW46IC0wLjRlbSAwLjVlbSAwIDA7XG59XG5cbi5jaXJjbGUtc3RlcC1ibGFjayB7XG4gIGhlaWdodDogMS40ZW07XG4gIHdpZHRoOiAxLjRlbTtcbiAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwiYmxhY2tcIik7XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcbiAgYm9yZGVyLXJhZGl1czogNTAlO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIHBhZGRpbmc6IDAuNWVtO1xuICB0ZXh0LWFsaWduOiBjZW50ZXI7XG4gIGZvbnQtd2VpZ2h0OiBib2xkO1xuICBtYXJnaW46IC0wLjRlbSAwLjVlbSAxZW0gMDtcbn1cblxuLmludGVycnVwdGlvbi1jYXJkIHtcbiAgcGFkZGluZzogMmVtIDNlbTtcbiAgYmFja2dyb3VuZDogJGdvdnVrLWxpbmstY29sb3VyIHVybChcIi9wdWJsaWMvaW1hZ2VzL2ZpbGUtYWNjb3VudHMtYW5kLWNpYy1yZXBvcnQtdHJhbnNwYXJlbnQucG5nXCIpIG5vLXJlcGVhdCA5NSUgNjAlO1xuXG4gICYuaW50ZXJydXB0aW9uLWNhcmQtcGFwZXIge1xuICAgIGJhY2tncm91bmQ6ICRnb3Z1ay1saW5rLWNvbG91ciB1cmwoXCIvcHVibGljL2ltYWdlcy9maWxlLXBhcGVyLnBuZ1wiKSBuby1yZXBlYXQgOTAlIDEwMCU7XG4gIH1cbiAgQGluY2x1ZGUgZ292dWstbWVkaWEtcXVlcnkoJHVudGlsOiB0YWJsZXQpIHtcbiAgICBiYWNrZ3JvdW5kLWltYWdlOiBub25lICFpbXBvcnRhbnQ7XG4gIH1cblxuICAmLmludGVycnVwdGlvbi1jYXJkLWNpYy1vbmx5IHtcbiAgICBiYWNrZ3JvdW5kOiAkZ292dWstbGluay1jb2xvdXIgdXJsKFwiL3B1YmxpYy9pbWFnZXMvZmlsZS1jaWMtcmVwb3J0LXRyYW5zcGFyZW50LnBuZ1wiKSBuby1yZXBlYXQgOTAlIDMwJTtcbiAgfVxuICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeSgkdW50aWw6IHRhYmxldCkge1xuICAgIGJhY2tncm91bmQtaW1hZ2U6IG5vbmUgIWltcG9ydGFudDtcbiAgfVxuXG4gICYuaW50ZXJydXB0aW9uLWNhcmQtYWNjb3VudHMtb25seSB7XG4gICAgYmFja2dyb3VuZDogJGdvdnVrLWxpbmstY29sb3VyIHVybChcIi9wdWJsaWMvaW1hZ2VzL2ZpbGUtYWNjb3VudHMtdHJhbnNwYXJlbnQucG5nXCIpIG5vLXJlcGVhdCA5MCUgMzAlO1xuICB9XG4gIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KCR1bnRpbDogdGFibGV0KSB7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogbm9uZSAhaW1wb3J0YW50O1xuICB9XG5cbiAgLmdvdnVrLWJ1dHRvbiB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG4gICAgY29sb3I6IGdvdnVrLWNvbG91cihcImJsYWNrXCIpO1xuXG4gICAgJjpob3ZlciB7XG4gICAgICBiYWNrZ3JvdW5kLWNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJncmV5LTNcIik7XG4gICAgfVxuICB9XG5cbiAgaDEge1xuICAgIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcbiAgfVxuXG4gIGgyIHtcbiAgICBkaXNwbGF5OiBpbmxpbmU7XG4gICAgY29sb3I6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICB9XG5cbiAgdWwge1xuICAgIHdpZHRoOiA3NSU7XG4gICAgcGFkZGluZzogMmVtIDAgMDtcbiAgICBAaW5jbHVkZSBnb3Z1ay1tZWRpYS1xdWVyeShtb2JpbGUpIHtcbiAgICAgIHdpZHRoOiAxMDAlO1xuICAgICAgbWFyZ2luLXRvcDogMC41ZW07XG4gICAgfVxuXG4gICAgbGkge1xuICAgICAgaDIge1xuICAgICAgICBwYWRkaW5nLWJvdHRvbTogMmVtO1xuICAgICAgICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gICAgICAgIHdpZHRoOiA4NSU7XG4gICAgICAgIG1hcmdpbjogMCAwIDAgMC4yZW07XG4gICAgICAgIEBpbmNsdWRlIGdvdnVrLW1lZGlhLXF1ZXJ5KG1vYmlsZSkge1xuICAgICAgICAgIHdpZHRoOiA4MCU7XG4gICAgICAgIH1cbiAgICAgIH1cblxuICAgICAgc3BhbiB7XG4gICAgICAgIHZlcnRpY2FsLWFsaWduOiB0b3A7XG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgYTpsaW5rLFxuICBhOnZpc2l0ZWQge1xuICAgIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKSAhaW1wb3J0YW50O1xuICB9XG5cbiAgLmJ1dHRvbiB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWNvbG91cjtcbiAgICBmb250LXdlaWdodDogNzAwO1xuXG4gICAgJjpmb2N1cyxcbiAgICAmOmhvdmVyIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IGdvdnVrLWNvbG91cihcImdyZXktM1wiKTtcbiAgICAgIGNvbG9yOiAkZ292dWstbGluay1jb2xvdXI7XG4gICAgfVxuICB9XG5cbiAgLmNpcmNsZS13aGl0ZSB7XG4gICAgYmFja2dyb3VuZC1jb2xvcjogZ292dWstY29sb3VyKFwid2hpdGVcIik7XG4gICAgY29sb3I6IGdvdnVrLWNvbG91cihcImJsYWNrXCIpO1xuICAgIG1hcmdpbi1yaWdodDogMC41ZW07XG4gICAgcG9zaXRpb246IHJlbGF0aXZlO1xuICAgIHRvcDogLS4zZW07XG4gIH1cbn1cblxuLmZsb2F0LXJpZ2h0IHtcbiAgZmxvYXQ6IHJpZ2h0O1xufSIsIlxuLy9SZXN0eWxpbmcgQ0hTIHByb2ZpbGVcbiNjb21wYW55LW51bWJlciB7XG4gIG1hcmdpbi10b3A6LTNlbTtcbn1cbiNhY3Rpb24tYnV0dG9ucyB7XG4gIG1hcmdpbjogMS41ZW0gMCAzZW07XG4gIGEge1xuICAgIG1hcmdpbi1yaWdodDogLjVlbTtcbiAgfVxuICBhI21hbmFnZS1jb21wYW55LWF1dGhlbnRpY2F0aW9uIHtcbiAgICBtYXJnaW4tdG9wOi43ZW07XG4gICAgZGlzcGxheTppbmxpbmUtYmxvY2s7XG4gIH1cbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA2NDBweCkge1xuICAjY29tcGFueS1udW1iZXIge1xuICAgIG1hcmdpbi10b3A6LTFlbSAhaW1wb3J0YW50O1xuICB9XG4gICNhY3Rpb24tYnV0dG9ucyB7XG4gICAgbWFyZ2luLWJvdHRvbTowO1xuICAgIGEge1xuICAgICAgbWFyZ2luLWJvdHRvbTowO1xuICAgIH1cbiAgICBhI21hbmFnZS1jb21wYW55LWF1dGhlbnRpY2F0aW9uIHtcbiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjtcbiAgICAgIGRpc3BsYXk6IGJsb2NrO1xuICAgIH1cbiAgfVxuICAjc2VhcmNoIC5zZWFyY2hmaWVsZCBpbnB1dCxcbiAgI3Byb2ZpbGUgLnNlYXJjaGZpZWxkIGlucHV0IHtcbiAgICB3aWR0aDogNzUlO1xuICB9XG4gICNzZWFyY2ggYTpsaW5rLFxuICAjcHJvZmlsZSBhOmxpbmsge1xuICAgIGZsb2F0OiByaWdodDtcbiAgfVxufVxuIiwiLy9DSFMgc3R5bGVzIC0gTk9UIEZPUiBQUk9EVUNUSU9OIVxuXG4jZ2xvYmFsLWhlYWRlciB7XG4gIGEjbG9nbyB7XG4gICAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiL3B1YmxpYy9pbWFnZXMvcm95YWwtY29hdC1vZi1hcm1zLXdoaXRlLnBuZ1wiKTtcbiAgICBiYWNrZ3JvdW5kLXBvc2l0aW9uOiAxMHB4IHRvcDtcbiAgICBiYWNrZ3JvdW5kLXNpemU6IDQ3cHggNDJweDtcbiAgICBwYWRkaW5nOiA4cHggMCAycHggNjJweDtcbiAgICB3aWR0aDogNDAwcHg7XG4gIH1cblxuICBhI3Byb3Bvc2l0aW9uLW5hbWUge1xuICAgIHBhZGRpbmctbGVmdDogMWVtO1xuICAgIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgICB0b3A6IDAuMzVlbTtcbiAgfVxufVxuXG4ubm9ybWFsIHtcbiAgZm9udC13ZWlnaHQ6IG5vcm1hbDtcbn1cblxudWwjbmF2aWdhdGlvbiB7XG4gIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbiAgZm9udC1zaXplOiAwLjllbTtcbiAgbWFyZ2luOiAwIDAgMWVtO1xuICBwYWRkaW5nOiAwLjhlbSAwO1xuICB0ZXh0LWFsaWduOiByaWdodDtcblxuICBsaSB7XG4gICAgZGlzcGxheTogaW5saW5lO1xuICAgIHBhZGRpbmc6IDAgMCAwIDEuNWVtO1xuICAgIGZvbnQtZmFtaWx5OiBcIm50YVwiLCBBcmlhbDtcbiAgICBmb250LXNpemU6IDE2cHg7XG4gIH1cbn1cblxuLmNlbnRlciB7XG4gIHRleHQtYWxpZ246IGNlbnRlcjtcbn1cblxuLnNlYXJjaC1iYXItYWN0aXZlIHtcbiAgYmFja2dyb3VuZDogJGdvdnVrLWNhbnZhcy1iYWNrZ3JvdW5kLWNvbG91ciBub25lIHJlcGVhdCBzY3JvbGwgMCAwO1xuICBwYWRkaW5nOiAwLjRlbSAwLjRlbSAwO1xuICBtYXJnaW4tYm90dG9tOiAyMHB4O1xufVxuXG4uanMtc2VhcmNoLWZvY3VzIHtcbiAgZm9udC1zaXplOiAxOXB4O1xuICBmb250LXdlaWdodDogNDAwO1xuICBoZWlnaHQ6IDUycHg7XG4gIGxpbmUtaGVpZ2h0OiAxLjMxNTc5O1xuICBtYXJnaW46IDA7XG4gIHBhZGRpbmc6IDAgMCAwIDEwcHg7XG4gIHRleHQtdHJhbnNmb3JtOiBub25lO1xuICB3aWR0aDogOTMlO1xufVxuXG4uZ292dWstYnV0dG9uLXNlYXJjaCB7XG4gIGJhY2tncm91bmQtY29sb3I6ICRnb3Z1ay1saW5rLWNvbG91cjtcbiAgYmFja2dyb3VuZC1pbWFnZTogdXJsKFwiL3B1YmxpYy9pbWFnZXMvc2VhcmNoLWJ1dHRvbi5wbmdcIik7XG4gIGJhY2tncm91bmQtcG9zaXRpb246IC0xMi41JSA1MCU7XG4gIGJhY2tncm91bmQtcmVwZWF0OiBuby1yZXBlYXQ7XG4gIGJvcmRlci1yYWRpdXM6IDA7XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJ3aGl0ZVwiKTtcbiAgaGVpZ2h0OiA1MnB4O1xuICBvdmVyZmxvdzogaGlkZGVuO1xuICB0ZXh0LWluZGVudDogLTUwMDBweDtcbiAgd2lkdGg6IDU0cHg7XG4gIHotaW5kZXg6IDQ7XG4gIG1hcmdpbi1ib3R0b206IDVweDtcblxuICAmOmZvY3VzLFxuICAmOmhvdmVyIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMmI4Y2M0O1xuICB9XG59XG5cbnN1cC5sYWJlbCB7XG4gIGNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJicmlnaHQtcHVycGxlXCIpO1xuICBkaXNwbGF5OiBpbmxpbmUtYmxvY2s7XG4gIGZvbnQtc2l6ZTogMC44ZW07XG4gIGZvbnQtd2VpZ2h0OiA3MDA7XG59XG5cbnVsLnNlYXJjaC10YWJzIHtcbiAgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkICRnb3Z1ay1ib3JkZXItY29sb3VyO1xuICBtYXJnaW4tYm90dG9tOiAzMHB4O1xuICBvdmVyZmxvdzogYXV0bztcbiAgcGFkZGluZzogMDtcblxuICBsaSB7XG4gICAgZmxvYXQ6IGxlZnQ7XG4gICAgbGlzdC1zdHlsZS10eXBlOiBub25lO1xuICAgIG1hcmdpbjogMCAyMHB4IDAgMDtcbiAgICBwYWRkaW5nOiAwIDhweCAxMHB4O1xuXG4gICAgJi5hY3RpdmUge1xuICAgICAgYm9yZGVyLWJvdHRvbTogMnB4IHNvbGlkICRnb3Z1ay1saW5rLWNvbG91cjtcbiAgICB9XG5cbiAgICBhIHtcbiAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcblxuICAgICAgJjpmb2N1cyxcbiAgICAgICY6aG92ZXIsXG4gICAgICAmOnZpc2l0ZWQge1xuICAgICAgICBjb2xvcjogJGdvdnVrLWxpbmstY29sb3VyO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG5tYWluLnNlYXJjaCAucmVzdWx0cy1saXN0IHtcbiAgcCB7XG4gICAgZm9udC1zaXplOiAxNnB4O1xuICAgIGxpbmUtaGVpZ2h0OiAxLjI1O1xuICAgIG1hcmdpbjogMDtcbiAgICBwYWRkaW5nOiAwO1xuICAgIHRleHQtdHJhbnNmb3JtOiBub25lO1xuXG4gICAgJi5tZXRhIHtcbiAgICAgIGNvbG9yOiAkZ292dWstc2Vjb25kYXJ5LXRleHQtY29sb3VyO1xuICAgICAgZm9udC1zaXplOiAxNnB4O1xuICAgICAgcGFkZGluZzogMCAwIDNweDtcbiAgICAgIHdvcmQtd3JhcDogYnJlYWstd29yZDtcbiAgICB9XG4gIH1cblxuICBsaSB7XG4gICAgcGFkZGluZzogMCAwIDI1cHg7XG4gIH1cblxuICBoMyB7XG4gICAgcGFkZGluZzogMDtcbiAgICBtYXJnaW46IDA7XG5cbiAgICBhIHtcbiAgICAgIGNvbG9yOiAkZ292dWstbGluay1jb2xvdXI7XG4gICAgICBmb250LXNpemU6IDIwcHg7XG4gICAgICBmb250LXdlaWdodDogbm9ybWFsO1xuICAgICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuXG4gICAgICAmOmZvY3VzLFxuICAgICAgJjpob3ZlcixcbiAgICAgICY6dmlzaXRlZCB7XG4gICAgICAgIGNvbG9yOiAkZ292dWstbGluay1ob3Zlci1jb2xvdXI7XG4gICAgICAgIHRleHQtZGVjb3JhdGlvbjogdW5kZXJsaW5lO1xuICAgICAgfVxuICAgIH1cbiAgfVxufVxuXG51bC5wYWdlciB7XG4gIHBhZGRpbmctdG9wOiAyZW07XG5cbiAgbGkge1xuICAgIGRpc3BsYXk6IGlubGluZTtcbiAgICBmbG9hdDogbGVmdDtcbiAgICBtYXJnaW46IDA7XG4gICAgcGFkZGluZzogMCAxLjRlbSAwIDA7XG4gIH1cbn1cblxuLmRhdGEsXG5iLFxuc3Ryb25nIHtcbiAgZm9udC13ZWlnaHQ6IGJvbGQ7XG4gIG1hcmdpbjogMDtcbn1cblxuLnZpZXcge1xuICBkaXNwbGF5OiBub25lO1xuXG4gICYuYWN0aXZlIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgfVxufVxuXG4ucHJvZmlsZSBkbCB7XG4gIG1hcmdpbi1ib3R0b206IDIwcHg7XG59XG5cbi5zZWN0aW9uLXRhYnM6OmFmdGVyIHtcbiAgY2xlYXI6IGJvdGg7XG4gIGNvbnRlbnQ6ICcnO1xuICBkaXNwbGF5OiBibG9jaztcbn1cblxuLnNlY3Rpb24tdGFicyB7XG4gIGJvcmRlci1ib3R0b206IDFweCBzb2xpZCAkZ292dWstYm9yZGVyLWNvbG91cjtcbiAgbWFyZ2luOiAxLjVlbSAwO1xufVxuQG1lZGlhIChtYXgtd2lkdGg6IDY0MHB4KSB7XG4gIC5zZWN0aW9uLXRhYnMge1xuICAgIGJvcmRlci1ib3R0b206IG1lZGl1bSBub25lO1xuICAgIG1hcmdpbjogMzBweCAwO1xuICB9XG59XG5cbi5zZWN0aW9uLXRhYnMgdWwge1xuICBtYXJnaW46IDA7XG4gIHBhZGRpbmc6IDA7XG4gIHBvc2l0aW9uOiByZWxhdGl2ZTtcbiAgdG9wOiAxcHg7XG59XG5cbi5zZWN0aW9uLXRhYnMgdWwgbGkge1xuICBkaXNwbGF5OiBpbmxpbmU7XG4gIGZsb2F0OiBsZWZ0O1xuICBsaXN0LXN0eWxlOiBvdXRzaWRlIG5vbmUgbm9uZTtcbiAgbWFyZ2luOiAwO1xuICBwYWRkaW5nOiAwO1xuXG4gIGgxIHtcbiAgICBtYXJnaW46IDA7XG4gIH1cbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA2NDBweCkge1xuICAuc2VjdGlvbi10YWJzIHVsIGxpIHtcbiAgICBkaXNwbGF5OiBibG9jaztcbiAgICBmbG9hdDogbm9uZTtcbiAgfVxufVxuXG4uc2VjdGlvbi10YWJzIHVsIGEge1xuICAtbW96LWJvcmRlci1ib3R0b20tY29sb3JzOiBub25lO1xuICAtbW96LWJvcmRlci1sZWZ0LWNvbG9yczogbm9uZTtcbiAgLW1vei1ib3JkZXItcmlnaHQtY29sb3JzOiBub25lO1xuICAtbW96LWJvcmRlci10b3AtY29sb3JzOiBub25lO1xuICBiYWNrZ3JvdW5kOiAkZ292dWstY2FudmFzLWJhY2tncm91bmQtY29sb3VyIG5vbmUgcmVwZWF0IHNjcm9sbCAwIDA7XG4gIGJvcmRlci1jb2xvcjogJGdvdnVrLWNhbnZhcy1iYWNrZ3JvdW5kLWNvbG91ciAkZ292dWstY2FudmFzLWJhY2tncm91bmQtY29sb3VyIC1tb3otdXNlLXRleHQtY29sb3I7XG4gIGJvcmRlci1pbWFnZTogbm9uZTtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZCBzb2xpZCBub25lO1xuICBib3JkZXItd2lkdGg6IDFweCAxcHggbWVkaXVtO1xuICBkaXNwbGF5OiBibG9jaztcbiAgZm9udC1zaXplOiAxOXB4O1xuICBmb250LXdlaWdodDogYm9sZDtcbiAgbGluZS1oZWlnaHQ6IDEuMzE1Nzk7XG4gIG1hcmdpbjogNXB4IDVweCA2cHggMDtcbiAgb3ZlcmZsb3c6IGhpZGRlbjtcbiAgcGFkZGluZzogNXB4IDA7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgdGV4dC10cmFuc2Zvcm06IG5vbmU7XG5cbiAgJjp2aXNpdGVkIHtcbiAgICBjb2xvcjogJGdvdnVrLWxpbmstY29sb3VyO1xuICB9XG5cbiAgJjpob3ZlciB7XG4gICAgY29sb3I6ICRnb3Z1ay1saW5rLWhvdmVyLWNvbG91cjtcbiAgfVxufVxuQG1lZGlhIChtYXgtd2lkdGg6IDY0MHB4KSB7XG4gIC5zZWN0aW9uLXRhYnMgdWwgYSB7XG4gICAgZm9udC1zaXplOiAxNnB4O1xuICAgIGxpbmUtaGVpZ2h0OiAxLjI1O1xuICB9XG59XG5cbi5zZWN0aW9uLXRhYnMgdWwgYTpmb2N1cyAubGFiZWwsXG4uc2VjdGlvbi10YWJzIHVsIGE6aG92ZXIgLmxhYmVsIHtcbiAgdGV4dC1kZWNvcmF0aW9uOiB1bmRlcmxpbmU7XG59XG5AbWVkaWEgKG1heC13aWR0aDogNjQwcHgpIHtcbiAgLnNlY3Rpb24tdGFicyB1bCBhIHtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gICAgZm9udC1zaXplOiAxNnB4O1xuICAgIGZvbnQtd2VpZ2h0OiBub3JtYWw7XG4gICAgbGluZS1oZWlnaHQ6IDEuMjU7XG4gICAgbWFyZ2luOiA1cHggMCAwO1xuICAgIHBhZGRpbmc6IDVweCAwIDVweCA1cHg7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiB1bmRlcmxpbmU7XG4gICAgdGV4dC10cmFuc2Zvcm06IG5vbmU7XG4gICAgd2lkdGg6IGNhbGMoMTAwJSAtIDEwcHgpO1xuICB9XG59XG5AbWVkaWEgKG1heC13aWR0aDogNjQwcHgpIGFuZCAobWF4LXdpZHRoOiA2NDBweCkge1xuICAuc2VjdGlvbi10YWJzIHVsIGEge1xuICAgIGZvbnQtc2l6ZTogMTRweDtcbiAgICBsaW5lLWhlaWdodDogMS4xNDI4NjtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDY0MXB4KSB7XG4gIC5zZWN0aW9uLXRhYnMgdWwgYSB7XG4gICAgcGFkZGluZzogMTFweCAxNHB4IDlweCA5cHg7XG4gIH1cbn1cblxuLnNlY3Rpb24tdGFicyB1bCBsaS5hY3RpdmUgYSB7XG4gIGJhY2tncm91bmQ6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpIG5vbmUgcmVwZWF0IHNjcm9sbCAwIDA7XG4gIGJvcmRlci1jb2xvcjogJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gIG1hcmdpbjogMCA1cHggMCAwO1xuICBwYWRkaW5nOiAxMHB4IDlweDtcbn1cbkBtZWRpYSAobWF4LXdpZHRoOiA2NDBweCkge1xuICAuc2VjdGlvbi10YWJzIHVsIGxpLmFjdGl2ZSBhIHtcbiAgICBib3JkZXItYm90dG9tOiAxcHggc29saWQgJGdvdnVrLWJvcmRlci1jb2xvdXI7XG4gICAgZm9udC13ZWlnaHQ6IGJvbGQ7XG4gICAgbWFyZ2luOiA1cHggMCAwO1xuICAgIHBhZGRpbmc6IDVweCAwIDVweCA1cHg7XG4gICAgdGV4dC1kZWNvcmF0aW9uOiBub25lO1xuICAgIHdpZHRoOiBjYWxjKDEwMCUgLSAxMHB4KTtcbiAgfVxufVxuQG1lZGlhIChtaW4td2lkdGg6IDY0MXB4KSB7XG4gIC5zZWN0aW9uLXRhYnMgdWwgbGkuYWN0aXZlIGEge1xuICAgIHBhZGRpbmc6IDE2cHggMTlweCAxNXB4IDE0cHg7XG4gIH1cbn1cblxuLnNlY3Rpb24tdGFicyB1bCBsaS5hY3RpdmUgYTpmb2N1cyB7XG4gIG91dGxpbmU6IG1lZGl1bSBub25lO1xufVxuXG4uc2VjdGlvbi10YWJzIHVsIGxpLmFjdGl2ZSBhIC5sYWJlbCB7XG4gIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbn1cblxuLnNlY3Rpb24tdGFicyB1bC50d28tdGFicyBsaSB7XG4gIHdpZHRoOiA1MCU7XG59XG5AbWVkaWEgKG1pbi13aWR0aDogNzY5cHgpIHtcbiAgLnNlY3Rpb24tdGFicyB1bC50d28tdGFicyBsaSB7XG4gICAgbWluLXdpZHRoOiAzMy4zMzMlO1xuICAgIHdpZHRoOiBhdXRvO1xuICB9XG59XG5cbi5zZWN0aW9uLXRhYnMucGxhaW4tdGFicyAudGFiLW5hdmlnYXRpb24gdWwgbGkgYSB7XG4gIGJhY2tncm91bmQtY29sb3I6IGdvdnVrLWNvbG91cihcIndoaXRlXCIpO1xuICBib3JkZXI6IG1lZGl1bSBub25lO1xuICBmb250LXdlaWdodDogbm9ybWFsO1xuICB0ZXh0LWRlY29yYXRpb246IHVuZGVybGluZTtcbn1cblxuLnNlY3Rpb24tdGFicy5wbGFpbi10YWJzIC50YWItbmF2aWdhdGlvbiB1bCBsaS5hY3RpdmUgYSB7XG4gIC1tb3otYm9yZGVyLWJvdHRvbS1jb2xvcnM6IG5vbmU7XG4gIC1tb3otYm9yZGVyLWxlZnQtY29sb3JzOiBub25lO1xuICAtbW96LWJvcmRlci1yaWdodC1jb2xvcnM6IG5vbmU7XG4gIC1tb3otYm9yZGVyLXRvcC1jb2xvcnM6IG5vbmU7XG4gIGJvcmRlci1jb2xvcjogJGdvdnVrLWNhbnZhcy1iYWNrZ3JvdW5kLWNvbG91ciAkZ292dWstY2FudmFzLWJhY2tncm91bmQtY29sb3VyIC1tb3otdXNlLXRleHQtY29sb3I7XG4gIGJvcmRlci1pbWFnZTogbm9uZTtcbiAgYm9yZGVyLXN0eWxlOiBzb2xpZCBzb2xpZCBub25lO1xuICBib3JkZXItd2lkdGg6IDFweCAxcHggbWVkaXVtO1xufVxuXG4uY29tcGFueS1oZWFkZXIge1xuICBtYXJnaW4tdG9wOiAyZW07XG59XG5cbiNhY2NvdW50cy1zdGFydC1wYWdlIGxpIHNwYW4ge1xuICBtYXJnaW4tcmlnaHQ6IDAuOWVtO1xuICBtYXJnaW4tYm90dG9tOiAxZW07XG59XG5cbm9sLmV4YW1wbGUtaWNvbi1saXN0IHtcbiAgaSB7XG4gICAgbWFyZ2luLXJpZ2h0OiAwLjVlbTtcbiAgICBwb3NpdGlvbjogcmVsYXRpdmU7XG4gICAgdG9wOiAwLjJlbTtcbiAgfVxufVxuXG4uZ2V0LXN0YXJ0ZWQgLmRlc3RpbmF0aW9uIHtcbiAgZGlzcGxheTogYmxvY2s7XG4gIGZvbnQtc2l6ZTogMTZweDtcbiAgZm9udC1zaXplLWFkanVzdDogMC41O1xuICBmb250LXdlaWdodDogNDAwO1xuICBsaW5lLWhlaWdodDogMS4yNTtcbiAgbWFyZ2luLXRvcDogMC4yZW07XG4gIG1heC13aWR0aDogMTNlbTtcbiAgdGV4dC10cmFuc2Zvcm06IG5vbmU7XG59XG5cbi5jaHMtZW1haWwge1xuICB1bCB7XG4gICAgQGluY2x1ZGUgZ292dWstZm9udCgkc2l6ZTogMTYpO1xuICAgIHBhZGRpbmctdG9wOiAxZW07XG5cbiAgICBsaSB7XG4gICAgICBwYWRkaW5nLWJvdHRvbTogMWVtO1xuICAgIH1cbiAgfVxuXG4gIHRhYmxlIHtcbiAgICBiYWNrZ3JvdW5kLWNvbG9yOiBnb3Z1ay1jb2xvdXIoXCJncmV5LTRcIik7XG4gICAgbWFyZ2luOiAyZW0gMDtcblxuICAgIHRoIHtcbiAgICAgIGJhY2tncm91bmQtY29sb3I6IGdvdnVrLWNvbG91cihcImdyZXktM1wiKTtcbiAgICAgIHBhZGRpbmc6IDdlbSAxZW07XG4gICAgfVxuXG4gICAgdGQge1xuICAgICAgcGFkZGluZzogMC43ZW0gMWVtO1xuICAgIH1cbiAgfVxufVxuXG4uYWN0aW9uLWJ1dHRvbi1saXN0IGxpIHtcbiAgcGFkZGluZy1ib3R0b206IDAuN2VtO1xufVxuXG4uZGVzdGluYXRpb24ge1xuICBmb250LXNpemU6IDE2cHg7XG4gIGRpc3BsYXk6IGJsb2NrO1xuICBwYWRkaW5nLXRvcDogMC41ZW07XG4gIG1heC13aWR0aDogMTNlbTtcbn1cblxuLmhpZGRlbiB7XG4gIGRpc3BsYXk6IG5vbmU7XG4gIHZpc2liaWxpdHk6IGhpZGRlbjtcbn1cblxuLnVwcGVyY2FzZSB7XG4gIHRleHQtdHJhbnNmb3JtOiB1cHBlcmNhc2U7XG59Il0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7QXdDUUUsQUFOQSxXQU1XLEVLSlgsQ0FBQyxDTEZXO0VIYVosV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztDR1hqQzs7QVZhRyxvTEFBb0w7QUFFcEwsVUFBVTtFQUNSLFdBQVcsRUFBRSxLQUFLO0VBQ2xCLEdBQUcsRVZFQyw0Q0FBa0M7RVVEdEMsR0FBRyxFVkNDLG1EQUFrQyxDVURnQiwyQkFBMkIsRVZDN0UsOENBQWtDLENVQVcsZUFBZSxFVkE1RCw2Q0FBa0MsQ1VDVSxjQUFjO0VBQzlELFdBQVcsRUFBRSxNQUFNO0VBQ25CLFVBQVUsRUFBRSxNQUFNO0VBQ2xCLFlBQVksRUFBRSxRQUFROzs7QUFHeEIsVUFBVTtFQUNSLFdBQVcsRUFBRSxLQUFLO0VBQ2xCLEdBQUcsRVZUQywyQ0FBa0M7RVVVdEMsR0FBRyxFVlZDLGtEQUFrQyxDVVVlLDJCQUEyQixFVlY1RSw2Q0FBa0MsQ1VXVSxlQUFlLEVWWDNELDRDQUFrQyxDVVlTLGNBQWM7RUFDN0QsV0FBVyxFQUFFLElBQUk7RUFDakIsVUFBVSxFQUFFLE1BQU07RUFDbEIsWUFBWSxFQUFFLFFBQVE7OztBQUd4QixVQUFVO0VBQ1IsV0FBVyxFQUFFLG1CQUFtQjtFQUNoQyxHQUFHLEVWcEJDLG9EQUFrQztFVXFCdEMsR0FBRyxFVnJCQywyREFBa0MsQ1VxQndCLDJCQUEyQixFVnJCckYsc0RBQWtDLENVc0JtQixlQUFlLEVWdEJwRSxxREFBa0MsQ1V1QmtCLGNBQWM7RUFDdEUsV0FBVyxFQUFFLE1BQU07RUFDbkIsVUFBVSxFQUFFLE1BQU07RUFDbEIsWUFBWSxFQUFFLFFBQVE7OztBQUd4QixVQUFVO0VBQ1IsV0FBVyxFQUFFLG1CQUFtQjtFQUNoQyxHQUFHLEVWL0JDLG1EQUFrQztFVWdDdEMsR0FBRyxFVmhDQywwREFBa0MsQ1VnQ3VCLDJCQUEyQixFVmhDcEYscURBQWtDLENVaUNrQixlQUFlLEVWakNuRSxvREFBa0MsQ1VrQ2lCLGNBQWM7RUFDckUsV0FBVyxFQUFFLElBQUk7RUFDakIsVUFBVSxFQUFFLE1BQU07RUFDbEIsWUFBWSxFQUFFLFFBQVE7OztBSXdLdEIsTUFBTSxDQUFDLEtBQUs7RU05TmxCLEFBTkEsV0FNVyxFS0pYLENBQUMsQ0xGVztJSHVCVixXQUFXLEV0QklXLFVBQVU7R3lCdkJqQzs7O0FBRUQsQVhvQkEsV1dwQlcsQVhvQlYsTUFBTSxFZ0J4QlAsQ0FBQyxBaEJ3QkEsTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJ1RFMsR0FBRyxDZ0J2RFMsS0FBSyxDckJOekIsT0FBTztFcUJPZixjQUFjLEVBQUUsQ0FBQztFQUNqQixnQkFBZ0IsRXJCUlIsT0FBTztDcUJTaEI7O0FXeEJELEFSdUJBLFdRdkJXLEFSdUJWLEtBQUssRWEzQk4sQ0FBQyxBYjJCQSxLQUFLLENBQUM7RUFDTCxLQUFLLEV4QkpDLE9BQU87Q3dCS2Q7O0FRekJELEFSMkJBLFdRM0JXLEFSMkJWLFFBQVEsRWEvQlQsQ0FBQyxBYitCQSxRQUFRLENBQUM7RUFDUixLQUFLLEV0QitFbUIsT0FBTztDc0I5RWhDOztBUTdCRCxBUitCQSxXUS9CVyxBUitCVixNQUFNLEVhbkNQLENBQUMsQWJtQ0EsTUFBTSxDQUFDO0VBQ04sS0FBSyxFeEJiTyxPQUFPO0N3QmNwQjs7QVFqQ0QsQVJtQ0EsV1FuQ1csQVJtQ1YsT0FBTyxFYXZDUixDQUFDLEFidUNBLE9BQU8sQ0FBQztFQUNQLEtBQUssRXhCakJPLE9BQU87Q3dCa0JwQjs7QUV5TEssTUFBTSxDQUFDLEtBQUs7RU05TmxCLEFSaUlJLFdRaklPLENSOEhSLEFBQUEsSUFBQyxFQUFNLEdBQUcsQUFBVCxDQUdDLE9BQU8sRWFySVosQ0FBQyxDYmtJRSxBQUFBLElBQUMsRUFBTSxHQUFHLEFBQVQsQ0FHQyxPQUFPLEVRaklaLFdBQVcsQ1IrSFIsQUFBQSxJQUFDLEVBQU0sU0FBUyxBQUFmLENBRUMsT0FBTyxFYXJJWixDQUFDLENibUlFLEFBQUEsSUFBQyxFQUFNLFNBQVMsQUFBZixDQUVDLE9BQU8sRVFqSVosV0FBVyxDUmdJUixBQUFBLElBQUMsRUFBTSxVQUFVLEFBQWhCLENBQ0MsT0FBTyxFYXJJWixDQUFDLENib0lFLEFBQUEsSUFBQyxFQUFNLFVBQVUsQUFBaEIsQ0FDQyxPQUFPLENBQUM7SUFDUCxPQUFPLEVBQUUsSUFBSSxDQUFDLFVBQVUsQ0FBQyxHQUFHO0lBQzVCLFNBQVMsRUFBRSxHQUFHO0lBS2QsU0FBUyxFQUFFLFVBQVU7R0FDdEI7OztBUWxJTCxBUmtEQSxrQlFsRGtCLEFSa0RqQixLQUFLLEVRbEROLGtCQUFrQixBUm1EakIsUUFBUSxFUW5EVCxrQkFBa0IsQVJvRGpCLE1BQU0sRVFwRFAsa0JBQWtCLEFScURqQixPQUFPLENBQUM7RUFDUCxLQUFLLEV4QnRDRyxPQUFPO0N3QnVDaEI7O0FRdkRELEFSMkRBLGtCUTNEa0IsQVIyRGpCLE1BQU0sQ0FBQztFQUNOLEtBQUssRXhCN0NFLE9BQU87Q3dCOENmOztBUTdERCxBUm1FRSxrQlFuRWdCLEFSbUVmLEtBQUssQUFBQSxNQUFNLENBQUM7RUs5Q2YsS0FBSyxFN0JOSSxPQUFPO0N3QnNEYjs7QUVrSkcsTUFBTSxDQUFDLEtBQUs7RU12TmxCLEFSbUVFLGtCUW5FZ0IsQVJtRWYsS0FBSyxBQUFBLE1BQU0sQ0FBQztJSzNDYixLQUFLLEUzQlVpQixPQUFPO0dzQm1DNUI7OztBUWpFSCxBUnVGQSx3QlF2RndCLEFSdUZ2QixLQUFLLEVRdkZOLHdCQUF3QixBUndGdkIsUUFBUSxFUXhGVCx3QkFBd0IsQVJ5RnZCLE1BQU0sRVF6RlAsd0JBQXdCLEFSMEZ2QixPQUFPLEVRMUZSLHdCQUF3QixBUjJGdkIsTUFBTSxDQUFDO0VLMUVSLEtBQUssRTdCTkksT0FBTztDd0JrRmY7O0FFc0hLLE1BQU0sQ0FBQyxLQUFLO0VNbk5sQixBUnVGQSx3QlF2RndCLEFSdUZ2QixLQUFLLEVRdkZOLHdCQUF3QixBUndGdkIsUUFBUSxFUXhGVCx3QkFBd0IsQVJ5RnZCLE1BQU0sRVF6RlAsd0JBQXdCLEFSMEZ2QixPQUFPLEVRMUZSLHdCQUF3QixBUjJGdkIsTUFBTSxDQUFDO0lLdkVOLEtBQUssRTNCVWlCLE9BQU87R3NCK0Q5Qjs7O0FRN0ZELEFSbUdFLHdCUW5Hc0IsQVJtR3JCLEtBQUssQUFBQSxNQUFNLENBQUM7RUtsRmYsS0FBSyxFN0JOSSxPQUFPO0N3QjBGYjs7QUU4R0csTUFBTSxDQUFDLEtBQUs7RU1uTmxCLEFSbUdFLHdCUW5Hc0IsQVJtR3JCLEtBQUssQUFBQSxNQUFNLENBQUM7SUsvRWIsS0FBSyxFM0JVaUIsT0FBTztHc0J1RTVCOzs7QVF0RkgsQUFDRSw2QkFEMkIsQUFDMUIsUUFBUSxDQUFDO0VBQ1IsS0FBSyxFaENSRCxPQUFPO0NnQ1NaOztBQ0dILEFBdENBLFdBc0NXLENBdENDO0VKYVosV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsSUFBeUI7RUF0Q3pDLEtBQUssRTdCTkksT0FBTztFaUN6QmQsVUFBVSxFQUFFLENBQUM7RUxpRlQsYUFBMEIsRXhCOUJ4QixJQUFJO0U2QmpEVixZQUFZLEVBQUUsQ0FBQztFQUNmLGVBQWUsRUFBRSxJQUFJO0NBTXRCOztBUHdOSyxNQUFNLENBQUMsS0FBSztFTzlMbEIsQUF0Q0EsV0FzQ1csQ0F0Q0M7SUp1QlYsV0FBVyxFdEJJVyxVQUFVO0cwQmZqQzs7O0FQd05LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFTzlMbEMsQUF0Q0EsV0FzQ1csQ0F0Q0M7SUpvSk4sU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0dJNUR4Qzs7O0FQd05LLE1BQU0sQ0FBQyxLQUFLO0VPOUxsQixBQXRDQSxXQXNDVyxDQXRDQztJSitJTixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0d5Qi9IcEI7OztBUHdOSyxNQUFNLENBQUMsS0FBSztFTzlMbEIsQUF0Q0EsV0FzQ1csQ0F0Q0M7SUpxQ1YsS0FBSyxFM0JVaUIsT0FBTztHK0JuQzlCOzs7QVB3TkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VPOUxsQyxBQXRDQSxXQXNDVyxDQXRDQztJTDJGSixhQUEwQixFeEJwQ3hCLElBQUk7RzZCM0NiOzs7QUEwQkQsQUE3QkUsV0E2QlMsQ0FBWCxXQUFXLENBN0JHO0VBQ1YsVUFBVSxFN0JDWCxJQUFJO0M2QkFKOztBUHlORyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RU85TGxDLEFBeEJBLFdBd0JXLEdBeEJHLEVBQUUsQ0FBQztJQUViLGFBQWEsRTdCTmQsR0FBRztHNkJRTDs7O0FBb0JELEFBakJFLFdBaUJTLENBbEJDLENBQUMsQUFDVixLQUFLLENBQUM7RUFDTCxLQUFLLEVqQ0lELE9BQU87Q2lDSFo7O0FBZUgsQUFiRSxXQWFTLENBbEJDLENBQUMsQUFLVixRQUFRLENBQUM7RUFDUixLQUFLLEUvQnVGaUIsT0FBTztDK0J0RjlCOztBQVdILEFBVEUsV0FTUyxDQWxCQyxDQUFDLEFBU1YsTUFBTSxDQUFDO0VBQ04sS0FBSyxFakNMSyxPQUFPO0NpQ01sQjs7QUFPSCxBQUxFLFdBS1MsQ0FsQkMsQ0FBQyxBQWFWLE9BQU8sQ0FBQztFQUNQLEtBQUssRWpDVEssT0FBTztDaUNVbEI7O0FBYUgsQUFOQSxtQkFNbUIsQ0FOQztFQUNsQixZQUFZLEU3QjlCWCxJQUFJO0U2QmdDTCxlQUFlLEVBQUUsSUFBSTtDQUN0Qjs7QUFXRCxBQUxBLG1CQUttQixDQUxDO0VBQ2xCLFlBQVksRTdCeENYLElBQUk7RTZCeUNMLGVBQWUsRUFBRSxPQUFPO0NBQ3pCOztBQ3BERCxBQUFBLGVBQWUsQ0FBQztFQUdkLGdCQUFnQixFbEN5QlIsT0FBTztDa0N4QmhCOztBQUdELEFBQUEscUJBQXFCLENBQUM7RUFHcEIsTUFBTSxFQUFFLENBQUM7RUFFVCxnQkFBZ0IsRWxDa0JULE9BQU87Q2tDakJmOztBQ0pELEFBVkEsaUJBVWlCLENBVkM7RU5nQ2xCLEtBQUssRTdCTkksT0FBTztFNkJmaEIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQTJDbEMsV0FBVyxFdEJiWSxHQUFHO0VzQjJGdEIsU0FBUyxFckI5REUsSUFBSTtFcUJrRWYsV0FBVyxFQXBFQyxPQUF5QjtFTWxFdkMsT0FBTyxFQUFFLEtBQUs7RUFFZCxVQUFVLEVBQUUsQ0FBQztFUDRFVCxhQUEwQixFeEJkeEIsSUFBSTtDK0I1RFg7O0FUME5LLE1BQU0sQ0FBQyxLQUFLO0VTeE5sQixBQVZBLGlCQVVpQixDQVZDO0lObUNoQixLQUFLLEUzQlVpQixPQUFPO0dpQ3JDOUI7OztBVDBOSyxNQUFNLENBQUMsS0FBSztFU3hObEIsQUFWQSxpQkFVaUIsQ0FWQztJTnFCaEIsV0FBVyxFdEJJVyxVQUFVO0c0QmpCakM7OztBVDBOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVN4TmxDLEFBVkEsaUJBVWlCLENBVkM7SU5rSlosU0FBUyxFckJ0RUEsSUFBSTtJcUIwRWIsV0FBVyxFQWhGRCxPQUF5QjtHTTlEeEM7OztBVDBOSyxNQUFNLENBQUMsS0FBSztFU3hObEIsQUFWQSxpQkFVaUIsQ0FWQztJTjZJWixTQUFTLEVyQjdEQSxJQUFJO0lxQjhEYixXQUFXLEVyQjdEQSxJQUFJO0cyQnpFcEI7OztBVDBOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVN4TmxDLEFBVkEsaUJBVWlCLENBVkM7SVB5RlYsYUFBMEIsRXhCcEJ4QixJQUFJO0crQjdEYjs7O0FBZ0JELEFBVkEsZ0JBVWdCLENBVkM7RU5rQmpCLEtBQUssRTdCTkksT0FBTztFNkJmaEIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQTJDbEMsV0FBVyxFdEJiWSxHQUFHO0VzQjJGdEIsU0FBUyxFckJoREUsSUFBSTtFcUJvRGYsV0FBVyxFQXBFQyxPQUF5QjtFTXBEdkMsT0FBTyxFQUFFLEtBQUs7RUFFZCxVQUFVLEVBQUUsQ0FBQztFUDhEVCxhQUEwQixFeEJ0QnhCLElBQUk7QytCdENYOztBVDRNSyxNQUFNLENBQUMsS0FBSztFUzFNbEIsQUFWQSxnQkFVZ0IsQ0FWQztJTnFCZixLQUFLLEUzQlVpQixPQUFPO0dpQ3ZCOUI7OztBVDRNSyxNQUFNLENBQUMsS0FBSztFUzFNbEIsQUFWQSxnQkFVZ0IsQ0FWQztJTk9mLFdBQVcsRXRCSVcsVUFBVTtHNEJIakM7OztBVDRNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVMxTWxDLEFBVkEsZ0JBVWdCLENBVkM7SU5vSVgsU0FBUyxFckJ4REEsSUFBSTtJcUI0RGIsV0FBVyxFQWhGRCxPQUF5QjtHTWhEeEM7OztBVDRNSyxNQUFNLENBQUMsS0FBSztFUzFNbEIsQUFWQSxnQkFVZ0IsQ0FWQztJTitIWCxTQUFTLEVyQi9DQSxJQUFJO0lxQmdEYixXQUFXLEVyQi9DQSxJQUFJO0cyQnpFcEI7OztBVDRNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVMxTWxDLEFBVkEsZ0JBVWdCLENBVkM7SVAyRVQsYUFBMEIsRXhCNUJ4QixJQUFJO0crQnZDYjs7O0FBZ0JELEFBVkEsZ0JBVWdCLENBVkM7RU5JakIsS0FBSyxFN0JOSSxPQUFPO0U2QmZoQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQnBCRSxJQUFJO0VxQndCZixXQUFXLEVBcEVDLE9BQXlCO0VNdEN2QyxPQUFPLEVBQUUsS0FBSztFQUVkLFVBQVUsRUFBRSxDQUFDO0VQZ0RULGFBQTBCLEV4QjlCeEIsSUFBSTtDK0JoQlg7O0FUOExLLE1BQU0sQ0FBQyxLQUFLO0VTNUxsQixBQVZBLGdCQVVnQixDQVZDO0lOT2YsS0FBSyxFM0JVaUIsT0FBTztHaUNUOUI7OztBVDhMSyxNQUFNLENBQUMsS0FBSztFUzVMbEIsQUFWQSxnQkFVZ0IsQ0FWQztJTlBmLFdBQVcsRXRCSVcsVUFBVTtHNEJXakM7OztBVDhMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVM1TGxDLEFBVkEsZ0JBVWdCLENBVkM7SU5zSFgsU0FBUyxFckI1QkEsSUFBSTtJcUJnQ2IsV0FBVyxFQWhGRCxJQUF5QjtHTWxDeEM7OztBVDhMSyxNQUFNLENBQUMsS0FBSztFUzVMbEIsQUFWQSxnQkFVZ0IsQ0FWQztJTmlIWCxTQUFTLEVyQm5CQSxJQUFJO0lxQm9CYixXQUFXLEVyQm5CQSxJQUFJO0cyQnZGcEI7OztBVDhMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVM1TGxDLEFBVkEsZ0JBVWdCLENBVkM7SVA2RFQsYUFBMEIsRXhCcEN4QixJQUFJO0crQmpCYjs7O0FBZ0JELEFBVkEsZ0JBVWdCLENBVkM7RU5WakIsS0FBSyxFN0JOSSxPQUFPO0U2QmZoQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFTXhCdkMsT0FBTyxFQUFFLEtBQUs7RUFFZCxVQUFVLEVBQUUsQ0FBQztFUGtDVCxhQUEwQixFeEI5QnhCLElBQUk7QytCRlg7O0FUZ0xLLE1BQU0sQ0FBQyxLQUFLO0VTOUtsQixBQVZBLGdCQVVnQixDQVZDO0lOUGYsS0FBSyxFM0JVaUIsT0FBTztHaUNLOUI7OztBVGdMSyxNQUFNLENBQUMsS0FBSztFUzlLbEIsQUFWQSxnQkFVZ0IsQ0FWQztJTnJCZixXQUFXLEV0QklXLFVBQVU7RzRCeUJqQzs7O0FUZ0xLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFUzlLbEMsQUFWQSxnQkFVZ0IsQ0FWQztJTndHWCxTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R01wQnhDOzs7QVRnTEssTUFBTSxDQUFDLEtBQUs7RVM5S2xCLEFBVkEsZ0JBVWdCLENBVkM7SU5tR1gsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHMkJ2RnBCOzs7QVRnTEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTOUtsQyxBQVZBLGdCQVVnQixDQVZDO0lQK0NULGFBQTBCLEV4QnBDeEIsSUFBSTtHK0JIYjs7O0FBUUQsQUFBQSxpQkFBaUIsQ0FBQztFTi9DbEIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJsQ0UsSUFBSTtFcUJzQ2YsV0FBVyxFQXBFQyxPQUF5QjtFTVR2QyxPQUFPLEVBQUUsS0FBSztFQUVkLGFBQWEsRS9CdkRaLEdBQUc7RStCeURKLEtBQUssRW5DdENHLE9BQU87Q21DdUNoQjs7QVRnS0ssTUFBTSxDQUFDLEtBQUs7RVN4S2xCLEFBQUEsaUJBQWlCLENBQUM7SU5yQ2hCLFdBQVcsRXRCSVcsVUFBVTtHNEJ5Q2pDOzs7QVRnS0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTeEtsQyxBQUFBLGlCQUFpQixDQUFDO0lOd0ZaLFNBQVMsRXJCMUNBLElBQUk7SXFCOENiLFdBQVcsRUFoRkQsT0FBeUI7R01KeEM7OztBVGdLSyxNQUFNLENBQUMsS0FBSztFU3hLbEIsQUFBQSxpQkFBaUIsQ0FBQztJTm1GWixTQUFTLEVyQmpDQSxJQUFJO0lxQmtDYixXQUFXLEVyQmpDQSxJQUFJO0cyQjNDcEI7OztBQUVELEFBQUEsZ0JBQWdCLENBQUM7RU56RGpCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCcEJFLElBQUk7RXFCd0JmLFdBQVcsRUFwRUMsT0FBeUI7RU1DdkMsT0FBTyxFQUFFLEtBQUs7RUFFZCxhQUFhLEUvQmpFWixHQUFHO0UrQmtFSixLQUFLLEVuQy9DRyxPQUFPO0NtQ29EaEI7O0FUbUpLLE1BQU0sQ0FBQyxLQUFLO0VTOUpsQixBQUFBLGdCQUFnQixDQUFDO0lOL0NmLFdBQVcsRXRCSVcsVUFBVTtHNEJzRGpDOzs7QVRtSkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTOUpsQyxBQUFBLGdCQUFnQixDQUFDO0lOOEVYLFNBQVMsRXJCNUJBLElBQUk7SXFCZ0NiLFdBQVcsRUFoRkQsSUFBeUI7R01TeEM7OztBVG1KSyxNQUFNLENBQUMsS0FBSztFUzlKbEIsQUFBQSxnQkFBZ0IsQ0FBQztJTnlFWCxTQUFTLEVyQm5CQSxJQUFJO0lxQm9CYixXQUFXLEVyQm5CQSxJQUFJO0cyQjVDcEI7OztBVG1KSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVM5SmxDLEFBQUEsZ0JBQWdCLENBQUM7SUFTYixhQUFhLEVBQUUsQ0FBQztHQUVuQjs7O0FBRUQsQUFBQSxnQkFBZ0IsQ0FBQztFTnRFakIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsSUFBeUI7RU1jdkMsT0FBTyxFQUFFLEtBQUs7RUFFZCxLQUFLLEVuQzNERyxPQUFPO0NtQzREaEI7O0FUMklLLE1BQU0sQ0FBQyxLQUFLO0VTakpsQixBQUFBLGdCQUFnQixDQUFDO0lONURmLFdBQVcsRXRCSVcsVUFBVTtHNEI4RGpDOzs7QVQySUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTakpsQyxBQUFBLGdCQUFnQixDQUFDO0lOaUVYLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHTWlCeEM7OztBVDJJSyxNQUFNLENBQUMsS0FBSztFU2pKbEIsQUFBQSxnQkFBZ0IsQ0FBQztJTjREWCxTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0cyQmxEcEI7OztBQVlELEFBUkEsYUFRYSxFQTZDYixnQkFBZ0IsQ0FyREY7RU4zRGQsS0FBSyxFN0JOSSxPQUFPO0U2QmZoQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQnBCRSxJQUFJO0VxQndCZixXQUFXLEVBcEVDLE9BQXlCO0VNeUJ2QyxVQUFVLEVBQUUsQ0FBQztFUGJULGFBQTBCLEV4QnRCeEIsSUFBSTtDK0JxQ1g7O0FUaUlLLE1BQU0sQ0FBQyxLQUFLO0VTL0hsQixBQVJBLGFBUWEsRUE2Q2IsZ0JBQWdCLENBckRGO0lOeERaLEtBQUssRTNCVWlCLE9BQU87R2lDb0Q5Qjs7O0FUaUlLLE1BQU0sQ0FBQyxLQUFLO0VTL0hsQixBQVJBLGFBUWEsRUE2Q2IsZ0JBQWdCLENBckRGO0lOdEVaLFdBQVcsRXRCSVcsVUFBVTtHNEJ3RWpDOzs7QVRpSUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTL0hsQyxBQVJBLGFBUWEsRUE2Q2IsZ0JBQWdCLENBckRGO0lOdURSLFNBQVMsRXJCNUJBLElBQUk7SXFCZ0NiLFdBQVcsRUFoRkQsSUFBeUI7R00yQnhDOzs7QVRpSUssTUFBTSxDQUFDLEtBQUs7RVMvSGxCLEFBUkEsYUFRYSxFQTZDYixnQkFBZ0IsQ0FyREY7SU5rRFIsU0FBUyxFckJuQkEsSUFBSTtJcUJvQmIsV0FBVyxFckJuQkEsSUFBSTtHMkIxQnBCOzs7QVRpSUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTL0hsQyxBQVJBLGFBUWEsRUE2Q2IsZ0JBQWdCLENBckRGO0lQRk4sYUFBMEIsRXhCNUJ4QixJQUFJO0crQm9DYjs7O0FBY0QsQUFSQSxhQVFhLEVBcUNiLFdBQVcsRUVoSlgsQ0FBQyxDRm1HYTtFTnZFZCxLQUFLLEU3Qk5JLE9BQU87RTZCZmhCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VNcUN2QyxVQUFVLEVBQUUsQ0FBQztFUHpCVCxhQUEwQixFeEI5QnhCLElBQUk7QytCeURYOztBVHFISyxNQUFNLENBQUMsS0FBSztFU25IbEIsQUFSQSxhQVFhLEVBcUNiLFdBQVcsRUVoSlgsQ0FBQyxDRm1HYTtJTnBFWixLQUFLLEUzQlVpQixPQUFPO0dpQ2dFOUI7OztBVHFISyxNQUFNLENBQUMsS0FBSztFU25IbEIsQUFSQSxhQVFhLEVBcUNiLFdBQVcsRUVoSlgsQ0FBQyxDRm1HYTtJTmxGWixXQUFXLEV0QklXLFVBQVU7RzRCb0ZqQzs7O0FUcUhLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFU25IbEMsQUFSQSxhQVFhLEVBcUNiLFdBQVcsRUVoSlgsQ0FBQyxDRm1HYTtJTjJDUixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R011Q3hDOzs7QVRxSEssTUFBTSxDQUFDLEtBQUs7RVNuSGxCLEFBUkEsYUFRYSxFQXFDYixXQUFXLEVFaEpYLENBQUMsQ0ZtR2E7SU5zQ1IsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHMkI1QnBCOzs7QVRxSEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTbkhsQyxBQVJBLGFBUWEsRUFxQ2IsV0FBVyxFRWhKWCxDQUFDLENGbUdhO0lQZE4sYUFBMEIsRXhCcEN4QixJQUFJO0crQndEYjs7O0FBY0QsQUFSQSxhQVFhLENBUkM7RU5uRmQsS0FBSyxFN0JOSSxPQUFPO0U2QmZoQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQlFFLElBQUk7RXFCSmYsV0FBVyxFQXBFQyxPQUF5QjtFTWlEdkMsVUFBVSxFQUFFLENBQUM7RVByQ1QsYUFBMEIsRXhCOUJ4QixJQUFJO0MrQnFFWDs7QVR5R0ssTUFBTSxDQUFDLEtBQUs7RVN2R2xCLEFBUkEsYUFRYSxDQVJDO0lOaEZaLEtBQUssRTNCVWlCLE9BQU87R2lDNEU5Qjs7O0FUeUdLLE1BQU0sQ0FBQyxLQUFLO0VTdkdsQixBQVJBLGFBUWEsQ0FSQztJTjlGWixXQUFXLEV0QklXLFVBQVU7RzRCZ0dqQzs7O0FUeUdLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFU3ZHbEMsQUFSQSxhQVFhLENBUkM7SU4rQlIsU0FBUyxFckJBQSxJQUFJO0lxQkliLFdBQVcsRUFoRkQsSUFBeUI7R01tRHhDOzs7QVR5R0ssTUFBTSxDQUFDLEtBQUs7RVN2R2xCLEFBUkEsYUFRYSxDQVJDO0lOMEJSLFNBQVMsRXJCU0EsSUFBSTtJcUJSYixXQUFXLEVyQlNBLEdBQUc7RzJCOUJuQjs7O0FUeUdLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFU3ZHbEMsQUFSQSxhQVFhLENBUkM7SVAxQk4sYUFBMEIsRXhCcEN4QixJQUFJO0crQm9FYjs7O0FBY0QsQUFSQSxjQVFjLENBUkM7RU4vRmYsS0FBSyxFN0JOSSxPQUFPO0U2QmZoQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQnNCRSxJQUFJO0VxQmxCZixXQUFXLEVBcEVDLElBQXlCO0VNNkR2QyxVQUFVLEVBQUUsQ0FBQztFUGpEVCxhQUEwQixFeEI5QnhCLElBQUk7QytCaUZYOztBVDZGSyxNQUFNLENBQUMsS0FBSztFUzNGbEIsQUFSQSxjQVFjLENBUkM7SU41RmIsS0FBSyxFM0JVaUIsT0FBTztHaUN3RjlCOzs7QVQ2RkssTUFBTSxDQUFDLEtBQUs7RVMzRmxCLEFBUkEsY0FRYyxDQVJDO0lOMUdiLFdBQVcsRXRCSVcsVUFBVTtHNEI0R2pDOzs7QVQ2RkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTM0ZsQyxBQVJBLGNBUWMsQ0FSQztJTm1CVCxTQUFTLEVyQmNBLElBQUk7SXFCVmIsV0FBVyxFQWhGRCxPQUF5QjtHTStEeEM7OztBVDZGSyxNQUFNLENBQUMsS0FBSztFUzNGbEIsQUFSQSxjQVFjLENBUkM7SU5jVCxTQUFTLEVyQnVCQSxJQUFJO0lxQnRCYixXQUFXLEVyQnVCQSxHQUFHO0cyQmhDbkI7OztBVDZGSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVMzRmxDLEFBUkEsY0FRYyxDQVJDO0lQdENQLGFBQTBCLEV4QnBDeEIsSUFBSTtHK0JnRmI7OztBQWxDRCxBQXdEQSxhQXhEYSxHQTNFYixnQkFBZ0IsRUF3SGhCLGdCQUFnQixHQXhIaEIsZ0JBQWdCLENBbUlrQjtFQUNoQyxXQUFXLEUvQnBKVixHQUFHO0MrQnlKTDs7QVRpRUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTL0hsQyxBQXdEQSxhQXhEYSxHQTNFYixnQkFBZ0IsRUF3SGhCLGdCQUFnQixHQXhIaEIsZ0JBQWdCLENBbUlrQjtJQUk5QixXQUFXLEUvQnRKWixJQUFJO0crQndKTjs7O0FBbERELEFBb0RBLGFBcERhLEdBdkZiLGdCQUFnQixFQTRIaEIsV0FBVyxHQTVIWCxnQkFBZ0IsRUVwQmhCLENBQUMsR0ZvQkQsZ0JBQWdCO0FBbUdoQixhQUFhLEdBbkdiLGdCQUFnQjtBRlloQixXQUFXLEdFWlgsZ0JBQWdCLENBNkllO0VQbkZ6QixXQUEwQixFeEI5QnhCLElBQUk7QytCbUhYOztBVDJESyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVNuSGxDLEFBb0RBLGFBcERhLEdBdkZiLGdCQUFnQixFQTRIaEIsV0FBVyxHQTVIWCxnQkFBZ0IsRUVwQmhCLENBQUMsR0ZvQkQsZ0JBQWdCO0VBbUdoQixhQUFhLEdBbkdiLGdCQUFnQjtFRlloQixXQUFXLEdFWlgsZ0JBQWdCLENBNkllO0lQNUV2QixXQUEwQixFeEJwQ3hCLElBQUk7RytCa0hiOzs7QUF4REQsQUEwREEsYUExRGEsR0F6RWIsZ0JBQWdCLEVBOEdoQixXQUFXLEdBOUdYLGdCQUFnQixFRWxDaEIsQ0FBQyxHRmtDRCxnQkFBZ0I7QUFxRmhCLGFBQWEsR0FyRmIsZ0JBQWdCO0FGRmhCLFdBQVcsR0VFWCxnQkFBZ0I7QUF5RWhCLGFBQWEsR0EzRGIsZ0JBQWdCO0FBZ0doQixXQUFXLEdBaEdYLGdCQUFnQjtBRWhEaEIsQ0FBQyxHRmdERCxnQkFBZ0I7QUF1RWhCLGFBQWEsR0F2RWIsZ0JBQWdCO0FGaEJoQixXQUFXLEdFZ0JYLGdCQUFnQixDQTBIZTtFQUM3QixXQUFXLEUvQnZLVixHQUFHO0MrQjRLTDs7QVQ4Q0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VTbkhsQyxBQTBEQSxhQTFEYSxHQXpFYixnQkFBZ0IsRUE4R2hCLFdBQVcsR0E5R1gsZ0JBQWdCLEVFbENoQixDQUFDLEdGa0NELGdCQUFnQjtFQXFGaEIsYUFBYSxHQXJGYixnQkFBZ0I7RUZGaEIsV0FBVyxHRUVYLGdCQUFnQjtFQXlFaEIsYUFBYSxHQTNEYixnQkFBZ0I7RUFnR2hCLFdBQVcsR0FoR1gsZ0JBQWdCO0VFaERoQixDQUFDLEdGZ0RELGdCQUFnQjtFQXVFaEIsYUFBYSxHQXZFYixnQkFBZ0I7RUZoQmhCLFdBQVcsR0VnQlgsZ0JBQWdCLENBMEhlO0lBSTNCLFdBQVcsRS9CektaLElBQUk7RytCMktOOzs7QUMzS0QsQUFYQSxvQkFXb0IsQ0FYQztFQUNuQixNQUFNLEVBQUUsQ0FBQztFQUNULE1BQU0sRUFBRSxDQUFDO0VBS1AsTUFBTSxFQUFFLENBQUM7Q0FFWjs7QUFhRCxBQUxBLHdCQUt3QixDQUxDO0VSbUVuQixVQUEwQixFeEJkeEIsSUFBSTtFd0JjTixhQUEwQixFeEJkeEIsSUFBSTtDZ0NsRFg7O0FWZ05LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFVTlNbEMsQUFMQSx3QkFLd0IsQ0FMQztJUjBFakIsVUFBMEIsRXhCcEJ4QixJQUFJO0dnQ25EYjs7O0FWZ05LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFVTlNbEMsQUFMQSx3QkFLd0IsQ0FMQztJUjBFakIsYUFBMEIsRXhCcEJ4QixJQUFJO0dnQ25EYjs7O0FBV0QsQUFMQSx1QkFLdUIsQ0FMQztFUjBEbEIsVUFBMEIsRXhCdEJ4QixJQUFJO0V3QnNCTixhQUEwQixFeEJ0QnhCLElBQUk7Q2dDakNYOztBVnVNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVVyTWxDLEFBTEEsdUJBS3VCLENBTEM7SVJpRWhCLFVBQTBCLEV4QjVCeEIsSUFBSTtHZ0NsQ2I7OztBVnVNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RVVyTWxDLEFBTEEsdUJBS3VCLENBTEM7SVJpRWhCLGFBQTBCLEV4QjVCeEIsSUFBSTtHZ0NsQ2I7OztBQVdELEFBTEEsdUJBS3VCLENBTEM7RVJpRGxCLFVBQTBCLEV4QjlCeEIsSUFBSTtFd0I4Qk4sYUFBMEIsRXhCOUJ4QixJQUFJO0NnQ2hCWDs7QVY4TEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VVNUxsQyxBQUxBLHVCQUt1QixDQUxDO0lSd0RoQixVQUEwQixFeEJwQ3hCLElBQUk7R2dDakJiOzs7QVY4TEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VVNUxsQyxBQUxBLHVCQUt1QixDQUxDO0lSd0RoQixhQUEwQixFeEJwQ3hCLElBQUk7R2dDakJiOzs7QUFZRCxBQUpBLDZCQUk2QixDQUpDO0VBQzVCLGFBQWEsRUFBRSxHQUFHLENBQUMsS0FBSyxDcENqQmhCLE9BQU87Q29Da0JoQjs7QUdoREQsQUFBQSxpQkFBaUIsQ0FBQztFWG9GWixhQUEwQixFeEJ0QnhCLElBQUk7Q21DeERYOztBYjhOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWFwT2xDLEFBQUEsaUJBQWlCLENBQUM7SVgyRlYsYUFBMEIsRXhCNUJ4QixJQUFJO0dtQ3pEYjs7O0FBTkQsQUFHRSxpQkFIZSxDQUdmLGlCQUFpQixBQUFBLGFBQWEsQ0FBQztFQUM3QixhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUFHSCxBQUFBLHdCQUF3QixDQUFDO0VBQ3ZCLFlBQVksRW5DR1gsSUFBSTtFbUNGTCxXQUFXLEVsQzhCTSxHQUFHLENrQzlCOEIsS0FBSyxDdkNPbEQsT0FBTztDdUNBYjs7QUFURCxBQUlFLHdCQUpzQixDQUl0QixpQkFBaUIsQ0FBQztFQUVoQixPQUFPLEVBQUUsQ0FBQztFQUNWLE1BQU0sRUFBRSxDQUFDO0NBQ1Y7O0FoQjhCSCxBQUFBLGVBQWUsQ0FBSjtFQUVULFlBQVksRWxCckJJLEtBQWlCO0VrQnNCakMsV0FBVyxFbEJ0QkssS0FBaUI7Q2tCdUJsQzs7QUFKRCxBSnZDQSxlSXVDZSxBSnZDZCxNQUFNLENBQUM7RUFDTixPQUFPLEVBQUUsRUFBRTtFQUNYLE9BQU8sRUFBRSxLQUFLO0VBQ2QsS0FBSyxFQUFFLElBQUk7Q0FDWjs7QUkwRUQsQUFBQSw4QkFBOEIsQ0FBVDtFQUNuQixrQkFBa0IsRUFBRSxVQUFVO0VBQ3RCLFVBQVUsRUFBRSxVQUFVO0VBRTVCLEtBQUssRUFBRSxJQUFJO0VBRWIsT0FBTyxFQUFFLENBQUMsQ2xCaEVNLElBQWlCO0NrQnFFbEM7O0FHb0lLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFSC9JbEMsQUFBQSw4QkFBOEIsQ0FBVDtJQVFqQixLQUFLLEVBckZJLEdBQUc7SUFzRlosS0FBSyxFQVhvQyxJQUFJO0dBYWhEOzs7QUFYRCxBQUFBLDRCQUE0QixDQUFQO0VBQ25CLGtCQUFrQixFQUFFLFVBQVU7RUFDdEIsVUFBVSxFQUFFLFVBQVU7RUFFNUIsS0FBSyxFQUFFLElBQUk7RUFFYixPQUFPLEVBQUUsQ0FBQyxDbEJoRU0sSUFBaUI7Q2tCcUVsQzs7QUdvSUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VIL0lsQyxBQUFBLDRCQUE0QixDQUFQO0lBUWpCLEtBQUssRUFwRkUsUUFBUTtJQXFGZixLQUFLLEVBWG9DLElBQUk7R0FhaEQ7OztBQVhELEFBQUEsMkJBQTJCLENBQU47RUFDbkIsa0JBQWtCLEVBQUUsVUFBVTtFQUN0QixVQUFVLEVBQUUsVUFBVTtFQUU1QixLQUFLLEVBQUUsSUFBSTtFQUViLE9BQU8sRUFBRSxDQUFDLENsQmhFTSxJQUFpQjtDa0JxRWxDOztBR29JSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RUgvSWxDLEFBQUEsMkJBQTJCLENBQU47SUFRakIsS0FBSyxFQW5GQyxHQUFHO0lBb0ZULEtBQUssRUFYb0MsSUFBSTtHQWFoRDs7O0FBWEQsQUFBQSw2QkFBNkIsQ0FBUjtFQUNuQixrQkFBa0IsRUFBRSxVQUFVO0VBQ3RCLFVBQVUsRUFBRSxVQUFVO0VBRTVCLEtBQUssRUFBRSxJQUFJO0VBRWIsT0FBTyxFQUFFLENBQUMsQ2xCaEVNLElBQWlCO0NrQnFFbEM7O0FHb0lLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFSC9JbEMsQUFBQSw2QkFBNkIsQ0FBUjtJQVFqQixLQUFLLEVBbEZHLFFBQVE7SUFtRmhCLEtBQUssRUFYb0MsSUFBSTtHQWFoRDs7O0FBWEQsQUFBQSxpQ0FBaUMsQ0FBWjtFQUNuQixrQkFBa0IsRUFBRSxVQUFVO0VBQ3RCLFVBQVUsRUFBRSxVQUFVO0VBRTVCLEtBQUssRUFBRSxJQUFJO0VBRWIsT0FBTyxFQUFFLENBQUMsQ2xCaEVNLElBQWlCO0NrQnFFbEM7O0FHb0lLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFSC9JbEMsQUFBQSxpQ0FBaUMsQ0FBWjtJQVFqQixLQUFLLEVBakZPLEdBQUc7SUFrRmYsS0FBSyxFQVhvQyxJQUFJO0dBYWhEOzs7QUFYRCxBQUFBLHVCQUF1QixDQUFGO0VBQ25CLGtCQUFrQixFQUFFLFVBQVU7RUFDdEIsVUFBVSxFQUFFLFVBQVU7RUFFNUIsS0FBSyxFQUFFLElBQUk7RUFFYixPQUFPLEVBQUUsQ0FBQyxDbEJoRU0sSUFBaUI7Q2tCcUVsQzs7QUdvSUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VIL0lsQyxBQUFBLHVCQUF1QixDQUFGO0lBUWpCLEtBQUssRUFoRkgsSUFBSTtJQWlGTixLQUFLLEVBWG9DLElBQUk7R0FhaEQ7OztBa0JqRUQsQUFBQSxtQkFBbUIsQ0FBQztFYnFEZCxXQUEwQixFeEJ0QnhCLElBQUk7RXdCc0JOLGNBQTBCLEV4QnRCeEIsSUFBSTtFcUN4Q1osT0FBTyxFQUFFLEtBQUs7Q0FXYjs7QWZtTUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0Vlck1sQyxBQUFBLG1CQUFtQixDQUFDO0liNERaLFdBQTBCLEV4QjVCeEIsSUFBSTtHcUM5QmI7OztBZm1NSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWVyTWxDLEFBQUEsbUJBQW1CLENBQUM7SWI0RFosY0FBMEIsRXhCNUJ4QixJQUFJO0dxQzlCYjs7O0FBRUQsQUFBQSxzQkFBc0IsQ0FBQztFYmlEakIsV0FBMEIsRXhCZHhCLElBQUk7Q3FDakNYOztBZitMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWVqTWxDLEFBQUEsc0JBQXNCLENBQUM7SWJ3RGYsV0FBMEIsRXhCcEJ4QixJQUFJO0dxQ2xDYjs7O0FDZkQsQUFBQSxzQkFBc0IsQ0FBQztFQXRCdkIsU0FBUyxFckNhUSxLQUFLO0VxQ050QixNQUFNLEVBQUUsQ0FBQyxDckNvQlMsSUFBaUI7Q3FDSGxDOztBaEI0TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQjlNbEMsQUFBQSxzQkFBc0IsQ0FBQztJQVhyQixNQUFNLEVBQUUsQ0FBQyxDckNTRSxJQUFJO0dxQ0loQjs7O0FoQjRNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLE1BQU07RWdCOU0vQixBQUFBLHNCQUFzQixDQUFDO0lBTHJCLE1BQU0sRUFBRSxNQUFNO0dBT2Y7OztBRXBCRCxBQUFBLGdCQUFnQixDQUFDO0Vmb0liLFNBQVMsRXJCUUUsSUFBSTtFcUJKZixXQUFXLEVBcEVDLE9BQXlCO0VBM0R6QyxXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VlTmhDLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLFFBQVEsRUFBRSxRQUFRO0VBRWxCLFVBQVUsRXhDQVQsSUFBSTtFd0NDTCxhQUFhLEV4Q0RaLElBQUk7RXdDSUwsWUFBWSxFQUFFLElBQUk7RUFJbEIsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLEM1Q1FqQixPQUFPO0U0Q0xkLGVBQWUsRUFBRSxJQUFJO0NBaUJ0Qjs7QWxCNExLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFa0JoT2xDLEFBQUEsZ0JBQWdCLENBQUM7SWZnSlgsU0FBUyxFckJBQSxJQUFJO0lxQkliLFdBQVcsRUFoRkQsSUFBeUI7R2VoQ3hDOzs7QWxCNExLLE1BQU0sQ0FBQyxLQUFLO0VrQmhPbEIsQUFBQSxnQkFBZ0IsQ0FBQztJZjJJWCxTQUFTLEVyQlNBLElBQUk7SXFCUmIsV0FBVyxFckJTQSxHQUFHO0dvQ2pIbkI7OztBbEI0TEssTUFBTSxDQUFDLEtBQUs7RWtCaE9sQixBQUFBLGdCQUFnQixDQUFDO0lmbUJmLFdBQVcsRXRCSVcsVUFBVTtHcUNhakM7OztBQXBDRCxBdkJzQkEsZ0J1QnRCZ0IsQXZCc0JmLE1BQU0sQ0FBQztFQUNOLE9BQU8sRWhCdURTLEdBQUcsQ2dCdkRTLEtBQUssQ3JCTnpCLE9BQU87RXFCT2YsY0FBYyxFQUFFLENBQUM7RUFDakIsZ0JBQWdCLEVyQlJSLE9BQU87Q3FCU2hCOztBdUIxQkQsQXBCb0dBLGdCb0JwR2dCLEFwQm9HZixLQUFLLEVvQnBHTixnQkFBZ0IsQXBCcUdmLFFBQVEsRW9CckdULGdCQUFnQixBcEJzR2YsTUFBTSxFb0J0R1AsZ0JBQWdCLEFwQnVHZixPQUFPLEVvQnZHUixnQkFBZ0IsQXBCd0dmLE1BQU0sQ0FBQztFSzFFUixLQUFLLEU3Qk5JLE9BQU87Q3dCa0ZmOztBRXNISyxNQUFNLENBQUMsS0FBSztFa0JoT2xCLEFwQm9HQSxnQm9CcEdnQixBcEJvR2YsS0FBSyxFb0JwR04sZ0JBQWdCLEFwQnFHZixRQUFRLEVvQnJHVCxnQkFBZ0IsQXBCc0dmLE1BQU0sRW9CdEdQLGdCQUFnQixBcEJ1R2YsT0FBTyxFb0J2R1IsZ0JBQWdCLEFwQndHZixNQUFNLENBQUM7SUt2RU4sS0FBSyxFM0JVaUIsT0FBTztHc0IrRDlCOzs7QW9CMUdELEFwQmdIRSxnQm9CaEhjLEFwQmdIYixLQUFLLEFBQUEsTUFBTSxDQUFDO0VLbEZmLEtBQUssRTdCTkksT0FBTztDd0IwRmI7O0FFOEdHLE1BQU0sQ0FBQyxLQUFLO0VrQmhPbEIsQXBCZ0hFLGdCb0JoSGMsQXBCZ0hiLEtBQUssQUFBQSxNQUFNLENBQUM7SUsvRWIsS0FBSyxFM0JVaUIsT0FBTztHc0J1RTVCOzs7QW9CbEhILEFBc0JFLGdCQXRCYyxBQXNCYixPQUFPLENBQUM7RWpCVVgsT0FBTyxFQUQ0RCxLQUFLO0VBR3hFLEtBQUssRUFBRSxDQUFDO0VBQ1IsTUFBTSxFQUFFLENBQUM7RUFFVCxZQUFZLEVBQUUsS0FBSztFQUNuQixZQUFZLEVBQUUsV0FBVztFQTJCdkIsaUJBQWlCLEVBQUUsbUNBQW1DO0VBQzlDLFNBQVMsRUFBRSxtQ0FBbUM7RUFFdEQsWUFBWSxFQTVCRSxHQUFTLENpQmpCOEMsR0FBRyxDakJpQjFELEdBQVMsQ0E0QjZCLENBQUM7RUFDckQsa0JBQWtCLEVBQUUsT0FBTztFaUI1Q3pCLE9BQU8sRUFBRSxFQUFFO0VBR1gsUUFBUSxFQUFFLFFBQVE7RUFFbEIsR0FBRyxFQUFFLElBQUk7RUFDVCxNQUFNLEVBQUUsR0FBRztFQUNYLElBQUksRUFBRSxDQUFDO0VBRVAsTUFBTSxFQUFFLElBQUk7Q0FDYjs7QUFuQ0gsQUFzQkUsZ0JBdEJjLEFBc0JiLE9BQU8sQ0FtQmM7RUFHdEIsR0FBRyxFQUFFLElBQVk7RUFDakIsTUFBTSxFQUhHLEdBQUc7Q0FJYjs7QUMvQkQsQUFBQSxrQkFBa0IsQ0FBQztFaEJObkIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJRRSxJQUFJO0VxQkpmLFdBQVcsRUFwRUMsT0FBeUI7RUF0Q3pDLEtBQUssRTdCTkksT0FBTztFNkNMZCxVQUFVLEV6Q1hULElBQUk7RXlDWUwsYUFBYSxFekNiWixJQUFJO0N5Q2NOOztBbkIyTUssTUFBTSxDQUFDLEtBQUs7RW1Cak5sQixBQUFBLGtCQUFrQixDQUFDO0loQklqQixXQUFXLEV0QklXLFVBQVU7R3NDRmpDOzs7QW5CMk1LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFbUJqTmxDLEFBQUEsa0JBQWtCLENBQUM7SWhCaUliLFNBQVMsRXJCQUEsSUFBSTtJcUJJYixXQUFXLEVBaEZELElBQXlCO0dnQi9DeEM7OztBbkIyTUssTUFBTSxDQUFDLEtBQUs7RW1Cak5sQixBQUFBLGtCQUFrQixDQUFDO0loQjRIYixTQUFTLEVyQlNBLElBQUk7SXFCUmIsV0FBVyxFckJTQSxHQUFHO0dxQ2hJbkI7OztBbkIyTUssTUFBTSxDQUFDLEtBQUs7RW1Cak5sQixBQUFBLGtCQUFrQixDQUFDO0loQmtCakIsS0FBSyxFM0JVaUIsT0FBTztHMkN0QjlCOzs7QUFFRCxBQUFBLHdCQUF3QixDQUFDO0VBR3ZCLE1BQU0sRUFBRSxDQUFDO0VBQ1QsT0FBTyxFQUFFLENBQUM7RUFDVixlQUFlLEVBQUUsSUFBSTtDQUN0Qjs7QUFORCxBMUJwQkEsd0IwQm9Cd0IsQTFCcEJ2QixNQUFNLENBQUM7RUFDTixPQUFPLEVBQUUsRUFBRTtFQUNYLE9BQU8sRUFBRSxLQUFLO0VBQ2QsS0FBSyxFQUFFLElBQUk7Q0FDWjs7QTBCd0JELEFBQUEsNkJBQTZCLENBQUM7RUFFNUIsT0FBTyxFQUFFLFlBQVk7RUFDckIsUUFBUSxFQUFFLFFBQVE7RUFFbEIsYUFBYSxFekM5QlosR0FBRztFeUNrQ0osV0FBVyxFekNqQ1YsSUFBSTtFeUNrQ0wsWUFBWSxFQUFFLFFBQStDO0VBRTdELEtBQUssRUFBRSxJQUFJO0NBK0RaOztBQTNFRCxBQWVFLDZCQWYyQixBQWUxQixPQUFPLENBQUM7RUFDUCxPQUFPLEVBQUUsRUFBRTtFQUNYLE9BQU8sRUFBRSxLQUFLO0VBRWQsUUFBUSxFQUFFLFFBQVE7RUFTbEIsR0FBRyxFQUFFLElBQUk7RUFDVCxNQUFNLEVBQUUsR0FBRztFQU1YLElBQUksRUFBRSxPQUE2RTtFQUVuRixLQUFLLEVBbkVNLEdBQUc7RUFvRWQsTUFBTSxFQXBFSyxHQUFHO0VBc0VkLE1BQU0sRUFBRSxNQUFNO0VBRWQsaUJBQWlCLEVBQUUsYUFBYTtFQUU1QixhQUFhLEVBQUUsYUFBYTtFQUV4QixTQUFTLEVBQUUsYUFBYTtFQUVoQyxNQUFNLEVBQUUsS0FBSztFQUNiLFlBQVksRUE1RU8sR0FBRyxDQUFILEdBQUcsQ0E0RW9DLENBQUMsQ0FBQyxDQUFDO0VBQzdELFlBQVksRTdDeEROLE9BQU87QzZDc0VkOztBQWhFSCxBQWtFRSw2QkFsRTJCLEFBa0UxQixZQUFZLENBQUM7RUFDWixXQUFXLEVBQUUsQ0FBQztFQUNkLFlBQVksRUFBRSxDQUFDO0NBTWhCOztBQTFFSCxBQXNFSSw2QkF0RXlCLEFBa0UxQixZQUFZLEFBSVYsT0FBTyxDQUFDO0VBQ1AsT0FBTyxFQUFFLElBQUk7RUFDYixPQUFPLEVBQUUsSUFBSTtDQUNkOztBQUlMLEFBQUEsd0JBQXdCLENBQUM7RWhCbkd6QixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0NnQm9HakM7O0FuQmlISyxNQUFNLENBQUMsS0FBSztFbUJwSGxCLEFBQUEsd0JBQXdCLENBQUM7SWhCekZ2QixXQUFXLEV0QklXLFVBQVU7R3NDd0ZqQzs7O0FBSEQsQXhCdEZBLHdCd0JzRndCLEF4QnRGdkIsTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJ1RFMsR0FBRyxDZ0J2RFMsS0FBSyxDckJOekIsT0FBTztFcUJPZixjQUFjLEVBQUUsQ0FBQztFQUNqQixnQkFBZ0IsRXJCUlIsT0FBTztDcUJTaEI7O0F3QmtGRCxBckJSQSx3QnFCUXdCLEFyQlJ2QixLQUFLLEVxQlFOLHdCQUF3QixBckJQdkIsUUFBUSxFcUJPVCx3QkFBd0IsQXJCTnZCLE1BQU0sRXFCTVAsd0JBQXdCLEFyQkx2QixPQUFPLEVxQktSLHdCQUF3QixBckJKdkIsTUFBTSxDQUFDO0VLMUVSLEtBQUssRTdCTkksT0FBTztDd0JrRmY7O0FFc0hLLE1BQU0sQ0FBQyxLQUFLO0VtQnBIbEIsQXJCUkEsd0JxQlF3QixBckJSdkIsS0FBSyxFcUJRTix3QkFBd0IsQXJCUHZCLFFBQVEsRXFCT1Qsd0JBQXdCLEFyQk52QixNQUFNLEVxQk1QLHdCQUF3QixBckJMdkIsT0FBTyxFcUJLUix3QkFBd0IsQXJCSnZCLE1BQU0sQ0FBQztJS3ZFTixLQUFLLEUzQlVpQixPQUFPO0dzQitEOUI7OztBcUJFRCxBckJJRSx3QnFCSnNCLEFyQklyQixLQUFLLEFBQUEsTUFBTSxDQUFDO0VLbEZmLEtBQUssRTdCTkksT0FBTztDd0IwRmI7O0FFOEdHLE1BQU0sQ0FBQyxLQUFLO0VtQnBIbEIsQXJCSUUsd0JxQkpzQixBckJJckIsS0FBSyxBQUFBLE1BQU0sQ0FBQztJSy9FYixLQUFLLEUzQlVpQixPQUFPO0dzQnVFNUI7OztBc0J4R0gsQUFBQSxhQUFhLENBQUM7RWpCRGQsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsTUFBeUI7RWlCdER2QyxrQkFBa0IsRUFBRSxVQUFVO0VBRXRCLFVBQVUsRUFBRSxVQUFVO0VBQzlCLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLFFBQVEsRUFBRSxRQUFRO0VBQ2xCLEtBQUssRUFBRSxJQUFJO0VBQ1gsVUFBVSxFQUFFLENBQUM7RWxCNERULGFBQTBCLEVBVFQsSUFBK0I7RWtCakRwRCxPQUFPLEVBQUUsR0FBaUYsQzFDZnpGLElBQUk7RTBDZ0JMLE1BQU0sRXpDa0N3QixHQUFHLEN5Q2xDUSxLQUFLLENBQUMsV0FBVztFQUMxRCxhQUFhLEVBQUUsQ0FBQztFQUNoQixLQUFLLEU5Q0lFLE9BQU87RThDSGQsZ0JBQWdCLEVBMUJJLE9BQU87RUEyQjNCLGtCQUFrQixFQUFFLENBQUMsQ3pDOEJTLEdBQUcsQ3lDOUJTLENBQUMsQ0F6QmhCLE9BQWlDO0VBMEJwRCxVQUFVLEVBQUUsQ0FBQyxDekM2QlMsR0FBRyxDeUM3QlMsQ0FBQyxDQTFCaEIsT0FBaUM7RUEyQjVELFVBQVUsRUFBRSxNQUFNO0VBQ2xCLGNBQWMsRUFBRSxHQUFHO0VBQ25CLE1BQU0sRUFBRSxPQUFPO0VBQ2Ysa0JBQWtCLEVBQUUsSUFBSTtDQW1GekI7O0FwQjZHSyxNQUFNLENBQUMsS0FBSztFb0J0TmxCLEFBQUEsYUFBYSxDQUFDO0lqQlNaLFdBQVcsRXRCSVcsVUFBVTtHdUM0RmpDOzs7QXBCNkdLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0J0TmxDLEFBQUEsYUFBYSxDQUFDO0lqQnNJUixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsQ0FBeUI7R2lCK0N4Qzs7O0FwQjZHSyxNQUFNLENBQUMsS0FBSztFb0J0TmxCLEFBQUEsYUFBYSxDQUFDO0lqQmlJUixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFaUJqSThCLElBQUk7R0F3R2xEOzs7QUF6R0QsQXpCSEEsYXlCR2EsQXpCSFosTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJzRVMsR0FBRyxDZ0J0RVMsS0FBSyxDckJTekIsT0FBTztFcUJSZixjQUFjLEVBQUUsQ0FBQztDQUNsQjs7QUtzTkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VvQnRObEMsQUFBQSxhQUFhLENBQUM7SWxCNkVOLGFBQTBCLEVBaEJYLElBQStCO0drQjRDckQ7OztBcEI2R0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VvQnRObEMsQUFBQSxhQUFhLENBQUM7SUE2QlYsS0FBSyxFQUFFLElBQUk7R0E0RWQ7OztBQXpHRCxBQWlDRSxhQWpDVyxBQWlDVixLQUFLLEVBakNSLGFBQWEsQUFrQ1YsUUFBUSxFQWxDWCxhQUFhLEFBbUNWLE9BQU8sRUFuQ1YsYUFBYSxBQW9DVixNQUFNLENBQUM7RUFDTixLQUFLLEU5Q2xCQSxPQUFPO0U4Q21CWixlQUFlLEVBQUUsSUFBSTtDQUN0Qjs7QUF2Q0gsQUErQ0ksYUEvQ1MsQUErQ1IsS0FBSyxBQUFBLE1BQU0sQ0FBQztFQUNYLEtBQUssRTlDN0JGLE9BQU87QzhDOEJYOztBQWpETCxBQXFERSxhQXJEVyxBQXFEVixrQkFBa0IsQ0FBQztFQUNsQixPQUFPLEVBQUUsQ0FBQztFQUNWLE1BQU0sRUFBRSxDQUFDO0NBQ1Y7O0FBeERILEFBMERFLGFBMURXLEFBMERWLE1BQU0sRUExRFQsYUFBYSxBQTJEVixNQUFNLENBQUM7RUFDTixnQkFBZ0IsRUFyRVEsT0FBZ0M7Q0FzRXpEOztBQTdESCxBQStERSxhQS9EVyxBQStEVixPQUFPLENBQUM7RUFDUCxHQUFHLEV6Q2pCeUIsR0FBRztFeUNrQi9CLGtCQUFrQixFQUFFLElBQUk7RUFDaEIsVUFBVSxFQUFFLElBQUk7Q0FLekI7O0FBdkVILEFBOEVFLGFBOUVXLEFBOEVWLFFBQVEsQ0FBQztFQUNSLE9BQU8sRUFBRSxFQUFFO0VBQ1gsT0FBTyxFQUFFLEtBQUs7RUFFZCxRQUFRLEVBQUUsUUFBUTtFQUVsQixHQUFHLEV6Q3JDeUIsSUFBRztFeUNzQy9CLEtBQUssRXpDdEN1QixJQUFHO0V5Q3VDL0IsTUFBTSxFQUFJLElBQXNEO0VBQ2hFLElBQUksRXpDeEN3QixJQUFHO0V5QzBDL0IsVUFBVSxFQUFFLFdBQVc7Q0FDeEI7O0FBMUZILEFBc0dFLGFBdEdXLEFBc0dWLE9BQU8sQUFBQSxRQUFRLENBQUM7RUFDZixHQUFHLEVBQUksSUFBc0Q7Q0FDOUQ7O0FBR0gsQUFBQSx1QkFBdUI7QUFDdkIsYUFBYSxDQUFBLEFBQUEsUUFBQyxDQUFTLFVBQVUsQUFBbkI7QUFDZCxhQUFhLENBQUEsQUFBQSxRQUFDLEFBQUEsRUFBVTtFQUN0QixPQUFPLEVBQUUsR0FBSTtFQUNiLFVBQVUsRUF6SFUsT0FBTztDQTRJNUI7O0FBdkJELEFBTUUsdUJBTnFCLEFBTXBCLE1BQU07QUFMVCxhQUFhLENBQUEsQUFBQSxRQUFDLENBQVMsVUFBVSxBQUFuQixDQUtYLE1BQU07QUFKVCxhQUFhLENBQUEsQUFBQSxRQUFDLEFBQUEsQ0FJWCxNQUFNLENBQUM7RUFDTixnQkFBZ0IsRUE1SEUsT0FBTztFQTZIekIsTUFBTSxFQUFFLE9BQU87Q0FDaEI7O0FBVEgsQUFXRSx1QkFYcUIsQUFXcEIsTUFBTTtBQVZULGFBQWEsQ0FBQSxBQUFBLFFBQUMsQ0FBUyxVQUFVLEFBQW5CLENBVVgsTUFBTTtBQVRULGFBQWEsQ0FBQSxBQUFBLFFBQUMsQUFBQSxDQVNYLE1BQU0sQ0FBQztFQUNOLE9BQU8sRUFBRSxJQUFJO0NBQ2Q7O0FBYkgsQUFlRSx1QkFmcUIsQUFlcEIsT0FBTztBQWRWLGFBQWEsQ0FBQSxBQUFBLFFBQUMsQ0FBUyxVQUFVLEFBQW5CLENBY1gsT0FBTztBQWJWLGFBQWEsQ0FBQSxBQUFBLFFBQUMsQUFBQSxDQWFYLE9BQU8sQ0FBQztFQUNQLEdBQUcsRUFBRSxDQUFDO0VBQ04sa0JBQWtCLEVBQUUsQ0FBQyxDekM3RU8sR0FBRyxDeUM2RVcsQ0FBQyxDQXBJbEIsT0FBaUM7RUFxSWxELFVBQVUsRUFBRSxDQUFDLEN6QzlFTyxHQUFHLEN5QzhFVyxDQUFDLENBcklsQixPQUFpQztDQXlJM0Q7O0FBR0gsQUFBQSxvQkFBb0IsQ0FBQztFakJ4RnJCLFdBQVcsRXRCYlksR0FBRztFc0IyRnRCLFNBQVMsRXJCcEJFLElBQUk7RXFCd0JmLFdBQVcsRWlCUTBELENBQUM7RUFFeEUsVUFBVSxFQUFFLElBQUk7RUFDaEIsV0FBVyxFQUFFLEdBQW1EO0VBQ2hFLGFBQWEsRTFDeElaLElBQUk7RTBDeUlMLGNBQWMsRUFBRSxHQUFtRDtFQUNuRSxZQUFZLEUxQzlJWCxJQUFJO0UwQ2dKTCxnQkFBZ0IsRS9CcklSLHNDQUFtQztFK0JzSTNDLGlCQUFpQixFQUFFLFNBQVM7RUFDNUIsbUJBQW1CLEVBQUUsUUFBUTtDQU05Qjs7QXBCZ0VLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0JsRmxDLEFBQUEsb0JBQW9CLENBQUM7SWpCRWYsU0FBUyxFckI1QkEsSUFBSTtJcUJnQ2IsV0FBVyxFaUJKd0QsQ0FBQztHQWdCekU7OztBcEJnRUssTUFBTSxDQUFDLEtBQUs7RW9CbEZsQixBQUFBLG9CQUFvQixDQUFDO0lqQkhmLFNBQVMsRXJCbkJBLElBQUk7SXFCb0JiLFdBQVcsRWlCSXdELENBQUM7R0FnQnpFOzs7QTFCeElELE1BQU0sTUFBTSxNQUFNLE9BQU8sNkJBQTZCLEVBQUUsQ0FBQyxRQUFRLE1BQU0sTUFBTSwyQkFBMkIsRUFBRSxDQUFDLFFBQVEsTUFBTSxNQUFNLHNCQUFzQixFQUFFLENBQUMsUUFBUSxNQUFNLE1BQU0sY0FBYyxFQUFFLE1BQU0sUUFBUSxNQUFNLE1BQU0sY0FBYyxFQUFFLEtBQUs7RTBCc0gzTyxBQUFBLG9CQUFvQixDQUFDO0lBZWpCLGdCQUFnQixFL0IxSVYseUNBQW1DO0krQjJJekMsZUFBZSxFQUFFLFNBQVM7R0FFN0I7OztBQXRKRCxBQUFBLGFBQWEsQ0E4SkM7RUFDWixXQUFXLEVBQUUsR0FBMkY7RUFDeEcsY0FBYyxFQUFFLEdBQStGO0NBQ2hIOztBQTdCRCxBQUFBLG9CQUFvQixDQStCQztFQUNuQixXQUFXLEVBQUUsR0FBMkY7RUFDeEcsY0FBYyxFQUFFLEdBQStGO0NBQ2hIOztBRWpMRCxBQUFBLG9CQUFvQixDQUFDO0VuQlVyQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFbUJsRXZDLE9BQU8sRUFBRSxLQUFLO0VBQ2QsYUFBYSxFNUNLWixJQUFJO0U0Q0pMLEtBQUssRUFBRSxJQUFJO0VBRVgsS0FBSyxFaERPQSxPQUFPO0NnRE5iOztBdEJ5TkssTUFBTSxDQUFDLEtBQUs7RXNCak9sQixBQUFBLG9CQUFvQixDQUFDO0luQm9CbkIsV0FBVyxFdEJJVyxVQUFVO0d5Q2hCakM7OztBdEJ5TkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VzQmpPbEMsQUFBQSxvQkFBb0IsQ0FBQztJbkJpSmYsU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0dtQjdEeEM7OztBdEJ5TkssTUFBTSxDQUFDLEtBQUs7RXNCak9sQixBQUFBLG9CQUFvQixDQUFDO0luQjRJZixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0d3Q2hJcEI7OztBQ1JELEFBQUEsZUFBZSxDQUFDO0VBQ2QsTUFBTSxFQUFFLENBQUM7RUFDVCxPQUFPLEVBQUUsQ0FBQztFQUNWLE1BQU0sRUFBRSxDQUFDO0NBRVY7O0FBTEQsQTlCSUEsZThCSmUsQTlCSWQsTUFBTSxDQUFDO0VBQ04sT0FBTyxFQUFFLEVBQUU7RUFDWCxPQUFPLEVBQUUsS0FBSztFQUNkLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0E4QkRELEFBQUEsdUJBQXVCLENBQUM7RXBCR3hCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VBdEN6QyxLQUFLLEU3Qk5JLE9BQU87RWlEWGQsa0JBQWtCLEVBQUUsVUFBVTtFQUN0QixVQUFVLEVBQUUsVUFBVTtFQUM5QixPQUFPLEVBQUUsS0FBSztFQUNkLFNBQVMsRUFBRSxJQUFJO0VBQ2YsYUFBYSxFN0NWWixJQUFJO0U2Q1dMLE9BQU8sRUFBRSxDQUFDO0VBRVYsUUFBUSxFQUFFLE1BQU07RUFFaEIsV0FBVyxFQUFFLE1BQU07Q0FDcEI7O0F2QnlNSyxNQUFNLENBQUMsS0FBSztFdUIxTmxCLEFBQUEsdUJBQXVCLENBQUM7SXBCYXRCLFdBQVcsRXRCSVcsVUFBVTtHMENBakM7OztBdkJ5TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1QjFObEMsQUFBQSx1QkFBdUIsQ0FBQztJcEIwSWxCLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHb0I3Q3hDOzs7QXZCeU1LLE1BQU0sQ0FBQyxLQUFLO0V1QjFObEIsQUFBQSx1QkFBdUIsQ0FBQztJcEJxSWxCLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3lDaEhwQjs7O0F2QnlNSyxNQUFNLENBQUMsS0FBSztFdUIxTmxCLEFBQUEsdUJBQXVCLENBQUM7SXBCMkJ0QixLQUFLLEUzQlVpQixPQUFPO0crQ3BCOUI7OztBQUlELEFBQUEsMkJBQTJCLENBQUM7RXBCbEI1QixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQjlERSxJQUFJO0VxQmtFZixXQUFXLEVBcEVDLE9BQXlCO0VvQnZDdkMsYUFBYSxFN0NyQlosSUFBSTtDNkNzQk47O0F2QmtNSyxNQUFNLENBQUMsS0FBSztFdUJyTWxCLEFBQUEsMkJBQTJCLENBQUM7SXBCUjFCLFdBQVcsRXRCSVcsVUFBVTtHMENPakM7OztBdkJrTUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1QnJNbEMsQUFBQSwyQkFBMkIsQ0FBQztJcEJxSHRCLFNBQVMsRXJCdEVBLElBQUk7SXFCMEViLFdBQVcsRUFoRkQsT0FBeUI7R29CdEN4Qzs7O0F2QmtNSyxNQUFNLENBQUMsS0FBSztFdUJyTWxCLEFBQUEsMkJBQTJCLENBQUM7SXBCZ0h0QixTQUFTLEVyQjdEQSxJQUFJO0lxQjhEYixXQUFXLEVyQjdEQSxJQUFJO0d5Q2pEcEI7OztBQUVELEFBQUEsMEJBQTBCLENBQUM7RXBCdkIzQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQmhERSxJQUFJO0VxQm9EZixXQUFXLEVBcEVDLE9BQXlCO0VvQmxDdkMsYUFBYSxFN0MxQlosSUFBSTtDNkMyQk47O0F2QjZMSyxNQUFNLENBQUMsS0FBSztFdUJoTWxCLEFBQUEsMEJBQTBCLENBQUM7SXBCYnpCLFdBQVcsRXRCSVcsVUFBVTtHMENZakM7OztBdkI2TEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1QmhNbEMsQUFBQSwwQkFBMEIsQ0FBQztJcEJnSHJCLFNBQVMsRXJCeERBLElBQUk7SXFCNERiLFdBQVcsRUFoRkQsT0FBeUI7R29CakN4Qzs7O0F2QjZMSyxNQUFNLENBQUMsS0FBSztFdUJoTWxCLEFBQUEsMEJBQTBCLENBQUM7SXBCMkdyQixTQUFTLEVyQi9DQSxJQUFJO0lxQmdEYixXQUFXLEVyQi9DQSxJQUFJO0d5QzFEcEI7OztBQUVELEFBQUEsMEJBQTBCLENBQUM7RXBCNUIzQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQnBCRSxJQUFJO0VxQndCZixXQUFXLEVBcEVDLE9BQXlCO0VvQjdCdkMsYUFBYSxFN0MvQlosSUFBSTtDNkNnQ047O0F2QndMSyxNQUFNLENBQUMsS0FBSztFdUIzTGxCLEFBQUEsMEJBQTBCLENBQUM7SXBCbEJ6QixXQUFXLEV0QklXLFVBQVU7RzBDaUJqQzs7O0F2QndMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVCM0xsQyxBQUFBLDBCQUEwQixDQUFDO0lwQjJHckIsU0FBUyxFckI1QkEsSUFBSTtJcUJnQ2IsV0FBVyxFQWhGRCxJQUF5QjtHb0I1QnhDOzs7QXZCd0xLLE1BQU0sQ0FBQyxLQUFLO0V1QjNMbEIsQUFBQSwwQkFBMEIsQ0FBQztJcEJzR3JCLFNBQVMsRXJCbkJBLElBQUk7SXFCb0JiLFdBQVcsRXJCbkJBLElBQUk7R3lDakZwQjs7O0FBRUQsQUFBQSwwQkFBMEIsQ0FBQztFcEJqQzNCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFc0IyRnRCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0NvQnhCeEM7O0F2Qm9MSyxNQUFNLENBQUMsS0FBSztFdUJ0TGxCLEFBQUEsMEJBQTBCLENBQUM7SXBCdkJ6QixXQUFXLEV0QklXLFVBQVU7RzBDcUJqQzs7O0F2Qm9MSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVCdExsQyxBQUFBLDBCQUEwQixDQUFDO0lwQnNHckIsU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0dvQnhCeEM7OztBdkJvTEssTUFBTSxDQUFDLEtBQUs7RXVCdExsQixBQUFBLDBCQUEwQixDQUFDO0lwQmlHckIsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHeUMzRnBCOzs7QUFLRCxBQUFBLHdCQUF3QixDQUFDO0VBQ3ZCLE1BQU0sRUFBRSxDQUFDO0VBQ1QsU0FBUyxFQUFFLE9BQU87RUFDbEIsV0FBVyxFQUFFLE9BQU87Q0FDckI7O0FDdERELEFBQUEsV0FBVyxDQUFDO0VyQlVaLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VxQmxFdkMsT0FBTyxFQUFFLEtBQUs7RUFFZCxhQUFhLEU5Q0laLElBQUk7RThDRkwsS0FBSyxFbERtQkcsT0FBTztDa0RsQmhCOztBeEJ5TkssTUFBTSxDQUFDLEtBQUs7RXdCak9sQixBQUFBLFdBQVcsQ0FBQztJckJvQlYsV0FBVyxFdEJJVyxVQUFVO0cyQ2hCakM7OztBeEJ5TkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V3QmpPbEMsQUFBQSxXQUFXLENBQUM7SXJCaUpOLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHcUI3RHhDOzs7QXhCeU5LLE1BQU0sQ0FBQyxLQUFLO0V3QmpPbEIsQUFBQSxXQUFXLENBQUM7SXJCNElOLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7RzBDaElwQjs7O0FBWUQsQUFBQSxZQUFZLEFBQUEsSUFBSyxDQUFBLGVBQWUsQ0FBQyxJQUFLLENBQUEsZUFBZSxDQUFDLElBQUssQ0FBQSxnQkFBZ0IsSUFBSSxXQUFXLENBQUM7RUFDekYsYUFBYSxFOUNiWixJQUFJO0M4Q2NOOztBQVlELEFBQUEsdUJBQXVCLEFBQUEsSUFBSyxDREk1QiwwQkFBMEIsQ0NKNkIsSUFBSyxDREQ1RCwwQkFBMEIsQ0NDNkQsSUFBSyxDRE41RiwyQkFBMkIsSUNNZ0csV0FBVyxDQUFDO0VBQ3JJLGFBQWEsRTlDM0JaLElBQUk7QzhDNEJOOztBQUlELEFBQUEsdUJBQXVCLEdBQUcsV0FBVztBQUNyQyx1QkFBdUIsR0FBRyxXQUFXLENBQUM7RUFDcEMsVUFBVSxFOUNuQ1QsSUFBRztDOENvQ0w7O0FDM0NELEFBQUEsWUFBWSxDQUFDO0V0QlViLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VBdEN6QyxLQUFLLEU3Qk5JLE9BQU87RW1EckJkLE9BQU8sRUFBRSxLQUFLO0VBRWQsYUFBYSxFL0NDWixHQUFHO0MrQ0FMOztBekIwTkssTUFBTSxDQUFDLEtBQUs7RXlCak9sQixBQUFBLFlBQVksQ0FBQztJdEJvQlgsV0FBVyxFdEJJVyxVQUFVO0c0Q2pCakM7OztBekIwTkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V5QmpPbEMsQUFBQSxZQUFZLENBQUM7SXRCaUpQLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHc0I5RHhDOzs7QXpCME5LLE1BQU0sQ0FBQyxLQUFLO0V5QmpPbEIsQUFBQSxZQUFZLENBQUM7SXRCNElQLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7RzJDaklwQjs7O0F6QjBOSyxNQUFNLENBQUMsS0FBSztFeUJqT2xCLEFBQUEsWUFBWSxDQUFDO0l0QmtDWCxLQUFLLEUzQlVpQixPQUFPO0dpRHJDOUI7OztBRGEwRCxBQUFMLGdCQUFxQixDQ1QxRDtFdEJEakIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQTJDbEMsV0FBVyxFdEJiWSxHQUFHO0VzQjJGdEIsU0FBUyxFckI5REUsSUFBSTtFcUJrRWYsV0FBVyxFQXBFQyxPQUF5QjtFc0J4RHZDLGFBQWEsRS9DSlosSUFBSTtDK0NLTjs7QXpCbU5LLE1BQU0sQ0FBQyxLQUFLO0V3QjdNeUMsQUFBTCxnQkFBcUIsQ0NUMUQ7SXRCU2YsV0FBVyxFdEJJVyxVQUFVO0c0Q1ZqQzs7O0F6Qm1OSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXdCN015QixBQUFMLGdCQUFxQixDQ1QxRDtJdEJzSVgsU0FBUyxFckJ0RUEsSUFBSTtJcUIwRWIsV0FBVyxFQWhGRCxPQUF5QjtHc0J2RHhDOzs7QXpCbU5LLE1BQU0sQ0FBQyxLQUFLO0V3QjdNeUMsQUFBTCxnQkFBcUIsQ0NUMUQ7SXRCaUlYLFNBQVMsRXJCN0RBLElBQUk7SXFCOERiLFdBQVcsRXJCN0RBLElBQUk7RzJDbEVwQjs7O0FETXFDLEFBQUwsZUFBb0IsQ0NKckM7RXRCTmhCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFc0IyRnRCLFNBQVMsRXJCaERFLElBQUk7RXFCb0RmLFdBQVcsRUFwRUMsT0FBeUI7RXNCbkR2QyxhQUFhLEUvQ1RaLElBQUk7QytDVU47O0F6QjhNSyxNQUFNLENBQUMsS0FBSztFd0I3TW9CLEFBQUwsZUFBb0IsQ0NKckM7SXRCSWQsV0FBVyxFdEJJVyxVQUFVO0c0Q0xqQzs7O0F6QjhNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXdCN01JLEFBQUwsZUFBb0IsQ0NKckM7SXRCaUlWLFNBQVMsRXJCeERBLElBQUk7SXFCNERiLFdBQVcsRUFoRkQsT0FBeUI7R3NCbER4Qzs7O0F6QjhNSyxNQUFNLENBQUMsS0FBSztFd0I3TW9CLEFBQUwsZUFBb0IsQ0NKckM7SXRCNEhWLFNBQVMsRXJCL0NBLElBQUk7SXFCZ0RiLFdBQVcsRXJCL0NBLElBQUk7RzJDM0VwQjs7O0FEQ2dCLEFBQUwsZUFBb0IsQ0NDaEI7RXRCWGhCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFc0IyRnRCLFNBQVMsRXJCcEJFLElBQUk7RXFCd0JmLFdBQVcsRUFwRUMsT0FBeUI7RXNCOUN2QyxhQUFhLEUvQ2ZaLElBQUk7QytDZ0JOOztBekJ5TUssTUFBTSxDQUFDLEtBQUs7RXdCN01ELEFBQUwsZUFBb0IsQ0NDaEI7SXRCRGQsV0FBVyxFdEJJVyxVQUFVO0c0Q0FqQzs7O0F6QnlNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXdCN01qQixBQUFMLGVBQW9CLENDQ2hCO0l0QjRIVixTQUFTLEVyQjVCQSxJQUFJO0lxQmdDYixXQUFXLEVBaEZELElBQXlCO0dzQjdDeEM7OztBekJ5TUssTUFBTSxDQUFDLEtBQUs7RXdCN01ELEFBQUwsZUFBb0IsQ0NDaEI7SXRCdUhWLFNBQVMsRXJCbkJBLElBQUk7SXFCb0JiLFdBQVcsRXJCbkJBLElBQUk7RzJDbEdwQjs7O0FBRUQsQUFBQSxlQUFlLENBQUM7RXRCaEJoQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtDc0J6Q3hDOztBekJxTUssTUFBTSxDQUFDLEtBQUs7RXlCdk1sQixBQUFBLGVBQWUsQ0FBQztJdEJOZCxXQUFXLEV0QklXLFVBQVU7RzRDSWpDOzs7QXpCcU1LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFeUJ2TWxDLEFBQUEsZUFBZSxDQUFDO0l0QnVIVixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R3NCekN4Qzs7O0F6QnFNSyxNQUFNLENBQUMsS0FBSztFeUJ2TWxCLEFBQUEsZUFBZSxDQUFDO0l0QmtIVixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0cyQzVHcEI7OztBQVFELEFBQUEsb0JBQW9CLENBQUM7RUFDbkIsTUFBTSxFQUFFLENBQUM7Q0FDVjs7QUo5QkQsQUFBQSx1QkFBdUIsQ0FBQztFbEJFeEIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsSUFBeUI7RWtCMUR2QyxPQUFPLEVBQUUsS0FBSztFQUNkLFFBQVEsRUFBRSxRQUFRO0VBRWxCLFVBQVUsRTNDRFQsSUFBSTtFMkNHTCxhQUFhLEUzQ1JaLElBQUk7RTJDU0wsT0FBTyxFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDM0NKYixJQUFJO0UyQ01MLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0FyQjZNSyxNQUFNLENBQUMsS0FBSztFcUJ6TmxCLEFBQUEsdUJBQXVCLENBQUM7SWxCWXRCLFdBQVcsRXRCSVcsVUFBVTtHd0NKakM7OztBckI2TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VxQnpObEMsQUFBQSx1QkFBdUIsQ0FBQztJbEJ5SWxCLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHa0JqRHhDOzs7QXJCNk1LLE1BQU0sQ0FBQyxLQUFLO0VxQnpObEIsQUFBQSx1QkFBdUIsQ0FBQztJbEJvSWxCLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3VDcEhwQjs7O0FBRUQsQUFBQSx1QkFBdUIsQUFBQSxXQUFXO0FBQ2xDLHVCQUF1QixBQUFBLGFBQWEsQ0FBQztFQUNuQyxhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUFFRCxBQUFBLHdCQUF3QixDQUFDO0VBQ3ZCLFFBQVEsRUFBRSxRQUFRO0VBRWxCLE9BQU8sRUFBRSxDQUFDO0VBQ1YsR0FBRyxFQUFFLENBQUM7RUFDTixJQUFJLEVBQUUsQ0FBQztFQUVQLEtBQUssRTNDckJKLElBQUk7RTJDc0JMLE1BQU0sRTNDdEJMLElBQUk7RTJDd0JMLE1BQU0sRUFBRSxPQUFPO0VBSWIsTUFBTSxFQUFFLENBQUM7RUFDVCxPQUFPLEVBQUUsQ0FBQztDQVNiOztBQUVELEFBQUEsd0JBQXdCLENBQUM7RUFDdkIsT0FBTyxFQUFFLFlBQVk7RUFDckIsYUFBYSxFQUFFLENBQUM7RUFDaEIsT0FBTyxFQUFFLEdBQUcsQzNDL0NYLElBQUksQ0FGSixHQUFHO0UyQ2tESixNQUFNLEVBQUUsT0FBTztFQUVmLGdCQUFnQixFQUFFLFlBQVk7RUFDOUIsWUFBWSxFQUFFLFlBQVk7Q0FDM0I7O0FBRUQsQUFBQSx1QkFBdUIsQ0FBQztFQUN0QixPQUFPLEVBQUUsS0FBSztFQUNkLGFBQWEsRTNDeERaLElBQUk7RTJDeURMLFlBQVksRTNDekRYLElBQUk7QzJDMEROOztBQUVELEFBQUEsd0JBQXdCLEdBQUcsd0JBQXdCLEFBQUEsUUFBUSxDQUFDO0VBQzFELE9BQU8sRUFBRSxFQUFFO0VBQ1gsa0JBQWtCLEVBQUUsVUFBVTtFQUN0QixVQUFVLEVBQUUsVUFBVTtFQUM5QixRQUFRLEVBQUUsUUFBUTtFQUNsQixHQUFHLEVBQUUsQ0FBQztFQUNOLElBQUksRUFBRSxDQUFDO0VBQ1AsS0FBSyxFM0MvREosSUFBSTtFMkNnRUwsTUFBTSxFM0NoRUwsSUFBSTtFMkNpRUwsTUFBTSxFMUNwQndCLEdBQUcsQzBDb0JRLEtBQUssQ0FBQyxZQUFZO0VBQzNELFVBQVUsRUFBRSxXQUFXO0NBR3hCOztBQUVELEFBQUEsd0JBQXdCLEdBQUcsd0JBQXdCLEFBQUEsT0FBTyxDQUFDO0VBQ3pELE9BQU8sRUFBRSxFQUFFO0VBRVgsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFQUFFLElBQUk7RUFDVCxJQUFJLEVBQUUsR0FBRztFQUNULEtBQUssRUFBRSxJQUFJO0VBQ1gsTUFBTSxFQUFFLEdBQUc7RUFFWCxpQkFBaUIsRUFBRSxjQUFjO0VBRTdCLGFBQWEsRUFBRSxjQUFjO0VBRXpCLFNBQVMsRUFBRSxjQUFjO0VBQ2pDLE1BQU0sRUFBRSxLQUFLO0VBQ2IsWUFBWSxFQUFFLENBQUMsQ0FBQyxDQUFDLEMxQzlEQSxHQUFHLENBQUgsR0FBRztFMENpRXBCLGdCQUFnQixFQUFFLFdBQVc7RUFFN0IsT0FBTyxFQUFFLENBQUM7RUFFVixVQUFVLEVBQUUsV0FBVztDQUN4Qjs7QUFHRCxBQUFBLHdCQUF3QixBQUFBLE1BQU0sR0FBRyx3QkFBd0IsQUFBQSxRQUFRLENBQUM7RUFJaEUsT0FBTyxFMUNuQ1MsR0FBRyxDMENtQ1MsS0FBSyxDQUFDLFdBQVc7RUFDN0MsY0FBYyxFMUNwQ0UsR0FBRztFMENxQ25CLGtCQUFrQixFQUFFLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDMUNyQ1QsR0FBRyxDTDdEWCxPQUFPO0UrQ21HUCxVQUFVLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEMxQ3RDVCxHQUFHLENMN0RYLE9BQU87QytDb0doQjs7QUFHRCxBQUFBLHdCQUF3QixBQUFBLFFBQVEsR0FBRyx3QkFBd0IsQUFBQSxPQUFPLENBQUM7RUFDakUsT0FBTyxFQUFFLENBQUM7Q0FDWDs7QUFHRCxBQUFBLHdCQUF3QixBQUFBLFNBQVM7QUFDakMsd0JBQXdCLEFBQUEsU0FBUyxHQUFHLHdCQUF3QixDQUFDO0VBQzNELE1BQU0sRUFBRSxPQUFPO0NBQ2hCOztBQUVELEFBQUEsd0JBQXdCLEFBQUEsU0FBUyxHQUFHLHdCQUF3QixDQUFDO0VBQzNELE9BQU8sRUFBRSxFQUFFO0NBQ1o7O0FBVUQsQUFBQSw4QkFBOEIsQ0FBQztFbkI5RHpCLGFBQTBCLEV4QjlCeEIsSUFBSTtFMkM4RlYsV0FBVyxFQVJnQixJQUE4RDtFQVN6RixZQUFZLEVBTGEsSUFBd0U7RUFNakcsV0FBVyxFMUNoR2EsR0FBRyxDMENnR1ksS0FBSyxDL0N4SHBDLE9BQU87QytDaUloQjs7QXJCcUVLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFcUJsRmxDLEFBQUEsOEJBQThCLENBQUM7SW5CdkR2QixhQUEwQixFeEJwQ3hCLElBQUk7RzJDd0diOzs7QUFQQyxBQUFBLFdBQVcsQ0FBRSxzQ0FBUSxDQUFDO0VBQ3BCLE9BQU8sRUFBRSxJQUFJO0NBQ2Q7O0FBUkgsQUFVRSw4QkFWNEIsR0FVeEIsV0FBVyxDQUFDO0VBQ2QsYUFBYSxFQUFFLENBQUM7Q0FDakI7O0FNdkpILEFBQUEsWUFBWSxDQUFDO0V4Qk1iLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0V3QjdEdkMsa0JBQWtCLEVBQUUsVUFBVTtFQUV0QixVQUFVLEVBQUUsVUFBVTtFQUM5QixLQUFLLEVBQUUsSUFBSTtFQUNYLE1BQU0sRUFBRSxJQUFJO0VBQ1osVUFBVSxFQUFFLENBQUM7RUFFYixPQUFPLEVqRFJOLEdBQUc7RWlEV0osTUFBTSxFaER3Q3dCLEdBQUcsQ2dEeENRLEtBQUssQ3JET3ZDLE9BQU87RXFETmQsYUFBYSxFQUFFLENBQUM7RUFHaEIsa0JBQWtCLEVBQUUsSUFBSTtFQUNyQixlQUFlLEVBQUUsSUFBSTtFQUNoQixVQUFVLEVBQUUsSUFBSTtDQUN6Qjs7QTNCd01LLE1BQU0sQ0FBQyxLQUFLO0UyQjdObEIsQUFBQSxZQUFZLENBQUM7SXhCZ0JYLFdBQVcsRXRCSVcsVUFBVTtHOENDakM7OztBM0J3TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0UyQjdObEMsQUFBQSxZQUFZLENBQUM7SXhCNklQLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHd0I1Q3hDOzs7QTNCd01LLE1BQU0sQ0FBQyxLQUFLO0UyQjdObEIsQUFBQSxZQUFZLENBQUM7SXhCd0lQLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7RzZDL0dwQjs7O0FBckJELEFoQ0lBLFlnQ0pZLEFoQ0lYLE1BQU0sQ0FBQztFQUNOLE9BQU8sRWhCc0VTLEdBQUcsQ2dCdEVTLEtBQUssQ3JCU3pCLE9BQU87RXFCUmYsY0FBYyxFQUFFLENBQUM7Q0FDbEI7O0FnQ2dCRCxBQUFBLFlBQVksQUFBQSwyQkFBMkI7QUFDdkMsWUFBWSxBQUFBLDJCQUEyQixDQUFDO0VBQ3RDLE1BQU0sRUFBRSxDQUFDO0VBQ1Qsa0JBQWtCLEVBQUUsSUFBSTtDQUN6Qjs7QUFFRCxBQUFBLFlBQVksQ0FBQSxBQUFBLElBQUMsQ0FBSyxRQUFRLEFBQWIsRUFBZTtFQUMxQixlQUFlLEVBQUUsU0FBUztDQUMzQjs7QUFFRCxBQUFBLG1CQUFtQixDQUFDO0VBQ2xCLE1BQU0sRWhEMkI4QixHQUFHLENnRDNCUSxLQUFLLENyRHhCL0MsT0FBTztDcUR5QmI7O0FBTUQsQUFBQSxzQkFBc0IsQ0FBQztFQUNyQixTQUFTLEVBQUUsSUFBVTtDQUN0Qjs7QUFFRCxBQUFBLHNCQUFzQixDQUFDO0VBQ3JCLFNBQVMsRUFBRSxJQUFVO0NBQ3RCOztBQUVELEFBQUEsc0JBQXNCLENBQUM7RUFDckIsU0FBUyxFQUFFLElBQVU7Q0FDdEI7O0FBRUQsQUFBQSxxQkFBcUIsQ0FBQztFQUNwQixTQUFTLEVBQUUsTUFBTTtDQUNsQjs7QUFFRCxBQUFBLHFCQUFxQixDQUFDO0VBQ3BCLFNBQVMsRUFBRSxHQUFHO0NBQ2Y7O0FBRUQsQUFBQSxxQkFBcUIsQ0FBQztFQUNwQixTQUFTLEVBQUUsS0FBSztDQUNqQjs7QUFFRCxBQUFBLHFCQUFxQixDQUFDO0VBQ3BCLFNBQVMsRUFBRSxLQUFLO0NBQ2pCOztBRGxFRCxBQUFBLGlCQUFpQixDQUFDO0VBR2hCLFNBQVMsRUFBRSxDQUFDO0NBQ2I7O0FBSkQsQWpDREEsaUJpQ0NpQixBakNEaEIsTUFBTSxDQUFDO0VBQ04sT0FBTyxFQUFFLEVBQUU7RUFDWCxPQUFPLEVBQUUsS0FBSztFQUNkLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0FpQ0dELEFBQUEsdUJBQXVCLENBQUM7RUFDdEIsT0FBTyxFQUFFLFlBQVk7RUFDckIsWUFBWSxFaERIWCxJQUFJO0VnRElMLGFBQWEsRUFBRSxDQUFDO0NBQ2pCOztBQUVELEFBQUEsd0JBQXdCLENBQUM7RUFDdkIsT0FBTyxFQUFFLEtBQUs7Q0FDZjs7QUFFRCxBQUFBLHdCQUF3QixDQUFDO0VBQ3ZCLGFBQWEsRUFBRSxDQUFDO0NBQ2pCOztBRXRCRCxBQUFBLGNBQWMsQ0FBQztFekJTZixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFQXRDekMsS0FBSyxFN0JOSSxPQUFPO0U0QndEVixhQUEwQixFeEJ0QnhCLElBQUk7RWtEckRWLE9BQU8sRUFBRSxLQUFLO0NBQ2Y7O0E1QjBOSyxNQUFNLENBQUMsS0FBSztFNEJoT2xCLEFBQUEsY0FBYyxDQUFDO0l6Qm1CYixXQUFXLEV0QklXLFVBQVU7RytDakJqQzs7O0E1QjBOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTRCaE9sQyxBQUFBLGNBQWMsQ0FBQztJekJnSlQsU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0d5QjlEeEM7OztBNUIwTkssTUFBTSxDQUFDLEtBQUs7RTRCaE9sQixBQUFBLGNBQWMsQ0FBQztJekIySVQsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHOENqSXBCOzs7QTVCME5LLE1BQU0sQ0FBQyxLQUFLO0U0QmhPbEIsQUFBQSxjQUFjLENBQUM7SXpCaUNiLEtBQUssRTNCVWlCLE9BQU87R29EckM5Qjs7O0E1QjBOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTRCaE9sQyxBQUFBLGNBQWMsQ0FBQztJMUJ1RlAsYUFBMEIsRXhCNUJ4QixJQUFJO0drRHJEYjs7O0FBRUQsQUFBQSx1QkFBdUIsQ0FBQztFQUV0QixPQUFPLEVBQUUsWUFBWTtFQUdyQixRQUFRLEVBQUUsUUFBUTtFQUVsQixhQUFhLEVsRFRaLEdBQUc7RWtEWUosWUFBWSxFQUFFLElBQXNDO0VBR3BELEtBQUssRXREQ0MsT0FBTztFc0RBYixNQUFNLEVBQUUsT0FBTztDQUNoQjs7QUFHRCxBQUFBLDRCQUE0QixDQUFDO0VBQzNCLGVBQWUsRUFBRSxTQUFTO0NBQzNCOztBQUVELEFBQUEsdUJBQXVCLEFBQUEsTUFBTSxDQUFDO0VBQzVCLEtBQUssRXREVk8sT0FBTztDc0RXcEI7O0FBRUQsQUFBQSx1QkFBdUIsQUFBQSxNQUFNLENBQUM7RUFFNUIsT0FBTyxFQUFFLEdBQTBCLENBQUMsS0FBSyxDdERuQmpDLE9BQU87RXNEb0JmLGNBQWMsRUFBRSxJQUFJO0VBQ3BCLFVBQVUsRXREckJGLE9BQU87Q3NEc0JoQjs7QUFJRCxBQUFBLHVCQUF1QixBQUFBLHdCQUF3QixDQUFDO0VBQzlDLE9BQU8sRUFBRSxJQUFJO0NBQ2Q7O0FBR0QsQUFBQSx1QkFBdUIsQUFBQSxPQUFPLENBQUM7RUFDN0IsT0FBTyxFQUFFLEVBQUU7RUFDWCxRQUFRLEVBQUUsUUFBUTtFQUVsQixHQUFHLEVBQUUsQ0FBQztFQUNOLE1BQU0sRUFBRSxDQUFDO0VBQ1QsSUFBSSxFQUFFLENBQUM7RUFFUCxNQUFNLEVBQUUsSUFBSTtFM0J4QmQsT0FBTyxFQUQ0RCxLQUFLO0VBR3hFLEtBQUssRUFBRSxDQUFDO0VBQ1IsTUFBTSxFQUFFLENBQUM7RUFFVCxZQUFZLEVBQUUsS0FBSztFQUNuQixZQUFZLEVBQUUsV0FBVztFQWV2QixpQkFBaUIsRUFBRSxpQ0FBaUM7RUFDNUMsU0FBUyxFQUFFLGlDQUFpQztFQUVwRCxZQUFZLEVBaEJFLEdBQVMsQ0FnQk0sQ0FBQyxDQWhCaEIsR0FBUyxDQTlCakIsUUFBbUM7RUErQ3pDLGlCQUFpQixFQUFFLE9BQU87QzJCTTNCOztBQUhDLEFBQUEsY0FBYyxDQUFBLEFBQUEsSUFBQyxBQUFBLElBWmpCLHVCQUF1QixBQUFBLE9BQU8sQ0FZSDtFM0I1QjNCLE9BQU8sRUFENEQsS0FBSztFQUd4RSxLQUFLLEVBQUUsQ0FBQztFQUNSLE1BQU0sRUFBRSxDQUFDO0VBRVQsWUFBWSxFQUFFLEtBQUs7RUFDbkIsWUFBWSxFQUFFLFdBQVc7RUFxQnZCLGlCQUFpQixFQUFFLGlDQUFpQztFQUM1QyxTQUFTLEVBQUUsaUNBQWlDO0VBRXBELFlBQVksRUFwRE4sUUFBbUMsQ0E4QjNCLEdBQVMsQ0FzQmMsQ0FBQyxDQXRCeEIsR0FBUztFQXVCdkIsZ0JBQWdCLEVBQUUsT0FBTztDMkJEeEI7O0FBR0gsQUFBQSxvQkFBb0IsQ0FBQztFQUNuQixPQUFPLEVsRDFETixJQUFJO0VrRDJETCxZQUFZLEVsRDFEWCxJQUFJO0VrRDJETCxXQUFXLEVqRGhDTSxHQUFHLENpRGdDYSxLQUFLLEN0RDFDOUIsT0FBTztDc0QyQ2hCOztBQUVELEFBQUEsb0JBQW9CLENBQUMsQ0FBQyxDQUFDO0VBQ3JCLFVBQVUsRUFBRSxDQUFDO0VBQ2IsYUFBYSxFbERoRVosSUFBSTtDa0RpRU47O0FBRUQsQUFBQSxvQkFBb0IsR0FBRyxXQUFXLENBQUM7RUFDakMsYUFBYSxFQUFFLENBQUM7Q0FDakI7O0FDNUVELEFBQUEsb0JBQW9CLENBQUM7RTFCNEJyQixLQUFLLEU3Qk5JLE9BQU87RTRCc0RWLE9BQVksRXhCNUJWLElBQUk7RXdCOEJOLGFBQTBCLEV4QmR4QixJQUFJO0VtRDFEVixNQUFNLEVsRDBDa0IsR0FBRyxDa0QxQ1EsS0FBSyxDdkRLbkMsT0FBTztDdURBYjs7QTdCbU5LLE1BQU0sQ0FBQyxLQUFLO0U2QjlObEIsQUFBQSxvQkFBb0IsQ0FBQztJMUIrQm5CLEtBQUssRTNCVWlCLE9BQU87R3FEOUI5Qjs7O0E3Qm1OSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTZCOU5sQyxBQUFBLG9CQUFvQixDQUFDO0kzQm1GYixPQUFZLEV4QmxDVixJQUFJO0dtRHRDYjs7O0E3Qm1OSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTZCOU5sQyxBQUFBLG9CQUFvQixDQUFDO0kzQnFGYixhQUEwQixFeEJwQnhCLElBQUk7R21EdERiOzs7QUFYRCxBbENLQSxvQmtDTG9CLEFsQ0tuQixNQUFNLENBQUM7RUFDTixPQUFPLEVoQnNFUyxHQUFHLENnQnRFUyxLQUFLLENyQlN6QixPQUFPO0VxQlJmLGNBQWMsRUFBRSxDQUFDO0NBQ2xCOztBS3NOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTZCOU5sQyxBQUFBLG9CQUFvQixDQUFDO0lBU2pCLE1BQU0sRWxEeUJTLEdBQUcsQ2tEekJVLEtBQUssQ3ZERTlCLE9BQU87R3VEQWI7OztBQUVELEFBQUEsMkJBQTJCLENBQUM7RTFCTjVCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFc0IyRnRCLFNBQVMsRXJCcEJFLElBQUk7RXFCd0JmLFdBQVcsRUFwRUMsT0FBeUI7RTBCbER2QyxVQUFVLEVBQUUsQ0FBQztFM0I4RFQsYUFBMEIsRXhCOUJ4QixJQUFJO0NtRDlCWDs7QTdCNE1LLE1BQU0sQ0FBQyxLQUFLO0U2QmpObEIsQUFBQSwyQkFBMkIsQ0FBQztJMUJJMUIsV0FBVyxFdEJJVyxVQUFVO0dnREhqQzs7O0E3QjRNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTZCak5sQyxBQUFBLDJCQUEyQixDQUFDO0kxQmlJdEIsU0FBUyxFckI1QkEsSUFBSTtJcUJnQ2IsV0FBVyxFQWhGRCxJQUF5QjtHMEJoRHhDOzs7QTdCNE1LLE1BQU0sQ0FBQyxLQUFLO0U2QmpObEIsQUFBQSwyQkFBMkIsQ0FBQztJMUI0SHRCLFNBQVMsRXJCbkJBLElBQUk7SXFCb0JiLFdBQVcsRXJCbkJBLElBQUk7RytDckdwQjs7O0E3QjRNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTZCak5sQyxBQUFBLDJCQUEyQixDQUFDO0kzQndFcEIsYUFBMEIsRXhCcEN4QixJQUFJO0dtRC9CYjs7O0FBRUQsQUFBQSwwQkFBMEIsQ0FBQztFMUJiM0IsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsSUFBeUI7QzBCdkN4Qzs7QTdCbU1LLE1BQU0sQ0FBQyxLQUFLO0U2QjFNbEIsQUFBQSwwQkFBMEIsQ0FBQztJMUJIekIsV0FBVyxFdEJJVyxVQUFVO0dnRE1qQzs7O0E3Qm1NSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTZCMU1sQyxBQUFBLDBCQUEwQixDQUFDO0kxQjBIckIsU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0cwQnZDeEM7OztBN0JtTUssTUFBTSxDQUFDLEtBQUs7RTZCMU1sQixBQUFBLDBCQUEwQixDQUFDO0kxQnFIckIsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHK0MxR3BCOzs7QUFQRCxBQUdFLDBCQUh3QixDQUd4QixDQUFDLENBQUM7RUFDQSxVQUFVLEVBQUUsQ0FBQztFM0JzRFgsYUFBMEIsRXhCOUJ4QixJQUFJO0NtRHRCVDs7QTdCb01HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFNkIxTWxDLEFBR0UsMEJBSHdCLENBR3hCLENBQUMsQ0FBQztJM0I4REksYUFBMEIsRXhCcEN4QixJQUFJO0dtRHZCWDs7O0FBSUgsQUFBQSwwQkFBMEIsQ0FBQztFQUN6QixVQUFVLEVBQUUsQ0FBQztFQUNiLGFBQWEsRUFBRSxDQUFDO0NBQ2pCOztBQUVELEFBQUEsMEJBQTBCLENBQUMsQ0FBQyxDQUFDO0UxQmlCN0IsV0FBVyxFdEJiWSxHQUFHO0NnRGtCekI7O0FBdEJELEFsQ2ZBLDBCa0NlMEIsQ0FBQyxDQUFDLEFsQ2YzQixNQUFNLENBQUM7RUFDTixPQUFPLEVoQnVEUyxHQUFHLENnQnZEUyxLQUFLLENyQk56QixPQUFPO0VxQk9mLGNBQWMsRUFBRSxDQUFDO0VBQ2pCLGdCQUFnQixFckJSUixPQUFPO0NxQlNoQjs7QWtDV0QsQUFLRSwwQkFMd0IsQ0FBQyxDQUFDLEFBS3pCLEtBQUssRUFMUiwwQkFBMEIsQ0FBQyxDQUFDLEFBTXpCLFFBQVEsRUFOWCwwQkFBMEIsQ0FBQyxDQUFDLEFBT3pCLE1BQU0sRUFQVCwwQkFBMEIsQ0FBQyxDQUFDLEFBUXpCLE9BQU8sRUFSViwwQkFBMEIsQ0FBQyxDQUFDLEFBU3pCLE1BQU0sQ0FBQztFQUNOLEtBQUssRXZEbENGLE9BQU87RXVEbUNWLGVBQWUsRUFBRSxTQUFTO0NBQzNCOztBQVpILEFBa0JJLDBCQWxCc0IsQ0FBQyxDQUFDLEFBa0J2QixLQUFLLEFBQUEsTUFBTSxDQUFDO0VBQ1gsS0FBSyxFdkQzQ0osT0FBTztDdUQ0Q1Q7O0FDdERMLEFBQUEsa0JBQWtCLENBQUM7RTNCTW5CLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VBdEN6QyxLQUFLLEU3Qk5JLE9BQU87Q3dEakJmOztBOUJ5TkssTUFBTSxDQUFDLEtBQUs7RThCN05sQixBQUFBLGtCQUFrQixDQUFDO0kzQmdCakIsV0FBVyxFdEJJVyxVQUFVO0dpRGhCakM7OztBOUJ5TkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0U4QjdObEMsQUFBQSxrQkFBa0IsQ0FBQztJM0I2SWIsU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0cyQjdEeEM7OztBOUJ5TkssTUFBTSxDQUFDLEtBQUs7RThCN05sQixBQUFBLGtCQUFrQixDQUFDO0kzQndJYixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0dnRGhJcEI7OztBOUJ5TkssTUFBTSxDQUFDLEtBQUs7RThCN05sQixBQUFBLGtCQUFrQixDQUFDO0kzQjhCakIsS0FBSyxFM0JVaUIsT0FBTztHc0RwQzlCOzs7QUFKRCxBbkNJQSxrQm1DSmtCLEFuQ0lqQixNQUFNLENBQUM7RUFDTixPQUFPLEVoQnNFUyxHQUFHLENnQnRFUyxLQUFLLENyQlN6QixPQUFPO0VxQlJmLGNBQWMsRUFBRSxDQUFDO0NBQ2xCOztBbUNERCxBQUFBLHlCQUF5QixDQUFDO0VBQ3hCLE1BQU0sRW5Ec0Q4QixHQUFHLENtRHREUSxLQUFLLEN4REcvQyxPQUFPO0N3REZiOztBQ0tELEFBQUEsYUFBYSxDQUFDO0U1QlBkLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCUUUsSUFBSTtFcUJKZixXQUFXLEVBcEVDLE9BQXlCO0VEWW5DLFdBQTBCLEV4QmxCeEIsSUFBSTtFd0JrQk4sY0FBMEIsRXhCMUJ4QixJQUFJO0VxRGpDVixVQUFVLEVBQUUsR0FBRyxDQUFDLEtBQUssQ0FsQkcsT0FBTztFQW1CL0IsS0FBSyxFQWpCYSxPQUFPO0VBa0J6QixVQUFVLEV6RElGLE9BQU87Q3lESGhCOztBL0J3TUssTUFBTSxDQUFDLEtBQUs7RStCaE5sQixBQUFBLGFBQWEsQ0FBQztJNUJHWixXQUFXLEV0QklXLFVBQVU7R2tEQ2pDOzs7QS9Cd01LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFK0JoTmxDLEFBQUEsYUFBYSxDQUFDO0k1QmdJUixTQUFTLEVyQkFBLElBQUk7SXFCSWIsV0FBVyxFQWhGRCxJQUF5QjtHNEI1Q3hDOzs7QS9Cd01LLE1BQU0sQ0FBQyxLQUFLO0UrQmhObEIsQUFBQSxhQUFhLENBQUM7STVCMkhSLFNBQVMsRXJCU0EsSUFBSTtJcUJSYixXQUFXLEVyQlNBLEdBQUc7R2lEN0huQjs7O0EvQndNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RStCaE5sQyxBQUFBLGFBQWEsQ0FBQztJN0J1RU4sV0FBMEIsRXhCeEJ4QixJQUFJO0dxRHZDYjs7O0EvQndNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RStCaE5sQyxBQUFBLGFBQWEsQ0FBQztJN0J1RU4sY0FBMEIsRXhCaEN4QixJQUFJO0dxRC9CYjs7O0FBRUQsQXBDSkEsbUJvQ0ltQixBcENKbEIsTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJ1RFMsR0FBRyxDZ0J2RFMsS0FBSyxDckJOekIsT0FBTztFcUJPZixjQUFjLEVBQUUsQ0FBQztFQUNqQixnQkFBZ0IsRXJCUlIsT0FBTztDcUJTaEI7O0FvQ0FELEFBR0UsbUJBSGlCLEFBR2hCLEtBQUssRUFIUixtQkFBbUIsQUFJaEIsUUFBUSxDQUFDO0VBQ1IsS0FBSyxFQTFCVyxPQUFPO0NBMkJ4Qjs7QUFOSCxBQVFFLG1CQVJpQixBQVFoQixNQUFNLEVBUlQsbUJBQW1CLEFBU2hCLE9BQU8sQ0FBQztFQUNQLEtBQUssRUE3QmlCLE9BQU87Q0E4QjlCOztBQVhILEFwQ0pBLG1Cb0NJbUIsQXBDSmxCLE1BQU0sQ29Da0JHO0VBQ04sS0FBSyxFekRqQkEsT0FBTztDeURrQmI7O0FBaEJILEFBc0JJLG1CQXRCZSxBQXNCZCxLQUFLLEFBQUEsTUFBTSxDQUFDO0U1QmxCakIsS0FBSyxFN0JOSSxPQUFPO0N5RDBCWDs7QS9COEtDLE1BQU0sQ0FBQyxLQUFLO0UrQnRNbEIsQUFzQkksbUJBdEJlLEFBc0JkLEtBQUssQUFBQSxNQUFNLENBQUM7STVCZmYsS0FBSyxFM0JVaUIsT0FBTztHdURPMUI7OztBQUlMLEFBQUEsNEJBQTRCLENBQUM7RUFDM0IsTUFBTSxFQUFFLENBQUM7RTdCeUJMLGFBQTBCLEV4QmR4QixJQUFJO0VxRFRWLE1BQU0sRUFBRSxDQUFDO0VBQ1QsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLEN6RGhDaEIsT0FBTztDeURpQ2hCOztBL0JxS0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0UrQjFLbEMsQUFBQSw0QkFBNEIsQ0FBQztJN0JpQ3JCLGFBQTBCLEV4QnBCeEIsSUFBSTtHcURSYjs7O0FBRUQsQUFBQSxtQkFBbUIsQ0FBQztFQUNsQixPQUFPLEVBQUUsV0FBVztFQUNwQixPQUFPLEVBQUUsV0FBVztFQUNwQixPQUFPLEVBQUUsSUFBSTtFQUNiLFlBQVksRXBEMUNJLEtBQWlCO0VvRDJDakMsV0FBVyxFcEQzQ0ssS0FBaUI7RW9ENENqQyxhQUFhLEVBQUUsSUFBSTtFQUNmLFNBQVMsRUFBRSxJQUFJO0VBQ25CLGlCQUFpQixFQUFFLEdBQUc7RUFDbEIsY0FBYyxFQUFFLEdBQUc7RUFDZixXQUFXLEVBQUUsUUFBUTtFQUM3QixnQkFBZ0IsRUFBRSxNQUFNO0VBQ3BCLGFBQWEsRUFBRSxNQUFNO0VBQ2pCLGVBQWUsRUFBRSxNQUFNO0NBQ2hDOztBQUVELEFBQUEsd0JBQXdCLENBQUM7RUFDdkIsWUFBWSxFcER2REksSUFBaUI7RW9Ed0RqQyxhQUFhLEVyRHJFWixJQUFJO0VxRHNFTCxXQUFXLEVwRHpESyxJQUFpQjtDb0QwRGxDOztBQUVELEFBQUEsOEJBQThCLENBQUM7RUFDN0IsZ0JBQWdCLEVBQUUsQ0FBQztFQUNmLFFBQVEsRUFBRSxDQUFDO0VBQ1AsSUFBSSxFQUFFLENBQUM7Q0FLaEI7O0EvQnFJSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RStCN0lsQyxBQUFBLDhCQUE4QixDQUFDO0lBSzNCLHVCQUF1QixFQUFFLEtBQUs7SUFDMUIsVUFBVSxFQUFFLEtBQUs7R0FFeEI7OztBQUVELEFBQUEsMkJBQTJCLENBQUM7RUFDMUIsT0FBTyxFQUFFLFlBQVk7RUFDckIsWUFBWSxFckR4RlgsSUFBSTtFcUQ0RkwsY0FBYyxFQUFFLEdBQUc7Q0FDcEI7O0EvQjRISyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RStCbklsQyxBQUFBLDJCQUEyQixDQUFDO0lBSXhCLGFBQWEsRXJEekZkLElBQUk7R3FENEZOOzs7QUFFRCxBQUFBLGtDQUFrQyxDQUFDO0VBQ2pDLE9BQU8sRUFBRSxZQUFZO0NBQ3RCOztBQUVELEFBQUEsNkJBQTZCLENBQUM7RUFDNUIsT0FBTyxFQUFFLFlBQVk7RUFDckIsU0FBUyxFQS9Gc0IsS0FBd0M7RUFnR3ZFLFdBQVcsRUFBRSxLQUFxRDtFQUNsRSxnQkFBZ0IsRTFDM0ZSLHFDQUFtQztFMEMrRjNDLGlCQUFpQixFQUFFLFNBQVM7RUFDNUIsbUJBQW1CLEVBQUUsTUFBTTtFQUMzQixlQUFlLEVBdkdnQixLQUF3QyxDQUN2QyxLQUF5QztFQXVHekUsVUFBVSxFQUFFLE1BQU07RUFDbEIsZUFBZSxFQUFFLElBQUk7RUFDckIsV0FBVyxFQUFFLE1BQU07Q0FDcEI7O0FyQ2hHRCxNQUFNLE1BQU0sTUFBTSxPQUFPLDZCQUE2QixFQUFFLENBQUMsUUFBUSxNQUFNLE1BQU0sMkJBQTJCLEVBQUUsQ0FBQyxRQUFRLE1BQU0sTUFBTSxzQkFBc0IsRUFBRSxDQUFDLFFBQVEsTUFBTSxNQUFNLGNBQWMsRUFBRSxNQUFNLFFBQVEsTUFBTSxNQUFNLGNBQWMsRUFBRSxLQUFLO0VxQ2tGM08sQUFBQSw2QkFBNkIsQ0FBQztJQU0xQixnQkFBZ0IsRTFDN0ZWLHdDQUFtQztHMENxRzVDOzs7QUFFRCxBQUFBLDBCQUEwQixDQUFDO0VBQ3pCLFVBQVUsRUFBRSxDQUFDO0VBQ2IsYUFBYSxFckRwSFosSUFBSTtFcURxSEwsT0FBTyxFQUFFLENBQUM7Q0FDWDs7QUFFRCxBQUFBLCtCQUErQixDQUFDO0VBQzlCLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLFlBQVksRXJEMUhYLElBQUk7RXFEMkhMLGFBQWEsRXJEN0haLEdBQUc7Q3FEOEhMOztBQUVELEFBQUEsc0JBQXNCLENBQUM7RTdCdERqQixhQUEwQixFeEJsQnhCLElBQUk7RXFEMEVWLGNBQWMsRXJEL0hiLElBQUk7RXFEbUlMLGFBQWEsRUFBRSxHQUFHLENBQUMsS0FBSyxDekRsSGhCLE9BQU87Q3lEbUhoQjs7QS9CbUZLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFK0IxRmxDLEFBQUEsc0JBQXNCLENBQUM7STdCL0NmLGFBQTBCLEV4QnhCeEIsSUFBSTtHcUQ4RWI7OztBL0JtRkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0UrQjFGbEMsQUFBQSxzQkFBc0IsQ0FBQztJQUluQixjQUFjLEVyRG5JZixJQUFJO0dxRHNJTjs7O0FBRUQsQUFBQSx5QkFBeUIsQ0FBQztFQUN4QixPQUFPLEVBQUUsV0FBVztFQUNwQixPQUFPLEVBQUUsV0FBVztFQUNwQixPQUFPLEVBQUUsSUFBSTtFQUNiLFlBQVksRXBENUhJLEtBQWlCO0VvRDZIakMsV0FBVyxFcEQ3SEssS0FBaUI7RW9EOEhqQyxhQUFhLEVBQUUsSUFBSTtFQUNmLFNBQVMsRUFBRSxJQUFJO0NBQ3BCOztBQUVELEFBQUEsc0JBQXNCLENBQUM7RUFDckIsT0FBTyxFQUFFLFlBQVk7RUFDckIsWUFBWSxFcERwSUksSUFBaUI7RW9EcUlqQyxhQUFhLEVwRDVJRixJQUFJO0VvRDZJZixXQUFXLEVwRHRJSyxJQUFpQjtFb0R1SWpDLGNBQWMsRUFBRSxHQUFHO0VBRW5CLGdCQUFnQixFQUFFLENBQUM7RUFDZixpQkFBaUIsRUFBRSxDQUFDO0VBQ2hCLFNBQVMsRUFBRSxDQUFDO0VBQ3BCLGlCQUFpQixFQUFFLENBQUM7RUFDaEIsV0FBVyxFQUFFLENBQUM7Q0FPbkI7O0EvQnFESyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RStCdkVsQyxBQUFBLHNCQUFzQixDQUFDO0lBZW5CLHVCQUF1QixFQUFFLEtBQUs7SUFDMUIsVUFBVSxFQUFFLEtBQUs7R0FFeEI7OztBL0JxREssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0UrQmpEaEMsQUFBQSxzQkFBc0IsQUFBQSxZQUFZLENBQUM7SUFDakMsZ0JBQWdCLEVBQUUsQ0FBQztJQUNmLGlCQUFpQixFQUFFLENBQUM7SUFDaEIsU0FBUyxFQUFFLENBQUM7R0FDckI7OztBQUdILEFBQUEsbUJBQW1CLENBQUM7RUFDbEIsTUFBTSxFQUFFLENBQUM7RUFDVCxPQUFPLEVBQUUsQ0FBQztFQUNWLFVBQVUsRUFBRSxJQUFJO0VBQ2hCLGtCQUFrQixFcEQxS1AsSUFBSTtFb0QyS1AsVUFBVSxFcEQzS1AsSUFBSTtDb0Q0S2hCOztBL0JvQ0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0UrQmpDaEMsQUFBQSw4QkFBOEIsQ0FBQztJQUM3QixvQkFBb0IsRUFBRSxDQUFDO0lBQ2YsWUFBWSxFQUFFLENBQUM7R0FDeEI7RUFFRCxBQUFBLDhCQUE4QixDQUFDO0lBQzdCLG9CQUFvQixFQUFFLENBQUM7SUFDZixZQUFZLEVBQUUsQ0FBQztHQUN4Qjs7O0FBR0gsQUFBQSx3QkFBd0IsQ0FBQztFN0IxSG5CLGFBQTBCLEV4QjlCeEIsSUFBSTtDcUQwSlg7O0EvQm9CSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RStCdEJsQyxBQUFBLHdCQUF3QixDQUFDO0k3Qm5IakIsYUFBMEIsRXhCcEN4QixJQUFJO0dxRHlKYjs7O0FBRUQsQUFBQSx3QkFBd0IsQUFBQSxXQUFXLENBQUM7RUFDbEMsYUFBYSxFQUFFLENBQUM7Q0FDakI7O0FDck1ELEFBQUEsYUFBYSxDQUFDO0U3QkZkLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCUUUsSUFBSTtFcUJKZixXQUFXLEVBcEVDLE9BQXlCO0U2QnREdkMsYUFBYSxFdERQWixJQUFJLENzRE8yQixLQUFLLEMxRGU5QixPQUFPO0UwRGRkLEtBQUssRTFEY0UsT0FBTztFMERiZCxVQUFVLEUxRFFILE9BQU87QzBETmY7O0FoQzhNSyxNQUFNLENBQUMsS0FBSztFZ0NyTmxCLEFBQUEsYUFBYSxDQUFDO0k3QlFaLFdBQVcsRXRCSVcsVUFBVTtHbURMakM7OztBaEM4TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQ3JObEMsQUFBQSxhQUFhLENBQUM7STdCcUlSLFNBQVMsRXJCQUEsSUFBSTtJcUJJYixXQUFXLEVBaEZELElBQXlCO0c2QmxEeEM7OztBaEM4TUssTUFBTSxDQUFDLEtBQUs7RWdDck5sQixBQUFBLGFBQWEsQ0FBQztJN0JnSVIsU0FBUyxFckJTQSxJQUFJO0lxQlJiLFdBQVcsRXJCU0EsR0FBRztHa0RuSW5COzs7QUFFRCxBQUFBLG9DQUFvQyxDQUFDO0VBQ25DLE9BQU8sRUFBRSxDQUFDLEN0RGJULElBQUk7RXNEY0wsWUFBWSxFMURBTixPQUFPO0MwREtkOztBQVBELEFBSUUsb0NBSmtDLENBSWxDLDBCQUEwQixDQUFDO0VBQ3pCLEtBQUssRXREakJOLElBQUk7Q3NEa0JKOztBQUdILEFBQUEsd0JBQXdCLENBQUM7RUFFdkIsUUFBUSxFQUFFLFFBQVE7RUFDbEIsYUFBYSxFdER6QlosS0FBSTtFc0QwQkwsV0FBVyxFdEQxQlYsSUFBSTtFc0QyQkwsYUFBYSxFdEQzQlosSUFBSSxDc0QyQnFDLEtBQUssQzFEWnpDLE9BQU87QzBEYWQ7O0FBTkQsQXZDMUJBLHdCdUMwQndCLEF2QzFCdkIsTUFBTSxDQUFDO0VBQ04sT0FBTyxFQUFFLEVBQUU7RUFDWCxPQUFPLEVBQUUsS0FBSztFQUNkLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0F1QzhCRCxBQUFBLHVCQUF1QixDQUFDO0VBQ3RCLFlBQVksRXREaENYLEdBQUc7Q3NEaUNMOztBQUVELEFBQUEsNkJBQTZCLENBQUM7RUFDNUIsWUFBWSxFQUFFLEdBQUc7RUFDakIsSUFBSSxFQUFFLFlBQVk7RUFDbEIsY0FBYyxFQUFFLE1BQU07Q0FDdkI7O0FBRUQsQUFBQSw0Q0FBNEMsQ0FBQztFQUMzQyxLQUFLLEVBQUUsSUFBSTtFQUNYLE1BQU0sRUFBRSxJQUFJO0VBQ1osTUFBTSxFQUFFLENBQUM7RUFDVCxjQUFjLEVBQUUsTUFBTTtDQUN2Qjs7QUFFRCxBQUFBLDJCQUEyQixDQUFDO0U3QjdDNUIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJwQkUsSUFBSTtFcUJ3QmYsV0FBVyxFQXBFQyxPQUF5QjtDNkJaeEM7O0FoQ3dLSyxNQUFNLENBQUMsS0FBSztFZ0MxS2xCLEFBQUEsMkJBQTJCLENBQUM7STdCbkMxQixXQUFXLEV0QklXLFVBQVU7R21EaUNqQzs7O0FoQ3dLSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWdDMUtsQyxBQUFBLDJCQUEyQixDQUFDO0k3QjBGdEIsU0FBUyxFckI1QkEsSUFBSTtJcUJnQ2IsV0FBVyxFQWhGRCxJQUF5QjtHNkJaeEM7OztBaEN3S0ssTUFBTSxDQUFDLEtBQUs7RWdDMUtsQixBQUFBLDJCQUEyQixDQUFDO0k3QnFGdEIsU0FBUyxFckJuQkEsSUFBSTtJcUJvQmIsV0FBVyxFckJuQkEsSUFBSTtHa0RqRXBCOzs7QUFFRCxBQUFBLG1CQUFtQixDQUFDO0VBR2xCLGVBQWUsRUFBRSxJQUFJO0NBdUJ0Qjs7QUExQkQsQXJDcENBLG1CcUNvQ21CLEFyQ3BDbEIsTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJ1RFMsR0FBRyxDZ0J2RFMsS0FBSyxDckJOekIsT0FBTztFcUJPZixjQUFjLEVBQUUsQ0FBQztFQUNqQixnQkFBZ0IsRXJCUlIsT0FBTztDcUJTaEI7O0FxQ2dDRCxBQUtFLG1CQUxpQixBQUtoQixLQUFLLEVBTFIsbUJBQW1CLEFBTWhCLFFBQVEsQ0FBQztFQUNSLEtBQUssRTFEcENBLE9BQU87QzBEcUNiOztBQVJILEFBVUUsbUJBVmlCLEFBVWhCLE1BQU0sQ0FBQztFQUNOLGVBQWUsRUFBRSxTQUFTO0NBQzNCOztBQVpILEFyQ3BDQSxtQnFDb0NtQixBckNwQ2xCLE1BQU0sQ3FDa0RHO0VBQ04sS0FBSyxFMURqREEsT0FBTztDMERrRGI7O0FBaEJILEFBc0JJLG1CQXRCZSxBQXNCZCxLQUFLLEFBQUEsTUFBTSxDQUFDO0U3QmxEakIsS0FBSyxFN0JOSSxPQUFPO0MwRDBEWDs7QWhDOElDLE1BQU0sQ0FBQyxLQUFLO0VnQ3RLbEIsQUFzQkksbUJBdEJlLEFBc0JkLEtBQUssQUFBQSxNQUFNLENBQUM7STdCL0NmLEtBQUssRTNCVWlCLE9BQU87R3dEdUMxQjs7O0FBSUwsQUFBQSw2QkFBNkIsQ0FBQztFN0I3RTlCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFbURrRHhCLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLFNBQVMsRUFBRSxJQUFJO0VBQ2YsV0FBVyxFQUFFLElBQUk7Q0FlbEI7O0FoQ29ISyxNQUFNLENBQUMsS0FBSztFZ0MxSWxCLEFBQUEsNkJBQTZCLENBQUM7STdCbkU1QixXQUFXLEV0QklXLFVBQVU7R21EcUZqQzs7O0FBdEJELEFBU0UsNkJBVDJCLEFBUzFCLEtBQUssRUFUUiw2QkFBNkIsQUFVMUIsUUFBUSxDQUFDO0VBQ1IsZUFBZSxFQUFFLElBQUk7Q0FDdEI7O0FBWkgsQUFjRSw2QkFkMkIsQUFjMUIsTUFBTSxFQWRULDZCQUE2QixBQWUxQixPQUFPLENBQUM7RUFFUCxhQUFhLEVBQUUsSUFBSTtFQUduQixhQUFhLEVBQUUsU0FBUztDQUN6Qjs7QUFHSCxBQUFBLGlDQUFpQyxDQUFDO0VBQ2hDLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLGFBQWEsRXREekdaLElBQUk7RXlCRVAsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQTJDbEMsV0FBVyxFdEJiWSxHQUFHO0VzQjJGdEIsU0FBUyxFckJwQkUsSUFBSTtFcUJ3QmYsV0FBVyxFQXBFQyxPQUF5QjtDNkI4Q3hDOztBaEM4R0ssTUFBTSxDQUFDLEtBQUs7RWdDbEhsQixBQUFBLGlDQUFpQyxDQUFDO0k3QjNGaEMsV0FBVyxFdEJJVyxVQUFVO0dtRDJGakM7OztBaEM4R0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQ2xIbEMsQUFBQSxpQ0FBaUMsQ0FBQztJN0JrQzVCLFNBQVMsRXJCNUJBLElBQUk7SXFCZ0NiLFdBQVcsRUFoRkQsSUFBeUI7RzZCOEN4Qzs7O0FoQzhHSyxNQUFNLENBQUMsS0FBSztFZ0NsSGxCLEFBQUEsaUNBQWlDLENBQUM7STdCNkI1QixTQUFTLEVyQm5CQSxJQUFJO0lxQm9CYixXQUFXLEVyQm5CQSxJQUFJO0drRFBwQjs7O0FBRUQsQUFBQSxtQkFBbUIsQ0FBQztFOUJwQ2QsYUFBMEIsRXhCdEN4QixJQUFJO0VzRDRFVixhQUFhLEV0RHpHWixJQUFJO0NzRGlITjs7QWhDa0dLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFZ0M1R2xDLEFBQUEsbUJBQW1CLENBQUM7STlCN0JaLGFBQTBCLEV4QjVDeEIsSUFBSTtHc0RtRmI7OztBaENrR0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQzVHbEMsQUFBQSxtQkFBbUIsQ0FBQztJQUtoQixLQUFLLEVBQUUsTUFBTTtJQUNiLGFBQWEsRUFBRSxDQUFDO0lBQ2hCLEtBQUssRUFBRSxJQUFJO0lBQ1gsY0FBYyxFQUFFLEdBQUc7R0FFdEI7OztBaENrR0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQ2hHbEMsQUFBQSxzQkFBc0IsQ0FBQztJQUVuQixLQUFLLEVBQUUsTUFBTTtJQUNiLEtBQUssRUFBRSxJQUFJO0dBRWQ7OztBQUVELEFBQUEsMEJBQTBCLENBQUM7RTdCOUgzQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQlFFLElBQUk7RXFCSmYsV0FBVyxFQXBFQyxPQUF5QjtFNkJxRXZDLE9BQU8sRUFBRSxJQUFJO0VBQ2IsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFdERsSUYsSUFBSTtFc0RtSUwsS0FBSyxFQUFFLENBQUM7RUFDUixNQUFNLEVBQUUsQ0FBQztFQUNULE9BQU8sRUFBRSxDQUFDO0VBQ1YsTUFBTSxFQUFFLENBQUM7RUFDVCxLQUFLLEUxRG5IRSxPQUFPO0UwRG9IZCxVQUFVLEVBQUUsSUFBSTtDQWlCakI7O0FoQzhESyxNQUFNLENBQUMsS0FBSztFZ0N6RmxCLEFBQUEsMEJBQTBCLENBQUM7STdCcEh6QixXQUFXLEV0QklXLFVBQVU7R21EMklqQzs7O0FoQzhESyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWdDekZsQyxBQUFBLDBCQUEwQixDQUFDO0k3QlNyQixTQUFTLEVyQkFBLElBQUk7SXFCSWIsV0FBVyxFQWhGRCxJQUF5QjtHNkI4RnhDOzs7QWhDOERLLE1BQU0sQ0FBQyxLQUFLO0VnQ3pGbEIsQUFBQSwwQkFBMEIsQ0FBQztJN0JJckIsU0FBUyxFckJTQSxJQUFJO0lxQlJiLFdBQVcsRXJCU0EsR0FBRztHa0RhbkI7OztBQTNCRCxBQVlFLDBCQVp3QixBQVl2QixNQUFNLENBQUM7RUFDTixlQUFlLEVBQUUsU0FBUztDQUMzQjs7QUFkSCxBQWdCRSwwQkFoQndCLEFBZ0J2QixPQUFPLENBQUM7RS9CdkhYLE9BQU8sRStCd0hpRSxZQUFZO0UvQnRIcEYsS0FBSyxFQUFFLENBQUM7RUFDUixNQUFNLEVBQUUsQ0FBQztFQUVULFlBQVksRUFBRSxLQUFLO0VBQ25CLFlBQVksRUFBRSxXQUFXO0VBcUJ2QixpQkFBaUIsRUFBRSxpQ0FBaUM7RUFDNUMsU0FBUyxFQUFFLGlDQUFpQztFQUVwRCxZQUFZLEVBcEROLE1BQW1DLENBOEIzQixHQUFTLENBc0JjLENBQUMsQ0F0QnhCLEdBQVM7RUF1QnZCLGdCQUFnQixFQUFFLE9BQU87RStCMEZ2QixPQUFPLEVBQUUsRUFBRTtFQUNYLFdBQVcsRXREcEpaLEdBQUc7Q3NEcUpIOztBQXBCSCxBckNoSUEsMEJxQ2dJMEIsQXJDaEl6QixNQUFNLENBQUM7RUFDTixPQUFPLEVoQnNFUyxHQUFHLENnQnRFUyxLQUFLLENyQlN6QixPQUFPO0VxQlJmLGNBQWMsRUFBRSxDQUFDO0NBQ2xCOztBS3NOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWdDekZsQyxBQUFBLDBCQUEwQixDQUFDO0lBeUJ2QixHQUFHLEV0RHhKSixJQUFJO0dzRDBKTjs7O0FBRUQsQUFDRSxnQ0FEOEIsQUFDN0IsT0FBTyxDQUFDO0UvQnJJWCxPQUFPLEUrQnNJK0QsWUFBWTtFL0JwSWxGLEtBQUssRUFBRSxDQUFDO0VBQ1IsTUFBTSxFQUFFLENBQUM7RUFFVCxZQUFZLEVBQUUsS0FBSztFQUNuQixZQUFZLEVBQUUsV0FBVztFQVN2QixpQkFBaUIsRUFBRSxtQ0FBbUM7RUFDOUMsU0FBUyxFQUFFLG1DQUFtQztFQUV0RCxZQUFZLEVBQUUsQ0FBQyxDQVZELEdBQVMsQ0E5QmpCLE1BQW1DLENBOEIzQixHQUFTO0VBV3ZCLG1CQUFtQixFQUFFLE9BQU87QytCb0gzQjs7QUFHSCxBQUFBLHlCQUF5QixDQUFDO0U5QjFGcEIsYUFBMEIsRXhCdEN4QixJQUFJO0VzRGtJVixPQUFPLEVBQUUsS0FBSztFQUNkLE1BQU0sRUFBRSxDQUFDO0VBQ1QsT0FBTyxFQUFFLENBQUM7RUFDVixVQUFVLEVBQUUsSUFBSTtDQUNqQjs7QWhDZ0RLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFZ0N0RGxDLEFBQUEseUJBQXlCLENBQUM7STlCbkZsQixhQUEwQixFeEI1Q3hCLElBQUk7R3NEcUliOzs7QUFFRCxBQUNFLFdBRFMsQ0FDVCwwQkFBMEIsQ0FBQztFQUN6QixPQUFPLEVBQUUsS0FBSztDQUlmOztBaEN3Q0csTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQzlDbEMsQUFDRSxXQURTLENBQ1QsMEJBQTBCLENBQUM7SUFHdkIsT0FBTyxFQUFFLElBQUk7R0FFaEI7OztBQU5ILEFBUUUsV0FSUyxDQVFULHlCQUF5QixDQUFDO0VBQ3hCLE9BQU8sRUFBRSxJQUFJO0NBSWQ7O0FoQ2lDRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWdDOUNsQyxBQVFFLFdBUlMsQ0FRVCx5QkFBeUIsQ0FBQztJQUd0QixPQUFPLEVBQUUsS0FBSztHQUVqQjs7O0FBYkgsQUFlRSxXQWZTLENBZVQsK0JBQStCLENBQUM7RUFDOUIsT0FBTyxFQUFFLEtBQUs7Q0FDZjs7QWhDNkJHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFZ0N6QmxDLEFBQUEsOEJBQThCLENBQUM7SUFFM0IsTUFBTSxFQUFFLENBQUM7SUFDVCxPQUFPLEV0RHBNUixHQUFHLENzRG9Nd0IsQ0FBQztJQUMzQixVQUFVLEVBQUUsS0FBSztHQUVwQjs7O0FBRUQsQUFBQSwwQ0FBMEMsQ0FBQztFQUN6QyxXQUFXLEV0RHBNVixJQUFJO0NzRHFNTjs7QUFFRCxBQUFBLDhCQUE4QixDQUFDO0VBQzdCLE9BQU8sRXREN01OLElBQUksQ3NENk1xQixDQUFDO0VBQzNCLGFBQWEsRUFBRSxHQUFHLENBQUMsS0FBSyxDQTVNVyxPQUFPO0NBeU4zQzs7QWhDRkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VnQ2JsQyxBQUFBLDhCQUE4QixDQUFDO0lBSzNCLE9BQU8sRUFBRSxZQUFZO0lBQ3JCLFlBQVksRXREak5iLElBQUk7SXNEa05ILE9BQU8sRXREcE5SLEdBQUcsQ3NEb053QixDQUFDO0lBQzNCLE1BQU0sRUFBRSxDQUFDO0dBT1o7OztBQWZELEFBV0UsOEJBWDRCLENBVzVCLENBQUMsQ0FBQztFN0JyTkosV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQTJDbEMsV0FBVyxFdEJiWSxHQUFHO0VzQjJGdEIsU0FBUyxFckJRRSxJQUFJO0VxQkpmLFdBQVcsRUFwRUMsT0FBeUI7RTZCNEpyQyxXQUFXLEVBQUUsTUFBTTtDQUNwQjs7QWhDREcsTUFBTSxDQUFDLEtBQUs7RWdDYmxCLEFBV0UsOEJBWDRCLENBVzVCLENBQUMsQ0FBQztJN0IzTUYsV0FBVyxFdEJJVyxVQUFVO0dtRDBNL0I7OztBaENERyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWdDYmxDLEFBV0UsOEJBWDRCLENBVzVCLENBQUMsQ0FBQztJN0I5RUUsU0FBUyxFckJBQSxJQUFJO0lxQkliLFdBQVcsRUFoRkQsSUFBeUI7RzZCNkp0Qzs7O0FoQ0RHLE1BQU0sQ0FBQyxLQUFLO0VnQ2JsQixBQVdFLDhCQVg0QixDQVc1QixDQUFDLENBQUM7STdCbkZFLFNBQVMsRXJCU0EsSUFBSTtJcUJSYixXQUFXLEVyQlNBLEdBQUc7R2tENEVqQjs7O0FBR0gsQUFFSSxzQ0FGa0MsQ0FDcEMsQ0FBQyxBQUNFLEtBQUssRUFGVixzQ0FBc0MsQ0FDcEMsQ0FBQyxBQUVFLE1BQU0sRUFIWCxzQ0FBc0MsQ0FDcEMsQ0FBQyxBQUdFLFFBQVEsQ0FBQztFQUNSLEtBQUssRUFqT2dCLE9BQU87Q0FrTzdCOztBQUlMLEFBQUEsOEJBQThCLEFBQUEsV0FBVyxDQUFDO0VBQ3hDLFlBQVksRUFBRSxDQUFDO0NBQ2hCOztBaENoQkssTUFBTSxDQUFDLEtBQUs7RWdDck5sQixBQUFBLGFBQWEsQ0F3T0c7SUFDWixtQkFBbUIsRUFBRSxDQUFDO0lBQ3RCLEtBQUssRTFEN05BLE9BQU87STBEOE5aLFVBQVUsRUFBRSxXQUFXO0dBQ3hCO0VBeE1ILEFBQUEsNENBQTRDLENBMk1HO0lBQzNDLE9BQU8sRUFBRSxJQUFJO0dBQ2Q7RUFsTUgsQUFLRSxtQkFMaUIsQUFLaEIsS0FBSyxFQUxSLG1CQUFtQixBQU1oQixRQUFRLENBZ01HO0lBQ1IsS0FBSyxFMUR6T0YsT0FBTztHMEQwT1g7RUFKSCxBQU9FLG1CQVBpQixBQU9oQixNQUFNLENBQUM7SUFDTixPQUFPLEVBQUUsSUFBSTtHQUNkOzs7QUFNTCxBQUFBLDZCQUE2QjtBQUM3Qiw0Q0FBNEMsQ0FBQztFQUMzQyxRQUFRLEVBQUUsUUFBUTtFQUNsQixHQUFHLEVBQUUsSUFBSTtDQUNWOztBQXRRRCxBQUFBLGFBQWEsQ0F3UUM7RUFFWixXQUFXLEVBREYsR0FBRztDQUViOztBQ3ZSRCxBQUFBLGlCQUFpQixDQUFDO0U5QlVsQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFQXRDekMsS0FBSyxFN0JOSSxPQUFPO0UyRHRCZCxPQUFPLEV2RE1OLElBQUk7RXdCd0VELFVBQTBCLEV4QnRCeEIsSUFBSTtFd0JzQk4sYUFBMEIsRXhCdEJ4QixJQUFJO0V1RGxEVixLQUFLLEVBQUUsSUFBSTtFQUVYLFdBQVcsRXREaUNXLElBQUksQ3NEakNZLEtBQUssQzNEZ0JuQyxPQUFPO0MyRE5oQjs7QWpDNE1LLE1BQU0sQ0FBQyxLQUFLO0VpQ2pPbEIsQUFBQSxpQkFBaUIsQ0FBQztJOUJvQmhCLFdBQVcsRXRCSVcsVUFBVTtHb0RIakM7OztBakM0TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpQ2pPbEMsQUFBQSxpQkFBaUIsQ0FBQztJOUJpSlosU0FBUyxFckJkQSxJQUFJO0lxQmtCYixXQUFXLEVBaEZELE9BQXlCO0c4QmhEeEM7OztBakM0TUssTUFBTSxDQUFDLEtBQUs7RWlDak9sQixBQUFBLGlCQUFpQixDQUFDO0k5QjRJWixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0dtRG5IcEI7OztBakM0TUssTUFBTSxDQUFDLEtBQUs7RWlDak9sQixBQUFBLGlCQUFpQixDQUFDO0k5QmtDaEIsS0FBSyxFM0JVaUIsT0FBTztHeUR2QjlCOzs7QWpDNE1LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUNqT2xDLEFBQUEsaUJBQWlCLENBQUM7SS9Cd0ZWLFVBQTBCLEV4QjVCeEIsSUFBSTtHdUR2Q2I7OztBakM0TUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpQ2pPbEMsQUFBQSxpQkFBaUIsQ0FBQztJL0J3RlYsYUFBMEIsRXhCNUJ4QixJQUFJO0d1RHZDYjs7O0FBckJELEFBYUUsaUJBYmUsQ0FhZixZQUFZLENBQUM7RUFDWCxVQUFVLEVBQUUsQ0FBQztDQUNkOztBQWZILEFBaUJFLGlCQWpCZSxDQWlCZixXQUFXO0FBakJiLGlCQUFpQixDQWtCZixXQUFXLENBQUM7RUFDVixhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUNuQkgsQUFBQSxZQUFZLENBQUM7RS9CU2IsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsSUFBeUI7RStCakV2QyxrQkFBa0IsRUFBRSxVQUFVO0VBRXRCLFVBQVUsRUFBRSxVQUFVO0VBRTlCLGFBQWEsRXhEQ1osSUFBSTtFd0RBTCxPQUFPLEVBQUUsSUFBc0M7RUFFL0MsTUFBTSxFdkQwQlcsR0FBRyxDdUQxQlEsS0FBSyxDQUFDLFdBQVc7RUFFN0MsVUFBVSxFQUFFLE1BQU07Q0FLbkI7O0FsQytNSyxNQUFNLENBQUMsS0FBSztFa0NoT2xCLEFBQUEsWUFBWSxDQUFDO0kvQm1CWCxXQUFXLEV0QklXLFVBQVU7R3FETmpDOzs7QWxDK01LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFa0NoT2xDLEFBQUEsWUFBWSxDQUFDO0kvQmdKUCxTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7RytCbkR4Qzs7O0FsQytNSyxNQUFNLENBQUMsS0FBSztFa0NoT2xCLEFBQUEsWUFBWSxDQUFDO0kvQjJJUCxTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0dvRHRIcEI7OztBbEMrTUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VrQ2hPbEMsQUFBQSxZQUFZLENBQUM7SUFlVCxPQUFPLEVBQUUsSUFBc0M7R0FFbEQ7OztBQUVELEFBQUEsMEJBQTBCLENBQUM7RUFDekIsS0FBSyxFNURTRSxPQUFPO0U0RFJkLFVBQVUsRTVEREMsT0FBTztDNERFbkI7O0FBRUQsQUFBQSxtQkFBbUIsQ0FBQztFQUNsQixVQUFVLEVBQUUsQ0FBQztFQUNiLGFBQWEsRXhEZlosSUFBSTtFeUJGUCxXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQjlERSxJQUFJO0VxQmtFZixXQUFXLEVBcEVDLE9BQXlCO0MrQnZDeEM7O0FsQ21NSyxNQUFNLENBQUMsS0FBSztFa0N4TWxCLEFBQUEsbUJBQW1CLENBQUM7SS9CTGxCLFdBQVcsRXRCSVcsVUFBVTtHcURNakM7OztBbENtTUssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VrQ3hNbEMsQUFBQSxtQkFBbUIsQ0FBQztJL0J3SGQsU0FBUyxFckJ0RUEsSUFBSTtJcUIwRWIsV0FBVyxFQWhGRCxPQUF5QjtHK0J2Q3hDOzs7QWxDbU1LLE1BQU0sQ0FBQyxLQUFLO0VrQ3hNbEIsQUFBQSxtQkFBbUIsQ0FBQztJL0JtSGQsU0FBUyxFckI3REEsSUFBSTtJcUI4RGIsV0FBVyxFckI3REEsSUFBSTtHb0RsRHBCOzs7QUFFRCxBQUFBLG1CQUFtQixBQUFBLFdBQVcsQ0FBQztFQUM3QixhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUFFRCxBQUFBLGtCQUFrQixDQUFDO0UvQjFCbkIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJoREUsSUFBSTtFcUJvRGYsV0FBVyxFQXBFQyxPQUF5QjtDK0IvQnhDOztBbEMyTEssTUFBTSxDQUFDLEtBQUs7RWtDN0xsQixBQUFBLGtCQUFrQixDQUFDO0kvQmhCakIsV0FBVyxFdEJJVyxVQUFVO0dxRGNqQzs7O0FsQzJMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWtDN0xsQyxBQUFBLGtCQUFrQixDQUFDO0kvQjZHYixTQUFTLEVyQnhEQSxJQUFJO0lxQjREYixXQUFXLEVBaEZELE9BQXlCO0crQi9CeEM7OztBbEMyTEssTUFBTSxDQUFDLEtBQUs7RWtDN0xsQixBQUFBLGtCQUFrQixDQUFDO0kvQndHYixTQUFTLEVyQi9DQSxJQUFJO0lxQmdEYixXQUFXLEVyQi9DQSxJQUFJO0dvRHhEcEI7OztBRXRDRCxBQUFBLFVBQVUsQ0FBQztFakNVWCxXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBMkNsQyxXQUFXLEV0QmJZLEdBQUc7RXNCMkZ0QixTQUFTLEVyQlFFLElBQUk7RXFCSmYsV0FBVyxFaUN4SStDLElBQUk7RUFFaEUsT0FBTyxFQUFFLFlBQVk7RUFDckIsT0FBTyxFQUFFLE9BQU87RUFJaEIsY0FBYyxFQUFFLEdBQUc7RUFLbkIsT0FBTyxFQUFFLHFCQUFxQjtFQUM5QixjQUFjLEVBQUUsSUFBSTtFQUVwQixLQUFLLEU5RGNFLE9BQU87RThEYmQsZ0JBQWdCLEU5RE1WLE9BQU87RThETGIsY0FBYyxFQUFFLEdBQUc7RUFFbkIsZUFBZSxFQUFFLElBQUk7RUFDckIsY0FBYyxFQUFFLFNBQVM7Q0FDMUI7O0FwQzJNSyxNQUFNLENBQUMsS0FBSztFb0NqT2xCLEFBQUEsVUFBVSxDQUFDO0lqQ29CVCxXQUFXLEV0QklXLFVBQVU7R3VERmpDOzs7QXBDMk1LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0NqT2xDLEFBQUEsVUFBVSxDQUFDO0lqQ2lKTCxTQUFTLEVyQkFBLElBQUk7SXFCSWIsV0FBVyxFaUNwSjZDLElBQUk7R0FxQmpFOzs7QXBDMk1LLE1BQU0sQ0FBQyxLQUFLO0VvQ2pPbEIsQUFBQSxVQUFVLENBQUM7SWpDNElMLFNBQVMsRXJCU0EsSUFBSTtJcUJSYixXQUFXLEVpQzVJNkMsSUFBSTtHQXFCakU7OztBQUVELEFBQUEsb0JBQW9CLENBQUM7RUFDbkIsZ0JBQWdCLEU5RENSLE9BQU87QzhEQWhCOztBRHhCRCxBQUFBLG1CQUFtQixDQUFDO0VBQ2xCLFdBQVcsRXpES1YsSUFBSTtFeURKTCxjQUFjLEV6REliLElBQUk7RXlERkwsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLEM3RHFCaEIsT0FBTztDNkRwQmhCOztBQUVELEFBQUEsNEJBQTRCLENBQUM7RWhDQzdCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCUUUsSUFBSTtFcUJKZixXQUFXLEVBcEVDLE9BQXlCO0VBdEN6QyxLQUFLLEU3Qk5JLE9BQU87RTZEWmQsT0FBTyxFQUFFLEtBQUs7RUFDZCxNQUFNLEVBQUUsQ0FBQztDQUNWOztBbkNrTkssTUFBTSxDQUFDLEtBQUs7RW1DeE5sQixBQUFBLDRCQUE0QixDQUFDO0loQ1czQixXQUFXLEV0QklXLFVBQVU7R3NEVGpDOzs7QW5Da05LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFbUN4TmxDLEFBQUEsNEJBQTRCLENBQUM7SWhDd0l2QixTQUFTLEVyQkFBLElBQUk7SXFCSWIsV0FBVyxFQWhGRCxJQUF5QjtHZ0N0RHhDOzs7QW5Da05LLE1BQU0sQ0FBQyxLQUFLO0VtQ3hObEIsQUFBQSw0QkFBNEIsQ0FBQztJaENtSXZCLFNBQVMsRXJCU0EsSUFBSTtJcUJSYixXQUFXLEVyQlNBLEdBQUc7R3FEdkluQjs7O0FuQ2tOSyxNQUFNLENBQUMsS0FBSztFbUN4TmxCLEFBQUEsNEJBQTRCLENBQUM7SWhDeUIzQixLQUFLLEUzQlVpQixPQUFPO0cyRDdCOUI7OztBQUVELEFBQUEsaUNBQWlDLENBQUM7RUFDaEMsWUFBWSxFekRWWCxJQUFJO0N5RFdOOztBQUVELEFBQUEseUJBQXlCLENBQUM7RUFDeEIsT0FBTyxFQUFFLFVBQVU7RUFDbkIsY0FBYyxFQUFFLFFBQVE7Q0FDekI7O0FFdkJELEFBQUEsV0FBVyxDQUFDO0VsQ1NaLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VBdEN6QyxLQUFLLEU3Qk5JLE9BQU87RTRCd0RWLFVBQTBCLEV4QjFDeEIsR0FBRztFd0IwQ0wsYUFBMEIsRXhCdEJ4QixJQUFJO0MyRHJEWDs7QXJDMk5LLE1BQU0sQ0FBQyxLQUFLO0VxQ2hPbEIsQUFBQSxXQUFXLENBQUM7SWxDbUJWLFdBQVcsRXRCSVcsVUFBVTtHd0RsQmpDOzs7QXJDMk5LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFcUNoT2xDLEFBQUEsV0FBVyxDQUFDO0lsQ2dKTixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R2tDL0R4Qzs7O0FyQzJOSyxNQUFNLENBQUMsS0FBSztFcUNoT2xCLEFBQUEsV0FBVyxDQUFDO0lsQzJJTixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0d1RGxJcEI7OztBckMyTkssTUFBTSxDQUFDLEtBQUs7RXFDaE9sQixBQUFBLFdBQVcsQ0FBQztJbENpQ1YsS0FBSyxFM0JVaUIsT0FBTztHNkR0QzlCOzs7QXJDMk5LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFcUNoT2xDLEFBQUEsV0FBVyxDQUFDO0luQ3VGSixVQUEwQixFeEJoRHhCLEdBQUc7RzJEbENaOzs7QXJDMk5LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFcUNoT2xDLEFBQUEsV0FBVyxDQUFDO0luQ3VGSixhQUEwQixFeEI1QnhCLElBQUk7RzJEdERiOzs7QUFFRCxBQUFBLGtCQUFrQixDQUFDO0VsQ0VuQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFa0MzRHZDLGFBQWEsRTNESFosR0FBRztDMkRJTDs7QXJDc05LLE1BQU0sQ0FBQyxLQUFLO0VxQ3pObEIsQUFBQSxrQkFBa0IsQ0FBQztJbENZakIsV0FBVyxFdEJJVyxVQUFVO0d3RGJqQzs7O0FyQ3NOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFDek5sQyxBQUFBLGtCQUFrQixDQUFDO0lsQ3lJYixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R2tDMUR4Qzs7O0FyQ3NOSyxNQUFNLENBQUMsS0FBSztFcUN6TmxCLEFBQUEsa0JBQWtCLENBQUM7SWxDb0liLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3VEN0hwQjs7O0FBRUQsQUFBQSxpQkFBaUIsQ0FBQztFQUNoQixNQUFNLEVBQUUsQ0FBQztFQUNULE9BQU8sRUFBRSxDQUFDO0VBQ1YsVUFBVSxFQUFFLElBQUk7Q0FJakI7O0FyQzZNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFDcE5sQyxBQUFBLGlCQUFpQixDQUFDO0luQ29FWixhQUEwQixFeEJ0QnhCLElBQUk7RzJEdkNYOzs7QXJDNk1LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUyxPQUFwQixTQUFTLEVBQUUsU0FBUztFcUNwTmxDLEFBQUEsaUJBQWlCLENBQUM7SW5DMkVWLGFBQTBCLEV4QjVCeEIsSUFBSTtHMkR4Q2I7OztBQUVELEFBQUEsc0JBQXNCLENBQUM7RUFDckIsV0FBVyxFM0RaVixJQUFJO0MyRG1CTjs7QUFSRCxBQUdFLHNCQUhvQixBQUduQixRQUFRLENBQUM7RUFDUixPQUFPLEVBQUUsS0FBSztFQUNkLFdBQVcsRTNEaEJaLEtBQUk7RTJEaUJILGFBQWEsRTNEckJkLEdBQUc7QzJEc0JIOztBQUdILEFBQUEsZ0JBQWdCLENBQUM7RWxDdEJqQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBRmxDLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VrQ2hDdkMsT0FBTyxFQUFFLFlBQVk7RUFDckIsV0FBVyxFM0Q5QlYsSUFBSTtFMkQrQkwsY0FBYyxFM0QvQmIsSUFBSTtDMkRxQ047O0FyQ29MSyxNQUFNLENBQUMsS0FBSztFcUNqTWxCLEFBQUEsZ0JBQWdCLENBQUM7SWxDWmYsV0FBVyxFdEJJVyxVQUFVO0d3RHFCakM7OztBQWJELEExQ1RBLGdCMENTZ0IsQTFDVGYsTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJ1RFMsR0FBRyxDZ0J2RFMsS0FBSyxDckJOekIsT0FBTztFcUJPZixjQUFjLEVBQUUsQ0FBQztFQUNqQixnQkFBZ0IsRXJCUlIsT0FBTztDcUJTaEI7O0EwQ0tELEF2Q05BLGdCdUNNZ0IsQXZDTmYsS0FBSyxDQUFDO0VBQ0wsS0FBSyxFeEJKQyxPQUFPO0N3QktkOztBdUNJRCxBdkNGQSxnQnVDRWdCLEF2Q0ZmLFFBQVEsQ0FBQztFQUNSLEtBQUssRXRCK0VtQixPQUFPO0NzQjlFaEM7O0F1Q0FELEF2Q0VBLGdCdUNGZ0IsQXZDRWYsTUFBTSxDQUFDO0VBQ04sS0FBSyxFeEJiTyxPQUFPO0N3QmNwQjs7QXVDSkQsQXZDTUEsZ0J1Q05nQixBdkNNZixPQUFPLENBQUM7RUFDUCxLQUFLLEV4QmpCTyxPQUFPO0N3QmtCcEI7O0FFeUxLLE1BQU0sQ0FBQyxLQUFLO0VxQ2pNbEIsQUFBQSxnQkFBZ0IsQ0FBQztJbENaZixXQUFXLEV0QklXLFVBQVU7R3dEcUJqQzs7O0FyQ29MSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFDak1sQyxBQUFBLGdCQUFnQixDQUFDO0lsQ2lIWCxTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R2tDeEJ4Qzs7O0FyQ29MSyxNQUFNLENBQUMsS0FBSztFcUNqTWxCLEFBQUEsZ0JBQWdCLENBQUM7SWxDNEdYLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3VEM0ZwQjs7O0FBYkQsQUFTRSxnQkFUYyxDQVNiLEFBQUEsWUFBQyxDQUFlLE1BQU0sQUFBckIsRUFBdUI7RUFDdkIsS0FBSyxFL0RqQkEsT0FBTztFK0RrQlosZUFBZSxFQUFFLElBQUk7Q0FDdEI7O0FBR0gsQUFBQSxrQkFBa0IsQ0FBQztFbkNrQ2IsYUFBMEIsRXhCZHhCLElBQUk7QzJEbEJYOztBckNnTEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VxQ2xMbEMsQUFBQSxrQkFBa0IsQ0FBQztJbkN5Q1gsYUFBMEIsRXhCcEJ4QixJQUFJO0cyRG5CYjs7O0FyQ2dMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFDN0tsQyxBQUlJLFdBSk8sQ0FJUCxpQkFBaUIsQ0FBQztJQUVoQixhQUFhLEVBQUUsR0FBRyxDQUFDLEtBQUssQy9EL0JwQixPQUFPO0crRGdDWjtFQVBMLEE1Q2hEQSxXNENnRFcsQ0FJUCxpQkFBaUIsQTVDcERwQixNQUFNLENBQUM7SUFDTixPQUFPLEVBQUUsRUFBRTtJQUNYLE9BQU8sRUFBRSxLQUFLO0lBQ2QsS0FBSyxFQUFFLElBQUk7R0FDWjtFNEM0Q0QsQUFTSSxXQVRPLENBU1Asc0JBQXNCLENBQUM7SUFDckIsV0FBVyxFQUFFLENBQUM7R0FLZjtFQWZMLEFBWU0sV0FaSyxDQVNQLHNCQUFzQixBQUduQixRQUFRLENBQUM7SUFDUixPQUFPLEVBQUUsSUFBSTtHQUNkO0VBZFAsQUFpQkksV0FqQk8sQ0FpQlAsa0JBQWtCLENBQUM7SUFDakIsT0FBTyxFQUFFLElBQUk7R0FDZDtFQW5CTCxBQXFCSSxXQXJCTyxDQXFCUCxnQkFBZ0IsQ0FBQztJQUNmLFlBQVksRTNEbkVmLEdBQUc7STJEb0VBLGFBQWEsRTNEakVoQixJQUFJO0kyRGtFRCxZQUFZLEUzRGxFZixJQUFJO0kyRG1FRCxLQUFLLEVBQUUsSUFBSTtJQUNYLEtBQUssRS9EckRGLE9BQU87SStEc0RWLGdCQUFnQixFL0RsRFosT0FBTztJK0RtRFgsVUFBVSxFQUFFLE1BQU07SUFDbEIsZUFBZSxFQUFFLElBQUk7R0FxQnRCO0VBbERMLEFBK0JNLFdBL0JLLENBcUJQLGdCQUFnQixDQVViLEFBQUEsYUFBQyxDQUFlLE1BQU0sQUFBckIsRUFBdUI7SUFDdkIsVUFBVSxFM0Q3RWYsSUFBRztJMkQ4RUUsYUFBYSxFQUFFLElBQUk7SUFHbkIsV0FBVyxFQUFFLElBQXNCO0lBQ25DLGFBQWEsRUFBRSxJQUFzQjtJQUNyQyxjQUFjLEVBQUUsSUFBc0I7SUFDdEMsWUFBWSxFQUFFLElBQXNCO0lBRXBDLE1BQU0sRUFBRSxHQUFHLENBQUMsS0FBSyxDL0RsRWYsT0FBTztJK0RtRVQsYUFBYSxFQUFFLENBQUM7SUFDaEIsS0FBSyxFL0R0RUosT0FBTztJK0R1RVIsZ0JBQWdCLEUvRGxFZixPQUFPO0crRHVFVDtFQWpEUCxBQThDUSxXQTlDRyxDQXFCUCxnQkFBZ0IsQ0FVYixBQUFBLGFBQUMsQ0FBZSxNQUFNLEFBQXJCLENBZUMsTUFBTSxDQUFDO0lBQ04sZ0JBQWdCLEVBQUUsV0FBVztHQUM5QjtFQWhEVCxBQW9ESSxXQXBETyxDQW9EUCxrQkFBa0IsQ0FBQztJbkN2QmpCLGFBQTBCLEV4QjlDeEIsQ0FBQztJMkR1RUgsV0FBVyxFM0Q5RmQsSUFBSTtJMkQrRkQsYUFBYSxFM0RqR2hCLElBQUk7STJEa0dELGNBQWMsRTNEaEdqQixJQUFJO0kyRGlHRCxZQUFZLEUzRG5HZixJQUFJO0kyRG9HRCxNQUFNLEVBQUUsR0FBRyxDQUFDLEtBQUssQy9EbkZiLE9BQU87SStEb0ZYLFVBQVUsRUFBRSxDQUFDO0dBU2Q7OztBckN5R0MsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTLE9BQXBCLFNBQVMsRUFBRSxTQUFTO0VxQzdLbEMsQUFvREksV0FwRE8sQ0FvRFAsa0JBQWtCLENBQUM7SW5DaEJmLGFBQTBCLEV4QnBEeEIsQ0FBQztHMkRvRk47OztBckN5R0MsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VxQzdLbEMsQUE2RE0sV0E3REssQ0E2REosMEJBQVEsQ0FBQztJQUNSLE9BQU8sRUFBRSxJQUFJO0dBQ2Q7RUEvRFAsQUFpRU0sV0FqRUssQ0FvRFAsa0JBQWtCLEdBYVosV0FBVyxDQUFDO0lBQ2QsYUFBYSxFQUFFLENBQUM7R0FDakI7OztBQzVHUCxBQUFBLG1CQUFtQixDQUFDO0VuQ0RwQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFbUN2RHZDLE9BQU8sRUFBRSxLQUFLO0VBRWQsUUFBUSxFQUFFLFFBQVE7RUFFbEIsVUFBVSxFNURMVCxJQUFJO0U0RE9MLGFBQWEsRTVEWlosSUFBSTtFNERhTCxPQUFPLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEM1RFJiLElBQUk7RTREVUwsS0FBSyxFQUFFLElBQUk7Q0FDWjs7QXRDeU1LLE1BQU0sQ0FBQyxLQUFLO0VzQ3RObEIsQUFBQSxtQkFBbUIsQ0FBQztJbkNTbEIsV0FBVyxFdEJJVyxVQUFVO0d5REFqQzs7O0F0Q3lNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXNDdE5sQyxBQUFBLG1CQUFtQixDQUFDO0luQ3NJZCxTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R21DN0N4Qzs7O0F0Q3lNSyxNQUFNLENBQUMsS0FBSztFc0N0TmxCLEFBQUEsbUJBQW1CLENBQUM7SW5DaUlkLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3dEaEhwQjs7O0FBRUQsQUFBQSxtQkFBbUIsQUFBQSxXQUFXO0FBQzlCLG1CQUFtQixBQUFBLGFBQWEsQ0FBQztFQUMvQixhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUFFRCxBQUFBLG9CQUFvQixDQUFDO0VBQ25CLFFBQVEsRUFBRSxRQUFRO0VBRWxCLE9BQU8sRUFBRSxDQUFDO0VBQ1YsR0FBRyxFQUFFLENBQUM7RUFDTixJQUFJLEVBQUUsQ0FBQztFQUVQLEtBQUssRTVEekJKLElBQUk7RTREMEJMLE1BQU0sRTVEMUJMLElBQUk7RTRENEJMLE1BQU0sRUFBRSxPQUFPO0VBSWIsTUFBTSxFQUFFLENBQUM7RUFDVCxPQUFPLEVBQUUsQ0FBQztDQVNiOztBQUVELEFBQUEsb0JBQW9CLENBQUM7RUFDbkIsT0FBTyxFQUFFLFlBQVk7RUFDckIsYUFBYSxFQUFFLENBQUM7RUFDaEIsT0FBTyxFQUFFLEdBQUcsQzVEbkRYLElBQUksQ0FGSixHQUFHO0U0RHNESixNQUFNLEVBQUUsT0FBTztFQUVmLGdCQUFnQixFQUFFLFlBQVk7RUFDOUIsWUFBWSxFQUFFLFlBQVk7Q0FDM0I7O0FBRUQsQUFBQSxtQkFBbUIsQ0FBQztFQUNsQixPQUFPLEVBQUUsS0FBSztFQUNkLGFBQWEsRTVENURaLElBQUk7RTRENkRMLFlBQVksRTVEN0RYLElBQUk7QzREOEROOztBQUVELEFBQUEsb0JBQW9CLEdBQUcsb0JBQW9CLEFBQUEsUUFBUSxDQUFDO0VBQ2xELE9BQU8sRUFBRSxFQUFFO0VBQ1gsa0JBQWtCLEVBQUUsVUFBVTtFQUN0QixVQUFVLEVBQUUsVUFBVTtFQUM5QixRQUFRLEVBQUUsUUFBUTtFQUNsQixHQUFHLEVBQUUsQ0FBQztFQUNOLElBQUksRUFBRSxDQUFDO0VBRVAsS0FBSyxFNURwRUosSUFBSTtFNERxRUwsTUFBTSxFNURyRUwsSUFBSTtFNER1RUwsTUFBTSxFM0QxQndCLEdBQUcsQzJEMEJRLEtBQUssQ0FBQyxZQUFZO0VBQzNELGFBQWEsRUFBRSxHQUFHO0VBQ2xCLFVBQVUsRUFBRSxXQUFXO0NBQ3hCOztBQUVELEFBQUEsb0JBQW9CLEdBQUcsb0JBQW9CLEFBQUEsT0FBTyxDQUFDO0VBQ2pELE9BQU8sRUFBRSxFQUFFO0VBRVgsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFNURyRkYsSUFBSTtFNERzRkwsSUFBSSxFNUR0RkgsSUFBSTtFNER3RkwsS0FBSyxFQUFFLENBQUM7RUFDUixNQUFNLEVBQUUsQ0FBQztFQUVULE1BQU0sRTVEM0ZMLElBQUksQzREMkZvQixLQUFLLENBQUMsWUFBWTtFQUMzQyxhQUFhLEVBQUUsR0FBRztFQUNsQixPQUFPLEVBQUUsQ0FBQztFQUNWLFVBQVUsRUFBRSxZQUFZO0NBQ3pCOztBQUdELEFBQUEsb0JBQW9CLEFBQUEsTUFBTSxHQUFHLG9CQUFvQixBQUFBLFFBQVEsQ0FBQztFQUl4RCxPQUFPLEUzRC9CUyxHQUFHLEMyRCtCUyxLQUFLLENBQUMsV0FBVztFQUM3QyxjQUFjLEUzRGhDRSxHQUFHO0UyRGlDbkIsa0JBQWtCLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBdkdBLEdBQXdCLENoRVN6QyxPQUFPO0VnRStGUCxVQUFVLEVBQUUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBeEdBLEdBQXdCLENoRVN6QyxPQUFPO0NnRWdHaEI7O0FBR0QsQUFBQSxvQkFBb0IsQUFBQSxRQUFRLEdBQUcsb0JBQW9CLEFBQUEsT0FBTyxDQUFDO0VBQ3pELE9BQU8sRUFBRSxDQUFDO0NBQ1g7O0FBR0QsQUFBQSxvQkFBb0IsQUFBQSxTQUFTO0FBQzdCLG9CQUFvQixBQUFBLFNBQVMsR0FBRyxvQkFBb0IsQ0FBQztFQUNuRCxNQUFNLEVBQUUsT0FBTztDQUNoQjs7QUFFRCxBQUFBLG9CQUFvQixBQUFBLFNBQVMsR0FBRyxvQkFBb0IsQ0FBQztFQUNuRCxPQUFPLEVBQUUsRUFBRTtDQUNaOztBdENnR0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VzQzdGbEMsQTdDaElBLHFCNkNnSXFCLEE3Q2hJcEIsTUFBTSxDQUFDO0lBQ04sT0FBTyxFQUFFLEVBQUU7SUFDWCxPQUFPLEVBQUUsS0FBSztJQUNkLEtBQUssRUFBRSxJQUFJO0dBQ1o7RTZDNEhELEFBSUkscUJBSmlCLENBSWpCLG1CQUFtQixDQUFDO0lBQ2xCLFlBQVksRTVEL0hmLElBQUk7STREZ0lELEtBQUssRUFBRSxJQUFJO0lBQ1gsS0FBSyxFQUFFLElBQUk7R0FDWjs7O0FBSUwsQUFBQSxzQkFBc0IsQ0FBQztFbkN0SXZCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0VtQzhFdkMsS0FBSyxFNUR0SUosSUFBSTtFNER1SUwsYUFBYSxFNUQ1SVosSUFBSTtFNEQ2SUwsVUFBVSxFQUFFLE1BQU07Q0FDbkI7O0F0QzJFSyxNQUFNLENBQUMsS0FBSztFc0NqRmxCLEFBQUEsc0JBQXNCLENBQUM7SW5DNUhyQixXQUFXLEV0QklXLFVBQVU7R3lEOEhqQzs7O0F0QzJFSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXNDakZsQyxBQUFBLHNCQUFzQixDQUFDO0luQ0NqQixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R21DaUZ4Qzs7O0F0QzJFSyxNQUFNLENBQUMsS0FBSztFc0NqRmxCLEFBQUEsc0JBQXNCLENBQUM7SW5DSmpCLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3dEY3BCOzs7QUFVRCxBQUFBLDBCQUEwQixDQUFDO0VwQy9FckIsYUFBMEIsRXhCOUJ4QixJQUFJO0U0RCtHVixXQUFXLEVBUmdCLElBQTBEO0VBU3JGLFlBQVksRUFMYSxJQUFvRTtFQU03RixXQUFXLEUzRGpIYSxHQUFHLEMyRGlIWSxLQUFLLENoRXpJcEMsT0FBTztDZ0VrSmhCOztBdENvREssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VzQ2pFbEMsQUFBQSwwQkFBMEIsQ0FBQztJcEN4RW5CLGFBQTBCLEV4QnBDeEIsSUFBSTtHNER5SGI7OztBQVBDLEFBQUEsV0FBVyxDQUFFLGtDQUFRLENBQUM7RUFDcEIsT0FBTyxFQUFFLElBQUk7Q0FDZDs7QUFSSCxBQVVFLDBCQVZ3QixHQVVwQixXQUFXLENBQUM7RUFDZCxhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUN4S0gsQUFBQSxhQUFhLENBQUM7RXBDTWQsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRW9DcElnQyxJQUFJO0VBR2pELGtCQUFrQixFQUFFLFVBQVU7RUFFdEIsVUFBVSxFQUFFLFVBQVU7RUFDOUIsS0FBSyxFQUFFLElBQUk7RUFDWCxNQUFNLEVBQUUsSUFBSTtFQUVaLE9BQU8sRTdEUE4sR0FBRztFNkRRSixNQUFNLEU1RDJDd0IsR0FBRyxDNEQzQ1EsS0FBSyxDakVVdkMsT0FBTztDaUVUZjs7QXZDaU5LLE1BQU0sQ0FBQyxLQUFLO0V1QzdObEIsQUFBQSxhQUFhLENBQUM7SXBDZ0JaLFdBQVcsRXRCSVcsVUFBVTtHMERSakM7OztBdkNpTkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1QzdObEMsQUFBQSxhQUFhLENBQUM7SXBDNklSLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFb0NoSjhCLElBQUk7R0FXbEQ7OztBdkNpTkssTUFBTSxDQUFDLEtBQUs7RXVDN05sQixBQUFBLGFBQWEsQ0FBQztJcEN3SVIsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRW9DeEk4QixJQUFJO0dBV2xEOzs7QUFaRCxBNUNJQSxhNENKYSxBNUNJWixNQUFNLENBQUM7RUFDTixPQUFPLEVoQnNFUyxHQUFHLENnQnRFUyxLQUFLLENyQlN6QixPQUFPO0VxQlJmLGNBQWMsRUFBRSxDQUFDO0NBQ2xCOztBNENPRCxBQUFBLGFBQWEsQ0FBQyxNQUFNLEFBQUEsT0FBTztBQUMzQixhQUFhLENBQUMsTUFBTSxBQUFBLFFBQVE7QUFDNUIsYUFBYSxBQUFBLE1BQU0sQUFBQSxXQUFXLENBQUM7RUFDN0IsS0FBSyxFakVTRSxPQUFPO0VpRVJkLGdCQUFnQixFakVDVixPQUFPO0NpRUFkOztBQUVELEFBQUEsb0JBQW9CLENBQUM7RUFDbkIsTUFBTSxFNUR1QzhCLEdBQUcsQzREdkNRLEtBQUssQ2pFWi9DLE9BQU87Q2lFYWI7O0FDM0JELEFBQUEsZ0JBQWdCLENBQUM7RXBDdUNqQixRQUFRLEVBQUUsUUFBUTtFQUVsQixLQUFLLEVBQUUsR0FBRztFQUNWLE1BQU0sRUFBRSxHQUFHO0VBQ1gsTUFBTSxFQUFFLElBQUk7RUFFWixRQUFRLEVBQUUsTUFBTTtFQUNoQixJQUFJLEVBQUUsYUFBYTtFQUNuQixpQkFBaUIsRUFBRSxVQUFVO0VBQ3JCLFNBQVMsRUFBRSxVQUFVO0VBSzdCLFdBQVcsRUFBRSxNQUFNO0VEM0NuQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBeUg5QixTQUFTLEVyQlFFLElBQUk7RXFCSmYsV0FBVyxFQXBFQyxPQUF5QjtFcUMvRHZDLE9BQU8sRUFBRSxLQUFLO0VBQ2QsT0FBTyxFOURDTixJQUFJLENBQ0osSUFBSTtDOERETjs7QUFSRCxBcEN1REEsZ0JvQ3ZEZ0IsQXBDdURmLE9BQU8sRW9DdkRSLGdCQUFnQixBcEN3RGYsTUFBTSxDQUFDO0VBQ04sUUFBUSxFQUFFLE1BQU07RUFFaEIsS0FBSyxFQUFFLElBQUk7RUFDWCxNQUFNLEVBQUUsSUFBSTtFQUNaLE1BQU0sRUFBRSxPQUFPO0VBRWYsUUFBUSxFQUFFLE9BQU87RUFDakIsSUFBSSxFQUFFLElBQUk7RUFDVixpQkFBaUIsRUFBRSxJQUFJO0VBQ2YsU0FBUyxFQUFFLElBQUk7RUFFdkIsV0FBVyxFQUFFLE9BQU87Q0FDckI7O0FKNEpLLE1BQU0sQ0FBQyxLQUFLO0V3Q2pPbEIsQUFBQSxnQkFBZ0IsQ0FBQztJckNvQmYsV0FBVyxFdEJJVyxVQUFVO0cyRGhCakM7OztBQVJELEE3Q3VCQSxnQjZDdkJnQixBN0N1QmYsTUFBTSxDQUFDO0VBQ04sT0FBTyxFaEJ1RFMsR0FBRyxDZ0J2RFMsS0FBSyxDckJOekIsT0FBTztFcUJPZixjQUFjLEVBQUUsQ0FBQztFQUNqQixnQkFBZ0IsRXJCUlIsT0FBTztDcUJTaEI7O0E2QzNCRCxBMUNxR0EsZ0IwQ3JHZ0IsQTFDcUdmLEtBQUssRTBDckdOLGdCQUFnQixBMUNzR2YsUUFBUSxFMEN0R1QsZ0JBQWdCLEExQ3VHZixNQUFNLEUwQ3ZHUCxnQkFBZ0IsQTFDd0dmLE9BQU8sRTBDeEdSLGdCQUFnQixBMUN5R2YsTUFBTSxDQUFDO0VLMUVSLEtBQUssRTdCTkksT0FBTztDd0JrRmY7O0FFc0hLLE1BQU0sQ0FBQyxLQUFLO0V3Q2pPbEIsQTFDcUdBLGdCMENyR2dCLEExQ3FHZixLQUFLLEUwQ3JHTixnQkFBZ0IsQTFDc0dmLFFBQVEsRTBDdEdULGdCQUFnQixBMUN1R2YsTUFBTSxFMEN2R1AsZ0JBQWdCLEExQ3dHZixPQUFPLEUwQ3hHUixnQkFBZ0IsQTFDeUdmLE1BQU0sQ0FBQztJS3ZFTixLQUFLLEUzQlVpQixPQUFPO0dzQitEOUI7OztBMEMzR0QsQTFDaUhFLGdCMENqSGMsQTFDaUhiLEtBQUssQUFBQSxNQUFNLENBQUM7RUtsRmYsS0FBSyxFN0JOSSxPQUFPO0N3QjBGYjs7QUU4R0csTUFBTSxDQUFDLEtBQUs7RXdDak9sQixBMUNpSEUsZ0IwQ2pIYyxBMUNpSGIsS0FBSyxBQUFBLE1BQU0sQ0FBQztJSy9FYixLQUFLLEUzQlVpQixPQUFPO0dzQnVFNUI7OztBRThHRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXdDak9sQyxBQUFBLGdCQUFnQixDQUFDO0lyQ2lKWCxTQUFTLEVyQkFBLElBQUk7SXFCSWIsV0FBVyxFQWhGRCxJQUF5QjtHcUM3RHhDOzs7QXhDeU5LLE1BQU0sQ0FBQyxLQUFLO0V3Q2pPbEIsQUFBQSxnQkFBZ0IsQ0FBQztJckM0SVgsU0FBUyxFckJTQSxJQUFJO0lxQlJiLFdBQVcsRXJCU0EsR0FBRztHMEQ5SW5COzs7QUNSRCxBQUFBLFlBQVksQ0FBQztFdENVYixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFQXRDekMsS0FBSyxFN0JOSSxPQUFPO0VtRXRCZCxLQUFLLEVBQUUsSUFBSTtFdkM4RVAsYUFBMEIsRXhCdEJ4QixJQUFJO0UrRHJEVixjQUFjLEVBQUUsQ0FBQztFQUNqQixlQUFlLEVBQUUsUUFBUTtDQUMxQjs7QXpDeU5LLE1BQU0sQ0FBQyxLQUFLO0V5Q2pPbEIsQUFBQSxZQUFZLENBQUM7SXRDb0JYLFdBQVcsRXRCSVcsVUFBVTtHNERoQmpDOzs7QXpDeU5LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFeUNqT2xDLEFBQUEsWUFBWSxDQUFDO0l0Q2lKUCxTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R3NDN0R4Qzs7O0F6Q3lOSyxNQUFNLENBQUMsS0FBSztFeUNqT2xCLEFBQUEsWUFBWSxDQUFDO0l0QzRJUCxTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0cyRGhJcEI7OztBekN5TkssTUFBTSxDQUFDLEtBQUs7RXlDak9sQixBQUFBLFlBQVksQ0FBQztJdENrQ1gsS0FBSyxFM0JVaUIsT0FBTztHaUVwQzlCOzs7QXpDeU5LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFeUNqT2xDLEFBQUEsWUFBWSxDQUFDO0l2Q3dGTCxhQUEwQixFeEI1QnhCLElBQUk7RytEcERiOzs7QUFFRCxBQUFBLG9CQUFvQixDQUFDO0V0QzZDckIsV0FBVyxFdEJiWSxHQUFHO0U0RDdCeEIsT0FBTyxFL0RMTixJQUFJLENBRUosSUFBSSxDQUZKLElBQUksQytES3VELENBQUM7RUFDN0QsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENuRWFoQixPQUFPO0VtRVpmLFVBQVUsRUFBRSxJQUFJO0NBQ2pCOztBQUVELEFBQUEsa0JBQWtCLENBQUM7RUFDakIsT0FBTyxFL0RYTixJQUFJLENBRUosSUFBSSxDQUZKLElBQUksQytEV3VELENBQUM7RUFDN0QsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENuRU9oQixPQUFPO0VtRU5mLFVBQVUsRUFBRSxJQUFJO0NBQ2pCOztBQUVELEFBQUEsMkJBQTJCLENBQUM7RXRDZDVCLFdBQVcsRXZCTW1CLG1CQUFtQixFQVgzQixLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0M0RFY1Qjs7QXpDdU1LLE1BQU0sQ0FBQyxLQUFLO0V5Q3pNbEIsQUFBQSwyQkFBMkIsQ0FBQztJdENKMUIsV0FBVyxFdEJJVyxVQUFVO0c0REVqQzs7O0FBRUQsQUFBQSw2QkFBNkI7QUFDN0IsMkJBQTJCLENBQUM7RUFDMUIsVUFBVSxFQUFFLEtBQUs7Q0FDbEI7O0FBRUQsQUFBQSxvQkFBb0IsQUFBQSxXQUFXO0FBQy9CLGtCQUFrQixBQUFBLFdBQVcsQ0FBQztFQUM1QixhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUFFRCxBQUFBLHFCQUFxQixDQUFDO0V0Q2lCdEIsV0FBVyxFdEJiWSxHQUFHO0U0RER4QixPQUFPLEVBQUUsYUFBYTtFQUN0QixVQUFVLEVBQUUsSUFBSTtDQUNqQjs7QUN2Q0QsQUFBQSxlQUFlLENBQUM7RXZDTWhCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEV1Q3BJZ0MsSUFBSTtFQUdqRCxrQkFBa0IsRUFBRSxVQUFVO0VBRXRCLFVBQVUsRUFBRSxVQUFVO0VBQzlCLE9BQU8sRUFBRSxLQUFLO0VBQ2QsS0FBSyxFQUFFLElBQUk7RXhDcUVQLGFBQTBCLEV4QnRCeEIsSUFBSTtFZ0U3Q1YsT0FBTyxFaEVQTixHQUFHO0VnRVNKLE1BQU0sRS9EMEN3QixHQUFHLEMrRDFDUSxLQUFLLENwRVN2QyxPQUFPO0VvRVJkLGFBQWEsRUFBRSxDQUFDO0VBRWhCLGtCQUFrQixFQUFFLElBQUk7Q0FDekI7O0ExQzZNSyxNQUFNLENBQUMsS0FBSztFMEM3TmxCLEFBQUEsZUFBZSxDQUFDO0l2Q2dCZCxXQUFXLEV0QklXLFVBQVU7RzZESmpDOzs7QTFDNk1LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFMEM3TmxDLEFBQUEsZUFBZSxDQUFDO0l2QzZJVixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRXVDaEo4QixJQUFJO0dBZWxEOzs7QTFDNk1LLE1BQU0sQ0FBQyxLQUFLO0UwQzdObEIsQUFBQSxlQUFlLENBQUM7SXZDd0lWLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEV1Q3hJOEIsSUFBSTtHQWVsRDs7O0FBaEJELEEvQ0lBLGUrQ0plLEEvQ0lkLE1BQU0sQ0FBQztFQUNOLE9BQU8sRWhCc0VTLEdBQUcsQ2dCdEVTLEtBQUssQ3JCU3pCLE9BQU87RXFCUmYsY0FBYyxFQUFFLENBQUM7Q0FDbEI7O0FLc05LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFMEM3TmxDLEFBQUEsZUFBZSxDQUFDO0l4Q29GUixhQUEwQixFeEI1QnhCLElBQUk7R2dFeENiOzs7QUFFRCxBQUFBLHNCQUFzQixDQUFDO0VBQ3JCLE1BQU0sRS9EMEM4QixHQUFHLEMrRDFDUSxLQUFLLENwRVQvQyxPQUFPO0NvRVViOztBQ3ZCRCxBQUFBLG1CQUFtQixDQUFDO0V4Q1NwQixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFQXRDekMsS0FBSyxFN0JOSSxPQUFPO0VxRXBCZCxRQUFRLEVBQUUsUUFBUTtFekM0RWQsYUFBMEIsRXhCdEJ4QixJQUFJO0VpRXBEVixPQUFPLEVqRUNOLElBQUksQ2lFRHFCLENBQUM7Q0FDNUI7O0EzQ3lOSyxNQUFNLENBQUMsS0FBSztFMkNoT2xCLEFBQUEsbUJBQW1CLENBQUM7SXhDbUJsQixXQUFXLEV0QklXLFVBQVU7RzhEaEJqQzs7O0EzQ3lOSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RTJDaE9sQyxBQUFBLG1CQUFtQixDQUFDO0l4Q2dKZCxTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R3dDN0R4Qzs7O0EzQ3lOSyxNQUFNLENBQUMsS0FBSztFMkNoT2xCLEFBQUEsbUJBQW1CLENBQUM7SXhDMklkLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7RzZEaElwQjs7O0EzQ3lOSyxNQUFNLENBQUMsS0FBSztFMkNoT2xCLEFBQUEsbUJBQW1CLENBQUM7SXhDaUNsQixLQUFLLEUzQlVpQixPQUFPO0dtRXBDOUI7OztBM0N5TkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0UyQ2hPbEMsQUFBQSxtQkFBbUIsQ0FBQztJekN1RlosYUFBMEIsRXhCNUJ4QixJQUFJO0dpRXBEYjs7O0FBRUQsQUFBQSw4QkFBOEIsQ0FBQztFdkNEL0IsUUFBUSxFQUFFLFFBQVE7RUFFbEIsS0FBSyxFQUFFLEdBQUc7RUFDVixNQUFNLEVBQUUsR0FBRztFQUNYLE1BQU0sRUFBRSxJQUFJO0VBQ1osT0FBTyxFQUFFLENBQUM7RUFFVixRQUFRLEVBQUUsTUFBTTtFQUNoQixJQUFJLEVBQUUsYUFBYTtFQUNuQixpQkFBaUIsRUFBRSxVQUFVO0VBQ3JCLFNBQVMsRUFBRSxVQUFVO0VBRTdCLE1BQU0sRUFBRSxDQUFDO0VBS1QsV0FBVyxFQUFFLE1BQU07Q3VDZGxCOztBQUVELEFBQUEseUJBQXlCLENBQUM7RXhDSjFCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFOER6QnhCLE9BQU8sRUFBRSxZQUFZO0VBRXJCLFFBQVEsRUFBRSxRQUFRO0VBQ2xCLEdBQUcsRUFBRSxHQUFHO0VBQ1IsSUFBSSxFQUFFLENBQUM7RUFFUCxTQUFTLEVBQUUsSUFBSTtFQUNmLFVBQVUsRUFBRSxJQUFJO0VBQ2hCLFVBQVUsRUFBRSxLQUFLO0VBQ2pCLFdBQVcsRUFBRSxHQUFHO0VBSWhCLE1BQU0sRUFBRSxHQUFHLENBQUMsS0FBSyxDckVMVixPQUFPO0VxRU1kLGFBQWEsRUFBRSxHQUFHO0VBRWxCLEtBQUssRXJFSEUsT0FBTztFcUVJZCxVQUFVLEVyRVRILE9BQU87RXFFV2QsU0FBUyxFQUFFLEtBQUs7RUFDaEIsV0FBVyxFQUFFLElBQUk7RUFFakIsVUFBVSxFQUFFLE1BQU07RUFJbEIsbUJBQW1CLEVBQUUsSUFBSTtFQUN0QixnQkFBZ0IsRUFBRSxJQUFJO0VBQ3JCLGVBQWUsRUFBRSxJQUFJO0VBQ2pCLFdBQVcsRUFBRSxJQUFJO0NBQzFCOztBM0NrTEssTUFBTSxDQUFDLEtBQUs7RTJDbk5sQixBQUFBLHlCQUF5QixDQUFDO0l4Q014QixXQUFXLEV0QklXLFVBQVU7RzhEdUJqQzs7O0FBRUQsQUFBQSx5QkFBeUIsQ0FBQztFQUN4QixPQUFPLEVBQUUsS0FBSztFQUNkLFdBQVcsRWhFM0JLLEtBQWlCO0VnRTRCakMsWUFBWSxFQUFFLElBQUk7Q0FDbkI7O0FFekRELEFwRFFBLGVvRFJlLEFwRFFkLE1BQU0sQ0FBQztFQUNOLE9BQU8sRUFBRSxFQUFFO0VBQ1gsT0FBTyxFQUFFLEtBQUs7RUFDZCxLQUFLLEVBQUUsSUFBSTtDQUNaOztBcURaRCxBQUFBLHNCQUFzQixDQUFDO0UxQ2F2QixRQUFRLEVBQUUsUUFBUTtFQUVsQixLQUFLLEVBQUUsR0FBRztFQUNWLE1BQU0sRUFBRSxHQUFHO0VBQ1gsTUFBTSxFQUFFLElBQUk7RUFDWixPQUFPLEVBQUUsQ0FBQztFQUVWLFFBQVEsRUFBRSxNQUFNO0VBQ2hCLElBQUksRUFBRSxhQUFhO0VBQ25CLGlCQUFpQixFQUFFLFVBQVU7RUFDckIsU0FBUyxFQUFFLFVBQVU7RUFFN0IsTUFBTSxFQUFFLENBQUM7RUFLVCxXQUFXLEVBQUUsTUFBTTtDMEM1QmxCOztBQUdELEFBQUEsaUNBQWlDLENBQUM7RTFDc0NsQyxRQUFRLEVBQUUsUUFBUTtFQUVsQixLQUFLLEVBQUUsR0FBRztFQUNWLE1BQU0sRUFBRSxHQUFHO0VBQ1gsTUFBTSxFQUFFLElBQUk7RUFFWixRQUFRLEVBQUUsTUFBTTtFQUNoQixJQUFJLEVBQUUsYUFBYTtFQUNuQixpQkFBaUIsRUFBRSxVQUFVO0VBQ3JCLFNBQVMsRUFBRSxVQUFVO0VBSzdCLFdBQVcsRUFBRSxNQUFNO0MwQ2xEbEI7O0FBRkQsQTFDc0RBLGlDMEN0RGlDLEExQ3NEaEMsT0FBTyxFMEN0RFIsaUNBQWlDLEExQ3VEaEMsTUFBTSxDQUFDO0VBQ04sUUFBUSxFQUFFLE1BQU07RUFFaEIsS0FBSyxFQUFFLElBQUk7RUFDWCxNQUFNLEVBQUUsSUFBSTtFQUNaLE1BQU0sRUFBRSxPQUFPO0VBRWYsUUFBUSxFQUFFLE9BQU87RUFDakIsSUFBSSxFQUFFLElBQUk7RUFDVixpQkFBaUIsRUFBRSxJQUFJO0VBQ2YsU0FBUyxFQUFFLElBQUk7RUFFdkIsV0FBVyxFQUFFLE9BQU87Q0FDckI7O0EwQ2hFRCxBQUFBLGdDQUFnQyxDQUFDO0UxQ2tDakMsUUFBUSxFQUFFLFFBQVE7RUFFbEIsS0FBSyxFQUFFLEdBQUc7RUFDVixNQUFNLEVBQUUsR0FBRztFQUNYLE1BQU0sRUFBRSxJQUFJO0VBRVosUUFBUSxFQUFFLE1BQU07RUFDaEIsSUFBSSxFQUFFLGFBQWE7RUFDbkIsaUJBQWlCLEVBQUUsVUFBVTtFQUNyQixTQUFTLEVBQUUsVUFBVTtFQUs3QixXQUFXLEVBQUUsTUFBTTtDMEM5Q2xCOztBQUZELEExQ2tEQSxnQzBDbERnQyxBMUNrRC9CLE9BQU8sRTBDbERSLGdDQUFnQyxBMUNtRC9CLE1BQU0sQ0FBQztFQUNOLFFBQVEsRUFBRSxNQUFNO0VBRWhCLEtBQUssRUFBRSxJQUFJO0VBQ1gsTUFBTSxFQUFFLElBQUk7RUFDWixNQUFNLEVBQUUsT0FBTztFQUVmLFFBQVEsRUFBRSxPQUFPO0VBQ2pCLElBQUksRUFBRSxJQUFJO0VBQ1YsaUJBQWlCLEVBQUUsSUFBSTtFQUNmLFNBQVMsRUFBRSxJQUFJO0VBRXZCLFdBQVcsRUFBRSxPQUFPO0NBQ3JCOztBNEN4RUQsQUFBQSx3QkFBd0IsQ0FBQztFQUN2QixPQUFPLEVBQUUsaUJBQWlCO0NBQzNCOztBQUVELEFBQUEsOEJBQThCLENBQUM7RUFDN0IsT0FBTyxFQUFFLHVCQUF1QjtDQUNqQzs7QUFFRCxBQUFBLHVCQUF1QixDQUFDO0VBQ3RCLE9BQU8sRUFBRSxnQkFBZ0I7Q0FDMUI7O0FDMkJDLEFBQUEsa0JBQWtCLENBQXFCO0UvQzZDbkMsTUFBWSxFeEI1Q1YsQ0FBQyxDd0I0QzZDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsa0JBQWtCLENBQXFCO0kvQ29EakMsTUFBWSxFeEJsRFYsQ0FBQyxDd0JrRDZDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSxzQkFBc0IsQ0FBK0I7RS9DdUNuRCxVQUEwQixFeEI5Q3hCLENBQUMsQ3dCOEM0RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHNCQUFzQixDQUErQjtJL0M4Q2pELFVBQTBCLEV4QnBEeEIsQ0FBQyxDd0JvRDRELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEI5Q3hCLENBQUMsQ3dCOEM0RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QnBEeEIsQ0FBQyxDd0JvRDRELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEI5Q3hCLENBQUMsQ3dCOEM0RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHlCQUF5QixDQUE0QjtJL0M4Q2pELGFBQTBCLEV4QnBEeEIsQ0FBQyxDd0JvRDRELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEI5Q3hCLENBQUMsQ3dCOEM0RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QnBEeEIsQ0FBQyxDd0JvRDRELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxrQkFBa0IsQ0FBcUI7RS9DNkNuQyxNQUFZLEV4QnhDVixHQUFHLEN3QndDMkMsVUFBVTtDK0MxQzdEOztBakQ0TEcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRC9MaEMsQUFBQSxrQkFBa0IsQ0FBcUI7SS9Db0RqQyxNQUFZLEV4QjlDVixHQUFHLEN3QjhDMkMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHNCQUFzQixDQUErQjtFL0N1Q25ELFVBQTBCLEV4QjFDeEIsR0FBRyxDd0IwQzBELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsc0JBQXNCLENBQStCO0kvQzhDakQsVUFBMEIsRXhCaER4QixHQUFHLEN3QmdEMEQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QjFDeEIsR0FBRyxDd0IwQzBELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsd0JBQXdCLENBQTZCO0kvQzhDakQsWUFBMEIsRXhCaER4QixHQUFHLEN3QmdEMEQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHlCQUF5QixDQUE0QjtFL0N1Q25ELGFBQTBCLEV4QjFDeEIsR0FBRyxDd0IwQzBELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCaER4QixHQUFHLEN3QmdEMEQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QjFDeEIsR0FBRyxDd0IwQzBELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsdUJBQXVCLENBQThCO0kvQzhDakQsV0FBMEIsRXhCaER4QixHQUFHLEN3QmdEMEQsVUFBVTtHK0M1QzVFOzs7QUFWSCxBQUFBLGtCQUFrQixDQUFxQjtFL0M2Q25DLE1BQVksRXhCcENWLElBQUksQ3dCb0MwQyxVQUFVO0MrQzFDN0Q7O0FqRDRMRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEL0xoQyxBQUFBLGtCQUFrQixDQUFxQjtJL0NvRGpDLE1BQVksRXhCMUNWLElBQUksQ3dCMEMwQyxVQUFVO0crQ2pEL0Q7OztBQUtDLEFBQUEsc0JBQXNCLENBQStCO0UvQ3VDbkQsVUFBMEIsRXhCdEN4QixJQUFJLEN3QnNDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSxzQkFBc0IsQ0FBK0I7SS9DOENqRCxVQUEwQixFeEI1Q3hCLElBQUksQ3dCNEN5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsd0JBQXdCLENBQTZCO0UvQ3VDbkQsWUFBMEIsRXhCdEN4QixJQUFJLEN3QnNDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEI1Q3hCLElBQUksQ3dCNEN5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCdEN4QixJQUFJLEN3QnNDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEI1Q3hCLElBQUksQ3dCNEN5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsdUJBQXVCLENBQThCO0UvQ3VDbkQsV0FBMEIsRXhCdEN4QixJQUFJLEN3QnNDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx1QkFBdUIsQ0FBOEI7SS9DOENqRCxXQUEwQixFeEI1Q3hCLElBQUksQ3dCNEN5RCxVQUFVO0crQzVDNUU7OztBQVZILEFBQUEsa0JBQWtCLENBQXFCO0UvQzZDbkMsTUFBWSxFeEJoQ1YsSUFBSSxDd0JnQzBDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsa0JBQWtCLENBQXFCO0kvQ29EakMsTUFBWSxFeEJ0Q1YsSUFBSSxDd0JzQzBDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSxzQkFBc0IsQ0FBK0I7RS9DdUNuRCxVQUEwQixFeEJsQ3hCLElBQUksQ3dCa0N5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHNCQUFzQixDQUErQjtJL0M4Q2pELFVBQTBCLEV4QnhDeEIsSUFBSSxDd0J3Q3lELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEJsQ3hCLElBQUksQ3dCa0N5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QnhDeEIsSUFBSSxDd0J3Q3lELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEJsQ3hCLElBQUksQ3dCa0N5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHlCQUF5QixDQUE0QjtJL0M4Q2pELGFBQTBCLEV4QnhDeEIsSUFBSSxDd0J3Q3lELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEJsQ3hCLElBQUksQ3dCa0N5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QnhDeEIsSUFBSSxDd0J3Q3lELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxrQkFBa0IsQ0FBcUI7RS9DNkNuQyxNQUFZLEV4QjVCVixJQUFJLEN3QjRCMEMsVUFBVTtDK0MxQzdEOztBakQ0TEcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRC9MaEMsQUFBQSxrQkFBa0IsQ0FBcUI7SS9Db0RqQyxNQUFZLEV4QmxDVixJQUFJLEN3QmtDMEMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHNCQUFzQixDQUErQjtFL0N1Q25ELFVBQTBCLEV4QjlCeEIsSUFBSSxDd0I4QnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsc0JBQXNCLENBQStCO0kvQzhDakQsVUFBMEIsRXhCcEN4QixJQUFJLEN3Qm9DeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QjlCeEIsSUFBSSxDd0I4QnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsd0JBQXdCLENBQTZCO0kvQzhDakQsWUFBMEIsRXhCcEN4QixJQUFJLEN3Qm9DeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHlCQUF5QixDQUE0QjtFL0N1Q25ELGFBQTBCLEV4QjlCeEIsSUFBSSxDd0I4QnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCcEN4QixJQUFJLEN3Qm9DeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QjlCeEIsSUFBSSxDd0I4QnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsdUJBQXVCLENBQThCO0kvQzhDakQsV0FBMEIsRXhCcEN4QixJQUFJLEN3Qm9DeUQsVUFBVTtHK0M1QzVFOzs7QUFWSCxBQUFBLGtCQUFrQixDQUFxQjtFL0M2Q25DLE1BQVksRXhCeEJWLElBQUksQ3dCd0IwQyxVQUFVO0MrQzFDN0Q7O0FqRDRMRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEL0xoQyxBQUFBLGtCQUFrQixDQUFxQjtJL0NvRGpDLE1BQVksRXhCOUJWLElBQUksQ3dCOEIwQyxVQUFVO0crQ2pEL0Q7OztBQUtDLEFBQUEsc0JBQXNCLENBQStCO0UvQ3VDbkQsVUFBMEIsRXhCMUJ4QixJQUFJLEN3QjBCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSxzQkFBc0IsQ0FBK0I7SS9DOENqRCxVQUEwQixFeEJoQ3hCLElBQUksQ3dCZ0N5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsd0JBQXdCLENBQTZCO0UvQ3VDbkQsWUFBMEIsRXhCMUJ4QixJQUFJLEN3QjBCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEJoQ3hCLElBQUksQ3dCZ0N5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCMUJ4QixJQUFJLEN3QjBCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEJoQ3hCLElBQUksQ3dCZ0N5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsdUJBQXVCLENBQThCO0UvQ3VDbkQsV0FBMEIsRXhCMUJ4QixJQUFJLEN3QjBCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx1QkFBdUIsQ0FBOEI7SS9DOENqRCxXQUEwQixFeEJoQ3hCLElBQUksQ3dCZ0N5RCxVQUFVO0crQzVDNUU7OztBQVZILEFBQUEsa0JBQWtCLENBQXFCO0UvQzZDbkMsTUFBWSxFeEJwQlYsSUFBSSxDd0JvQjBDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsa0JBQWtCLENBQXFCO0kvQ29EakMsTUFBWSxFeEIxQlYsSUFBSSxDd0IwQjBDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSxzQkFBc0IsQ0FBK0I7RS9DdUNuRCxVQUEwQixFeEJ0QnhCLElBQUksQ3dCc0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHNCQUFzQixDQUErQjtJL0M4Q2pELFVBQTBCLEV4QjVCeEIsSUFBSSxDd0I0QnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEJ0QnhCLElBQUksQ3dCc0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QjVCeEIsSUFBSSxDd0I0QnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEJ0QnhCLElBQUksQ3dCc0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHlCQUF5QixDQUE0QjtJL0M4Q2pELGFBQTBCLEV4QjVCeEIsSUFBSSxDd0I0QnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEJ0QnhCLElBQUksQ3dCc0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QjVCeEIsSUFBSSxDd0I0QnlELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxrQkFBa0IsQ0FBcUI7RS9DNkNuQyxNQUFZLEV4QmhCVixJQUFJLEN3QmdCMEMsVUFBVTtDK0MxQzdEOztBakQ0TEcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRC9MaEMsQUFBQSxrQkFBa0IsQ0FBcUI7SS9Db0RqQyxNQUFZLEV4QnRCVixJQUFJLEN3QnNCMEMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHNCQUFzQixDQUErQjtFL0N1Q25ELFVBQTBCLEV4QmxCeEIsSUFBSSxDd0JrQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsc0JBQXNCLENBQStCO0kvQzhDakQsVUFBMEIsRXhCeEJ4QixJQUFJLEN3QndCeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QmxCeEIsSUFBSSxDd0JrQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsd0JBQXdCLENBQTZCO0kvQzhDakQsWUFBMEIsRXhCeEJ4QixJQUFJLEN3QndCeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHlCQUF5QixDQUE0QjtFL0N1Q25ELGFBQTBCLEV4QmxCeEIsSUFBSSxDd0JrQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCeEJ4QixJQUFJLEN3QndCeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QmxCeEIsSUFBSSxDd0JrQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsdUJBQXVCLENBQThCO0kvQzhDakQsV0FBMEIsRXhCeEJ4QixJQUFJLEN3QndCeUQsVUFBVTtHK0M1QzVFOzs7QUFWSCxBQUFBLGtCQUFrQixDQUFxQjtFL0M2Q25DLE1BQVksRXhCWlYsSUFBSSxDd0JZMEMsVUFBVTtDK0MxQzdEOztBakQ0TEcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRC9MaEMsQUFBQSxrQkFBa0IsQ0FBcUI7SS9Db0RqQyxNQUFZLEV4QmxCVixJQUFJLEN3QmtCMEMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHNCQUFzQixDQUErQjtFL0N1Q25ELFVBQTBCLEV4QmR4QixJQUFJLEN3QmN5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHNCQUFzQixDQUErQjtJL0M4Q2pELFVBQTBCLEV4QnBCeEIsSUFBSSxDd0JvQnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEJkeEIsSUFBSSxDd0JjeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEJwQnhCLElBQUksQ3dCb0J5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCZHhCLElBQUksQ3dCY3lELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCcEJ4QixJQUFJLEN3Qm9CeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QmR4QixJQUFJLEN3QmN5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QnBCeEIsSUFBSSxDd0JvQnlELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxrQkFBa0IsQ0FBcUI7RS9DNkNuQyxNQUFZLEV4QlJWLElBQUksQ3dCUTBDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsa0JBQWtCLENBQXFCO0kvQ29EakMsTUFBWSxFeEJkVixJQUFJLEN3QmMwQyxVQUFVO0crQ2pEL0Q7OztBQUtDLEFBQUEsc0JBQXNCLENBQStCO0UvQ3VDbkQsVUFBMEIsRXhCVnhCLElBQUksQ3dCVXlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsc0JBQXNCLENBQStCO0kvQzhDakQsVUFBMEIsRXhCaEJ4QixJQUFJLEN3QmdCeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QlZ4QixJQUFJLEN3QlV5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QmhCeEIsSUFBSSxDd0JnQnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEJWeEIsSUFBSSxDd0JVeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEJoQnhCLElBQUksQ3dCZ0J5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsdUJBQXVCLENBQThCO0UvQ3VDbkQsV0FBMEIsRXhCVnhCLElBQUksQ3dCVXlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsdUJBQXVCLENBQThCO0kvQzhDakQsV0FBMEIsRXhCaEJ4QixJQUFJLEN3QmdCeUQsVUFBVTtHK0M1QzVFOzs7QUFWSCxBQUFBLG1CQUFtQixDQUFvQjtFL0M2Q25DLE9BQVksRXhCNUNWLENBQUMsQ3dCNEM2QyxVQUFVO0MrQzFDN0Q7O0FqRDRMRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEL0xoQyxBQUFBLG1CQUFtQixDQUFvQjtJL0NvRGpDLE9BQVksRXhCbERWLENBQUMsQ3dCa0Q2QyxVQUFVO0crQ2pEL0Q7OztBQUtDLEFBQUEsdUJBQXVCLENBQThCO0UvQ3VDbkQsV0FBMEIsRXhCOUN4QixDQUFDLEN3QjhDNEQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx1QkFBdUIsQ0FBOEI7SS9DOENqRCxXQUEwQixFeEJwRHhCLENBQUMsQ3dCb0Q0RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCOUN4QixDQUFDLEN3QjhDNEQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEJwRHhCLENBQUMsQ3dCb0Q0RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsMEJBQTBCLENBQTJCO0UvQ3VDbkQsY0FBMEIsRXhCOUN4QixDQUFDLEN3QjhDNEQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSwwQkFBMEIsQ0FBMkI7SS9DOENqRCxjQUEwQixFeEJwRHhCLENBQUMsQ3dCb0Q0RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsd0JBQXdCLENBQTZCO0UvQ3VDbkQsWUFBMEIsRXhCOUN4QixDQUFDLEN3QjhDNEQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEJwRHhCLENBQUMsQ3dCb0Q0RCxVQUFVO0crQzVDNUU7OztBQVZILEFBQUEsbUJBQW1CLENBQW9CO0UvQzZDbkMsT0FBWSxFeEJ4Q1YsR0FBRyxDd0J3QzJDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsbUJBQW1CLENBQW9CO0kvQ29EakMsT0FBWSxFeEI5Q1YsR0FBRyxDd0I4QzJDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEIxQ3hCLEdBQUcsQ3dCMEMwRCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QmhEeEIsR0FBRyxDd0JnRDBELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEIxQ3hCLEdBQUcsQ3dCMEMwRCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHlCQUF5QixDQUE0QjtJL0M4Q2pELGFBQTBCLEV4QmhEeEIsR0FBRyxDd0JnRDBELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSwwQkFBMEIsQ0FBMkI7RS9DdUNuRCxjQUEwQixFeEIxQ3hCLEdBQUcsQ3dCMEMwRCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLDBCQUEwQixDQUEyQjtJL0M4Q2pELGNBQTBCLEV4QmhEeEIsR0FBRyxDd0JnRDBELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEIxQ3hCLEdBQUcsQ3dCMEMwRCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QmhEeEIsR0FBRyxDd0JnRDBELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxtQkFBbUIsQ0FBb0I7RS9DNkNuQyxPQUFZLEV4QnBDVixJQUFJLEN3Qm9DMEMsVUFBVTtDK0MxQzdEOztBakQ0TEcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRC9MaEMsQUFBQSxtQkFBbUIsQ0FBb0I7SS9Db0RqQyxPQUFZLEV4QjFDVixJQUFJLEN3QjBDMEMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QnRDeEIsSUFBSSxDd0JzQ3lELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsdUJBQXVCLENBQThCO0kvQzhDakQsV0FBMEIsRXhCNUN4QixJQUFJLEN3QjRDeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHlCQUF5QixDQUE0QjtFL0N1Q25ELGFBQTBCLEV4QnRDeEIsSUFBSSxDd0JzQ3lELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCNUN4QixJQUFJLEN3QjRDeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLDBCQUEwQixDQUEyQjtFL0N1Q25ELGNBQTBCLEV4QnRDeEIsSUFBSSxDd0JzQ3lELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsMEJBQTBCLENBQTJCO0kvQzhDakQsY0FBMEIsRXhCNUN4QixJQUFJLEN3QjRDeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QnRDeEIsSUFBSSxDd0JzQ3lELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsd0JBQXdCLENBQTZCO0kvQzhDakQsWUFBMEIsRXhCNUN4QixJQUFJLEN3QjRDeUQsVUFBVTtHK0M1QzVFOzs7QUFWSCxBQUFBLG1CQUFtQixDQUFvQjtFL0M2Q25DLE9BQVksRXhCaENWLElBQUksQ3dCZ0MwQyxVQUFVO0MrQzFDN0Q7O0FqRDRMRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEL0xoQyxBQUFBLG1CQUFtQixDQUFvQjtJL0NvRGpDLE9BQVksRXhCdENWLElBQUksQ3dCc0MwQyxVQUFVO0crQ2pEL0Q7OztBQUtDLEFBQUEsdUJBQXVCLENBQThCO0UvQ3VDbkQsV0FBMEIsRXhCbEN4QixJQUFJLEN3QmtDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx1QkFBdUIsQ0FBOEI7SS9DOENqRCxXQUEwQixFeEJ4Q3hCLElBQUksQ3dCd0N5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCbEN4QixJQUFJLEN3QmtDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEJ4Q3hCLElBQUksQ3dCd0N5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsMEJBQTBCLENBQTJCO0UvQ3VDbkQsY0FBMEIsRXhCbEN4QixJQUFJLEN3QmtDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSwwQkFBMEIsQ0FBMkI7SS9DOENqRCxjQUEwQixFeEJ4Q3hCLElBQUksQ3dCd0N5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsd0JBQXdCLENBQTZCO0UvQ3VDbkQsWUFBMEIsRXhCbEN4QixJQUFJLEN3QmtDeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEJ4Q3hCLElBQUksQ3dCd0N5RCxVQUFVO0crQzVDNUU7OztBQVZILEFBQUEsbUJBQW1CLENBQW9CO0UvQzZDbkMsT0FBWSxFeEI1QlYsSUFBSSxDd0I0QjBDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsbUJBQW1CLENBQW9CO0kvQ29EakMsT0FBWSxFeEJsQ1YsSUFBSSxDd0JrQzBDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEI5QnhCLElBQUksQ3dCOEJ5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QnBDeEIsSUFBSSxDd0JvQ3lELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEI5QnhCLElBQUksQ3dCOEJ5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHlCQUF5QixDQUE0QjtJL0M4Q2pELGFBQTBCLEV4QnBDeEIsSUFBSSxDd0JvQ3lELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSwwQkFBMEIsQ0FBMkI7RS9DdUNuRCxjQUEwQixFeEI5QnhCLElBQUksQ3dCOEJ5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLDBCQUEwQixDQUEyQjtJL0M4Q2pELGNBQTBCLEV4QnBDeEIsSUFBSSxDd0JvQ3lELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEI5QnhCLElBQUksQ3dCOEJ5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QnBDeEIsSUFBSSxDd0JvQ3lELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxtQkFBbUIsQ0FBb0I7RS9DNkNuQyxPQUFZLEV4QnhCVixJQUFJLEN3QndCMEMsVUFBVTtDK0MxQzdEOztBakQ0TEcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRC9MaEMsQUFBQSxtQkFBbUIsQ0FBb0I7SS9Db0RqQyxPQUFZLEV4QjlCVixJQUFJLEN3QjhCMEMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QjFCeEIsSUFBSSxDd0IwQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsdUJBQXVCLENBQThCO0kvQzhDakQsV0FBMEIsRXhCaEN4QixJQUFJLEN3QmdDeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHlCQUF5QixDQUE0QjtFL0N1Q25ELGFBQTBCLEV4QjFCeEIsSUFBSSxDd0IwQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCaEN4QixJQUFJLEN3QmdDeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLDBCQUEwQixDQUEyQjtFL0N1Q25ELGNBQTBCLEV4QjFCeEIsSUFBSSxDd0IwQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsMEJBQTBCLENBQTJCO0kvQzhDakQsY0FBMEIsRXhCaEN4QixJQUFJLEN3QmdDeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QjFCeEIsSUFBSSxDd0IwQnlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsd0JBQXdCLENBQTZCO0kvQzhDakQsWUFBMEIsRXhCaEN4QixJQUFJLEN3QmdDeUQsVUFBVTtHK0M1QzVFOzs7QUFWSCxBQUFBLG1CQUFtQixDQUFvQjtFL0M2Q25DLE9BQVksRXhCcEJWLElBQUksQ3dCb0IwQyxVQUFVO0MrQzFDN0Q7O0FqRDRMRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEL0xoQyxBQUFBLG1CQUFtQixDQUFvQjtJL0NvRGpDLE9BQVksRXhCMUJWLElBQUksQ3dCMEIwQyxVQUFVO0crQ2pEL0Q7OztBQUtDLEFBQUEsdUJBQXVCLENBQThCO0UvQ3VDbkQsV0FBMEIsRXhCdEJ4QixJQUFJLEN3QnNCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx1QkFBdUIsQ0FBOEI7SS9DOENqRCxXQUEwQixFeEI1QnhCLElBQUksQ3dCNEJ5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCdEJ4QixJQUFJLEN3QnNCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEI1QnhCLElBQUksQ3dCNEJ5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsMEJBQTBCLENBQTJCO0UvQ3VDbkQsY0FBMEIsRXhCdEJ4QixJQUFJLEN3QnNCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSwwQkFBMEIsQ0FBMkI7SS9DOENqRCxjQUEwQixFeEI1QnhCLElBQUksQ3dCNEJ5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsd0JBQXdCLENBQTZCO0UvQ3VDbkQsWUFBMEIsRXhCdEJ4QixJQUFJLEN3QnNCeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEI1QnhCLElBQUksQ3dCNEJ5RCxVQUFVO0crQzVDNUU7OztBQVZILEFBQUEsbUJBQW1CLENBQW9CO0UvQzZDbkMsT0FBWSxFeEJoQlYsSUFBSSxDd0JnQjBDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsbUJBQW1CLENBQW9CO0kvQ29EakMsT0FBWSxFeEJ0QlYsSUFBSSxDd0JzQjBDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEJsQnhCLElBQUksQ3dCa0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QnhCeEIsSUFBSSxDd0J3QnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEJsQnhCLElBQUksQ3dCa0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHlCQUF5QixDQUE0QjtJL0M4Q2pELGFBQTBCLEV4QnhCeEIsSUFBSSxDd0J3QnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSwwQkFBMEIsQ0FBMkI7RS9DdUNuRCxjQUEwQixFeEJsQnhCLElBQUksQ3dCa0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLDBCQUEwQixDQUEyQjtJL0M4Q2pELGNBQTBCLEV4QnhCeEIsSUFBSSxDd0J3QnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEJsQnhCLElBQUksQ3dCa0J5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QnhCeEIsSUFBSSxDd0J3QnlELFVBQVU7RytDNUM1RTs7O0FBVkgsQUFBQSxtQkFBbUIsQ0FBb0I7RS9DNkNuQyxPQUFZLEV4QlpWLElBQUksQ3dCWTBDLFVBQVU7QytDMUM3RDs7QWpENExHLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUQvTGhDLEFBQUEsbUJBQW1CLENBQW9CO0kvQ29EakMsT0FBWSxFeEJsQlYsSUFBSSxDd0JrQjBDLFVBQVU7RytDakQvRDs7O0FBS0MsQUFBQSx1QkFBdUIsQ0FBOEI7RS9DdUNuRCxXQUEwQixFeEJkeEIsSUFBSSxDd0JjeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx1QkFBdUIsQ0FBOEI7SS9DOENqRCxXQUEwQixFeEJwQnhCLElBQUksQ3dCb0J5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEseUJBQXlCLENBQTRCO0UvQ3VDbkQsYUFBMEIsRXhCZHhCLElBQUksQ3dCY3lELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEseUJBQXlCLENBQTRCO0kvQzhDakQsYUFBMEIsRXhCcEJ4QixJQUFJLEN3Qm9CeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLDBCQUEwQixDQUEyQjtFL0N1Q25ELGNBQTBCLEV4QmR4QixJQUFJLEN3QmN5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLDBCQUEwQixDQUEyQjtJL0M4Q2pELGNBQTBCLEV4QnBCeEIsSUFBSSxDd0JvQnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx3QkFBd0IsQ0FBNkI7RS9DdUNuRCxZQUEwQixFeEJkeEIsSUFBSSxDd0JjeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx3QkFBd0IsQ0FBNkI7SS9DOENqRCxZQUEwQixFeEJwQnhCLElBQUksQ3dCb0J5RCxVQUFVO0crQzVDNUU7OztBQVZILEFBQUEsbUJBQW1CLENBQW9CO0UvQzZDbkMsT0FBWSxFeEJSVixJQUFJLEN3QlEwQyxVQUFVO0MrQzFDN0Q7O0FqRDRMRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEL0xoQyxBQUFBLG1CQUFtQixDQUFvQjtJL0NvRGpDLE9BQVksRXhCZFYsSUFBSSxDd0JjMEMsVUFBVTtHK0NqRC9EOzs7QUFLQyxBQUFBLHVCQUF1QixDQUE4QjtFL0N1Q25ELFdBQTBCLEV4QlZ4QixJQUFJLEN3QlV5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHVCQUF1QixDQUE4QjtJL0M4Q2pELFdBQTBCLEV4QmhCeEIsSUFBSSxDd0JnQnlELFVBQVU7RytDNUM1RTs7O0FBRkQsQUFBQSx5QkFBeUIsQ0FBNEI7RS9DdUNuRCxhQUEwQixFeEJWeEIsSUFBSSxDd0JVeUQsVUFBVTtDK0NyQzFFOztBakRxTEMsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VpRHZMOUIsQUFBQSx5QkFBeUIsQ0FBNEI7SS9DOENqRCxhQUEwQixFeEJoQnhCLElBQUksQ3dCZ0J5RCxVQUFVO0crQzVDNUU7OztBQUZELEFBQUEsMEJBQTBCLENBQTJCO0UvQ3VDbkQsY0FBMEIsRXhCVnhCLElBQUksQ3dCVXlELFVBQVU7QytDckMxRTs7QWpEcUxDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFaUR2TDlCLEFBQUEsMEJBQTBCLENBQTJCO0kvQzhDakQsY0FBMEIsRXhCaEJ4QixJQUFJLEN3QmdCeUQsVUFBVTtHK0M1QzVFOzs7QUFGRCxBQUFBLHdCQUF3QixDQUE2QjtFL0N1Q25ELFlBQTBCLEV4QlZ4QixJQUFJLEN3QlV5RCxVQUFVO0MrQ3JDMUU7O0FqRHFMQyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWlEdkw5QixBQUFBLHdCQUF3QixDQUE2QjtJL0M4Q2pELFlBQTBCLEV4QmhCeEIsSUFBSSxDd0JnQnlELFVBQVU7RytDNUM1RTs7O0FDM0NILEFBQUEsc0JBQXNCLENBQU87RS9Db0kzQixTQUFTLEVyQjVFRSxJQUFJLENxQnVFc0IsVUFBVTtFQVMvQyxXQUFXLEVBcEVDLE9BQXlCLENBNkRJLFVBQVU7QytDL0hwRDs7QWxEOE5HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFa0RoT2hDLEFBQUEsc0JBQXNCLENBQU87SS9DZ0p6QixTQUFTLEVyQnBGQSxJQUFJLENxQm1Fc0IsVUFBVTtJQXFCN0MsV0FBVyxFQWhGRCxDQUF5QixDQTZESSxVQUFVO0crQy9IcEQ7OztBbEQ4TkcsTUFBTSxDQUFDLEtBQUs7RWtEaE9oQixBQUFBLHNCQUFzQixDQUFPO0kvQzJJekIsU0FBUyxFckIzRUEsSUFBSSxDcUIrRHNCLFVBQVU7SUFhN0MsV0FBVyxFckIzRUEsR0FBRyxDcUJnRXlCLFVBQVU7RytDL0hwRDs7O0FBRkQsQUFBQSxzQkFBc0IsQ0FBTztFL0NvSTNCLFNBQVMsRXJCOURFLElBQUksQ3FCeURzQixVQUFVO0VBUy9DLFdBQVcsRUFwRUMsT0FBeUIsQ0E2REksVUFBVTtDK0MvSHBEOztBbEQ4TkcsTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VrRGhPaEMsQUFBQSxzQkFBc0IsQ0FBTztJL0NnSnpCLFNBQVMsRXJCdEVBLElBQUksQ3FCcURzQixVQUFVO0lBcUI3QyxXQUFXLEVBaEZELE9BQXlCLENBNkRJLFVBQVU7RytDL0hwRDs7O0FsRDhORyxNQUFNLENBQUMsS0FBSztFa0RoT2hCLEFBQUEsc0JBQXNCLENBQU87SS9DMkl6QixTQUFTLEVyQjdEQSxJQUFJLENxQmlEc0IsVUFBVTtJQWE3QyxXQUFXLEVyQjdEQSxJQUFJLENxQmtEd0IsVUFBVTtHK0MvSHBEOzs7QUFGRCxBQUFBLHNCQUFzQixDQUFPO0UvQ29JM0IsU0FBUyxFckJoREUsSUFBSSxDcUIyQ3NCLFVBQVU7RUFTL0MsV0FBVyxFQXBFQyxPQUF5QixDQTZESSxVQUFVO0MrQy9IcEQ7O0FsRDhORyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWtEaE9oQyxBQUFBLHNCQUFzQixDQUFPO0kvQ2dKekIsU0FBUyxFckJ4REEsSUFBSSxDcUJ1Q3NCLFVBQVU7SUFxQjdDLFdBQVcsRUFoRkQsT0FBeUIsQ0E2REksVUFBVTtHK0MvSHBEOzs7QWxEOE5HLE1BQU0sQ0FBQyxLQUFLO0VrRGhPaEIsQUFBQSxzQkFBc0IsQ0FBTztJL0MySXpCLFNBQVMsRXJCL0NBLElBQUksQ3FCbUNzQixVQUFVO0lBYTdDLFdBQVcsRXJCL0NBLElBQUksQ3FCb0N3QixVQUFVO0crQy9IcEQ7OztBQUZELEFBQUEsc0JBQXNCLENBQU87RS9Db0kzQixTQUFTLEVyQmxDRSxJQUFJLENxQjZCc0IsVUFBVTtFQVMvQyxXQUFXLEVBcEVDLE9BQXlCLENBNkRJLFVBQVU7QytDL0hwRDs7QWxEOE5HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFa0RoT2hDLEFBQUEsc0JBQXNCLENBQU87SS9DZ0p6QixTQUFTLEVyQjFDQSxJQUFJLENxQnlCc0IsVUFBVTtJQXFCN0MsV0FBVyxFQWhGRCxPQUF5QixDQTZESSxVQUFVO0crQy9IcEQ7OztBbEQ4TkcsTUFBTSxDQUFDLEtBQUs7RWtEaE9oQixBQUFBLHNCQUFzQixDQUFPO0kvQzJJekIsU0FBUyxFckJqQ0EsSUFBSSxDcUJxQnNCLFVBQVU7SUFhN0MsV0FBVyxFckJqQ0EsSUFBSSxDcUJzQndCLFVBQVU7RytDL0hwRDs7O0FBRkQsQUFBQSxzQkFBc0IsQ0FBTztFL0NvSTNCLFNBQVMsRXJCcEJFLElBQUksQ3FCZXNCLFVBQVU7RUFTL0MsV0FBVyxFQXBFQyxPQUF5QixDQTZESSxVQUFVO0MrQy9IcEQ7O0FsRDhORyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWtEaE9oQyxBQUFBLHNCQUFzQixDQUFPO0kvQ2dKekIsU0FBUyxFckI1QkEsSUFBSSxDcUJXc0IsVUFBVTtJQXFCN0MsV0FBVyxFQWhGRCxJQUF5QixDQTZESSxVQUFVO0crQy9IcEQ7OztBbEQ4TkcsTUFBTSxDQUFDLEtBQUs7RWtEaE9oQixBQUFBLHNCQUFzQixDQUFPO0kvQzJJekIsU0FBUyxFckJuQkEsSUFBSSxDcUJPc0IsVUFBVTtJQWE3QyxXQUFXLEVyQm5CQSxJQUFJLENxQlF3QixVQUFVO0crQy9IcEQ7OztBQUZELEFBQUEsc0JBQXNCLENBQU87RS9Db0kzQixTQUFTLEVyQk5FLElBQUksQ3FCQ3NCLFVBQVU7RUFTL0MsV0FBVyxFQXBFQyxJQUF5QixDQTZESSxVQUFVO0MrQy9IcEQ7O0FsRDhORyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWtEaE9oQyxBQUFBLHNCQUFzQixDQUFPO0kvQ2dKekIsU0FBUyxFckJkQSxJQUFJLENxQkhzQixVQUFVO0lBcUI3QyxXQUFXLEVBaEZELE9BQXlCLENBNkRJLFVBQVU7RytDL0hwRDs7O0FsRDhORyxNQUFNLENBQUMsS0FBSztFa0RoT2hCLEFBQUEsc0JBQXNCLENBQU87SS9DMkl6QixTQUFTLEVyQkxBLElBQUksQ3FCUHNCLFVBQVU7SUFhN0MsV0FBVyxFckJMQSxJQUFJLENxQk53QixVQUFVO0crQy9IcEQ7OztBQUZELEFBQUEsc0JBQXNCLENBQU87RS9Db0kzQixTQUFTLEVyQlFFLElBQUksQ3FCYnNCLFVBQVU7RUFTL0MsV0FBVyxFQXBFQyxPQUF5QixDQTZESSxVQUFVO0MrQy9IcEQ7O0FsRDhORyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RWtEaE9oQyxBQUFBLHNCQUFzQixDQUFPO0kvQ2dKekIsU0FBUyxFckJBQSxJQUFJLENxQmpCc0IsVUFBVTtJQXFCN0MsV0FBVyxFQWhGRCxJQUF5QixDQTZESSxVQUFVO0crQy9IcEQ7OztBbEQ4TkcsTUFBTSxDQUFDLEtBQUs7RWtEaE9oQixBQUFBLHNCQUFzQixDQUFPO0kvQzJJekIsU0FBUyxFckJTQSxJQUFJLENxQnJCc0IsVUFBVTtJQWE3QyxXQUFXLEVyQlNBLEdBQUcsQ3FCcEJ5QixVQUFVO0crQy9IcEQ7OztBQUZELEFBQUEsc0JBQXNCLENBQU87RS9Db0kzQixTQUFTLEVyQnNCRSxJQUFJLENxQjNCc0IsVUFBVTtFQVMvQyxXQUFXLEVBcEVDLElBQXlCLENBNkRJLFVBQVU7QytDL0hwRDs7QWxEOE5HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFa0RoT2hDLEFBQUEsc0JBQXNCLENBQU87SS9DZ0p6QixTQUFTLEVyQmNBLElBQUksQ3FCL0JzQixVQUFVO0lBcUI3QyxXQUFXLEVBaEZELE9BQXlCLENBNkRJLFVBQVU7RytDL0hwRDs7O0FsRDhORyxNQUFNLENBQUMsS0FBSztFa0RoT2hCLEFBQUEsc0JBQXNCLENBQU87SS9DMkl6QixTQUFTLEVyQnVCQSxJQUFJLENxQm5Dc0IsVUFBVTtJQWE3QyxXQUFXLEVyQnVCQSxHQUFHLENxQmxDeUIsVUFBVTtHK0MvSHBEOzs7QUFLSCxBQUFBLDZCQUE2QixDQUFDO0UvQ3FDOUIsV0FBVyxFdEJUZSxHQUFHLENzQlMyQixVQUFVO0MrQ25DakU7O0FBRUQsQUFBQSwwQkFBMEIsQ0FBQztFL0MyQzNCLFdBQVcsRXRCYlksR0FBRyxDc0JhMkIsVUFBVTtDK0N6QzlEOztBQ2xCRCxBQUFBLDhCQUE4QixDQUFDO0VBQzdCLEtBQUssRUFBRSxlQUFlO0NBS3ZCOztBbkQrTkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VtRHJPbEMsQUFBQSw4QkFBOEIsQ0FBQztJQUkzQixLQUFLLEVBQUUsY0FBYztHQUV4Qjs7O0FBRUQsQUFBQSwwQkFBMEIsQ0FBQztFQUN6QixLQUFLLEVBQUUsZUFBZTtDQUt2Qjs7QW5EdU5LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFbUQ3TmxDLEFBQUEsMEJBQTBCLENBQUM7SUFJdkIsS0FBSyxFQUFFLGlCQUFpQjtHQUUzQjs7O0FBRUQsQUFBQSx3QkFBd0IsQ0FBQztFQUN2QixLQUFLLEVBQUUsZUFBZTtDQUt2Qjs7QW5EK01LLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFbURyTmxDLEFBQUEsd0JBQXdCLENBQUM7SUFJckIsS0FBSyxFQUFFLGNBQWM7R0FFeEI7OztBQUVELEFBQUEseUJBQXlCLENBQUM7RUFDeEIsS0FBSyxFQUFFLGVBQWU7Q0FLdkI7O0FuRHVNSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RW1EN01sQyxBQUFBLHlCQUF5QixDQUFDO0lBSXRCLEtBQUssRUFBRSxpQkFBaUI7R0FFM0I7OztBQUVELEFBQUEsMkJBQTJCLENBQUM7RUFDMUIsS0FBSyxFQUFFLGVBQWU7Q0FLdkI7O0FuRCtMSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RW1Eck1sQyxBQUFBLDJCQUEyQixDQUFDO0lBSXhCLEtBQUssRUFBRSxjQUFjO0dBRXhCOzs7QUN0Q0gsQUFBQSx1QkFBdUIsQ0FBQztFakRjdEIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJORSxJQUFJO0VxQlVmLFdBQVcsRUFwRUMsSUFBeUI7Q2lEbEUxQzs7QXBEOE5PLE1BQU0sQ0FBQyxLQUFLO0VvRHJPcEIsQUFBQSx1QkFBdUIsQ0FBQztJakR3QnBCLFdBQVcsRXRCSVcsVUFBVTtHdUVyQm5DOzs7QXBEOE5PLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0RyT3BDLEFBQUEsdUJBQXVCLENBQUM7SWpEcUpoQixTQUFTLEVyQmRBLElBQUk7SXFCa0JiLFdBQVcsRUFoRkQsT0FBeUI7R2lEbEUxQzs7O0FwRDhOTyxNQUFNLENBQUMsS0FBSztFb0RyT3BCLEFBQUEsdUJBQXVCLENBQUM7SWpEZ0poQixTQUFTLEVyQkxBLElBQUk7SXFCTWIsV0FBVyxFckJMQSxJQUFJO0dzRXJJdEI7OztBcEQ4Tk8sTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VvRHJPcEMsQUFBQSx1QkFBdUIsQ0FBQztJQUtwQixPQUFPLEVBQUUsS0FBSztHQUVqQjs7O0FwRDhOTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RW9ENU5wQyxBQUFBLDhCQUE4QixDQUFDO0lBRzNCLEtBQUssRUFBRSxJQUFJO0dBTWQ7RUFURCxBQUtJLDhCQUwwQixDQUsxQixpQ0FBaUMsQ0FBQztJQUNoQyxLQUFLLEVBQUUsR0FBRztHQUNYOzs7QXBEcU5HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0RqTnBDLEFBQUEsNkJBQTZCLENBQUM7SUFHMUIsS0FBSyxFQUFFLElBQUk7R0FNZDtFQVRELEFBS0ksNkJBTHlCLENBS3pCLGlDQUFpQyxDQUFDO0lBQ2hDLEtBQUssRUFBRSxHQUFHO0dBQ1g7OztBQUlMLEFBQUEsaUNBQWlDLENBQUM7RUFDaEMsUUFBUSxFQUFFLFFBQVE7RUFDbEIsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLEM5RUZkLE9BQU87QzhFUWxCOztBcEQ4TE8sTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VvRHRNcEMsQUFBQSxpQ0FBaUMsQ0FBQztJQUs5QixPQUFPLEVBQUUsU0FBUztJQUNsQixtQkFBbUIsRUFBRSxDQUFDO0dBRXpCOzs7QXBEOExPLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0Q1THBDLEFBQUEsaUNBQWlDLEFBQUEsWUFBWSxDQUFDLGlDQUFpQztFQUMvRSxpQ0FBaUMsQUFBQSxZQUFZLENBQUMsK0JBQStCO0VBQzdFLGlDQUFpQyxBQUFBLFlBQVksQ0FBQywrQkFBK0IsQ0FBQztJQUUxRSxXQUFXLEVBQUUsQ0FBQztHQUVqQjs7O0FBRUQsQUFBQSxpQ0FBaUM7QUFDakMsK0JBQStCO0FBQy9CLCtCQUErQixDQUFDO0VBQzlCLE9BQU8sRUFBRSxLQUFLO0VBQ2QsTUFBTSxFQUFFLENBQUM7Q0FNVjs7QXBEMEtPLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFb0RwTHBDLEFBQUEsaUNBQWlDO0VBQ2pDLCtCQUErQjtFQUMvQiwrQkFBK0IsQ0FBQztJQUk1QixPQUFPLEVBQUUsVUFBVTtJQUNuQixhQUFhLEVBQUUsR0FBRyxDQUFDLEtBQUssQzlFekJoQixPQUFPO0k4RTBCZixPQUFPLEU5RHhDRCxTQUFpQyxDQUFqQyxTQUFpQyxDQUFqQyxTQUFpQyxDOER3Q29CLENBQUM7R0FFL0Q7OztBQUVELEFBQUEsaUNBQWlDLENBQUM7RUFDaEMsV0FBVyxFQUFFLElBQUk7RUFDakIsTUFBTSxFOUQ5Q0UsU0FBaUMsQzhEOENoQixHQUFHLEM5RDlDcEIsU0FBaUMsQzhEOENHLENBQUM7Q0FFOUM7O0FBRUQsQUFBQSwrQkFBK0IsQ0FBQztFQUM5QixjQUFjLEU5RG5ETixTQUFpQztDOERvRDFDOztBQUVELEFBQUEsK0JBQStCLENBQUM7RUFDOUIsVUFBVSxFQUFFLEtBQUs7RUFDakIsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFQUFFLENBQUM7RUFDTixLQUFLLEVBQUUsQ0FBQztDQU1UOztBcERvSk8sTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0VvRDlKcEMsQUFBQSwrQkFBK0IsQ0FBQztJQU81QixRQUFRLEVBQUUsTUFBTTtJQUNoQixhQUFhLEVBQUUsQ0FBQztHQUVuQjs7O0FwRG9KTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFEbk9wQyxBQUFBLG1CQUFtQixDQUFDO0lBRWhCLFNBQVMsRUFBRSxLQUFLO0dBRW5COzs7QUFLRCxBQUFBLGNBQWMsQ0FBQztFQUNiLFVBQVUsRUFBRSxJQUFJO0VBQ2hCLE9BQU8sRUFBRSxDQUFDO0VBQ1YsVUFBVSxFMUVPRyxJQUFJO0MwRUhsQjs7QXJEbU5PLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFcUQxTnBDLEFBQUEsY0FBYyxDQUFDO0lBS1gsVUFBVSxFQUFFLElBQW1CO0dBRWxDOzs7QUFFRCxBQUFBLHVCQUF1QixDQUFDO0VBQ3RCLE9BQU8sRUFBRSxLQUFLO0VsRFBkLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUEyQ2xDLFdBQVcsRXRCYlksR0FBRztFc0IyRnRCLFNBQVMsRXJCcEJFLElBQUk7RXFCd0JmLFdBQVcsRUFwRUMsT0FBeUI7RWtEakR6QyxNQUFNLEVBQUUsQ0FBQztFQUNULGNBQWMsRUFBRSxHQUFtQjtDQUNwQzs7QXJEMk1PLE1BQU0sQ0FBQyxLQUFLO0VxRGpOcEIsQUFBQSx1QkFBdUIsQ0FBQztJbERJcEIsV0FBVyxFdEJJVyxVQUFVO0d3RUZuQzs7O0FyRDJNTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFEak5wQyxBQUFBLHVCQUF1QixDQUFDO0lsRGlJaEIsU0FBUyxFckI1QkEsSUFBSTtJcUJnQ2IsV0FBVyxFQWhGRCxJQUF5QjtHa0QvQzFDOzs7QXJEMk1PLE1BQU0sQ0FBQyxLQUFLO0VxRGpOcEIsQUFBQSx1QkFBdUIsQ0FBQztJbEQ0SGhCLFNBQVMsRXJCbkJBLElBQUk7SXFCb0JiLFdBQVcsRXJCbkJBLElBQUk7R3VFcEd0Qjs7O0FBRUQsQUFBQSw4QkFBOEIsQ0FBQztFQUM3QixPQUFPLEVBQUUsVUFBVTtFQUNuQixhQUFhLEVBQUUsR0FBbUI7Q0FNbkM7O0FyRGlNTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFEek1wQyxBQUFBLDhCQUE4QixDQUFDO0lBSzNCLFNBQVMsRUF4Qk0sSUFBSTtJQXlCbkIsYUFBYSxFQUFFLENBQUM7R0FFbkI7OztBQUdELEFBQUEscUJBQXFCLENBQUM7RUFDcEIsVUFBVSxFQUFFLElBQUk7RUFDaEIsT0FBTyxFQUFFLENBQUM7RUFDVixhQUFhLEUxRXJCQSxJQUFJO0MwRTZCbEI7O0FyRG1MTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFEOUxwQyxBQUFBLHFCQUFxQixDQUFDO0lBS2xCLGFBQWEsRUFBRSxJQUFtQjtHQU1yQzs7O0FyRG1MTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXFEOUxwQyxBQUFBLHFCQUFxQixDQUFDO0lBU2xCLFlBQVksRUF2Q0csSUFBSTtHQXlDdEI7OztBQUVELEFBQUEsb0JBQW9CLENBQUM7RUFDbkIsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLEMvRXRCZCxPQUFPO0UrRXVCakIsV0FBVyxFM0UxQ1IsSUFBSTtFMkUyQ1AsY0FBYyxFM0UzQ1gsSUFBSTtDMkU2Q1I7O0FBTEQsQTVENUNFLG9CNEQ0Q2tCLEE1RDVDakIsTUFBTSxDQUFDO0VBQ04sT0FBTyxFQUFFLEVBQUU7RUFDWCxPQUFPLEVBQUUsS0FBSztFQUNkLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0E0RCtDSCxBQUFBLG9CQUFvQixBQUFBLFlBQVksQ0FBQztFQUMvQixVQUFVLEVBQUUsR0FBRyxDQUFDLEtBQUssQy9FN0JYLE9BQU87QytFOEJsQjs7QUFFRCxBQUFBLHlCQUF5QixDQUFDO0VBQ3hCLEtBQUssRUFBRSxLQUFLO0VBQ1osS0FBSyxFQUFFLElBQUk7Q0FDWjs7QUFFRCxBQUFBLDhCQUE4QixDQUFDO0VBQzdCLEtBQUssRUFBRSxLQUFLO0NBQ2I7O0FDcEVELEFBQUEsa0JBQWtCLENBQUM7RUFDakIsVUFBVSxFQUFFLElBQUksQ0FBQyxLQUFLLENoRndCZCxPQUFPO0VnRnZCZixXQUFXLEU1RVFSLElBQUk7QzRFUFI7O0FBRUQsQUFBQSxrQkFBa0IsQ0FBQyxXQUFXLEdBQUcsRUFBRSxDQUFDO0VBQ2xDLGFBQWEsRTVFSVYsSUFBSTtDNEVIUjs7QUNQRCxBQUNFLG9CQURrQixDQUNsQixZQUFZLENBQUM7RUFDWCxVQUFVLEVBQUUsS0FBSztDQUNsQjs7QUFISCxBQUtFLG9CQUxrQixDQUtsQixpQkFBaUIsQ0FBQztFQUNoQixhQUFhLEVBQUUsS0FBSztDQUNyQjs7QUFQSCxBQVNFLG9CQVRrQixDQVNsQixnQkFBZ0IsQ0FBQztFQUNmLE9BQU8sRUFBRSxJQUFJO0VBQ2IscUJBQXFCO0NBYXRCOztBQXhCSCxBQVlJLG9CQVpnQixDQVNsQixnQkFBZ0IsQ0FHZCxLQUFLLENBQUM7RUFDSixVQUFVLEVBQUUsSUFBSTtDQUNqQjs7QXZEcU5HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFdURuT3BDLEFBU0Usb0JBVGtCLENBU2xCLGdCQUFnQixDQUFDO0lBT2IsT0FBTyxFQUFFLEtBQUs7SUFDZCxVQUFVLEVBQUUsTUFBTTtJQUNsQixNQUFNLEVBQUUsS0FBSztHQU1oQjs7O0FBeEJILEFBcUJJLG9CQXJCZ0IsQ0FTbEIsZ0JBQWdCLENBWWQsZ0JBQWdCLENBQUM7RUFDZixNQUFNLEVBQUUsQ0FBQztDQUNWOztBQXZCTCxBQTBCRSxvQkExQmtCLENBMEJsQixNQUFNLENBQUM7RUFDTCxNQUFNLEVBQUUsSUFBSTtFQUNaLFlBQVksRUFBRSxDQUFDO0NBS2hCOztBQWpDSCxBQThCSSxvQkE5QmdCLENBMEJsQixNQUFNLENBSUosS0FBSyxDQUFDO0VBQ0osTUFBTSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENqRmZkLE9BQU87Q2lGZ0JYOztBQWhDTCxBQW1DRSxvQkFuQ2tCLENBbUNsQixVQUFVLENBQUM7RUFDVCxZQUFZLEVqRlBKLE9BQU87Q2lGUWhCOztBQXJDSCxBQXVDRSxvQkF2Q2tCLENBdUNsQixrQkFBa0IsQ0FBQztFQUNqQixRQUFRLEVBQUUsUUFBUTtFQUNsQixRQUFRLEVBQUUsT0FBTztFQUNqQixzQkFBc0I7Q0FZdkI7O0F2RDZLSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVEbk9wQyxBQXVDRSxvQkF2Q2tCLENBdUNsQixrQkFBa0IsQ0FBQztJQUtmLFFBQVEsRUFBRSxRQUFRO0lBQ2xCLFFBQVEsRUFBRSxNQUFNO0lBQ2hCLElBQUksRUFBRSxhQUFhO0lBQ25CLE1BQU0sRUFBRSxHQUFHO0lBQ1gsS0FBSyxFQUFFLEdBQUc7SUFDVixNQUFNLEVBQUUsSUFBSTtJQUNaLE9BQU8sRUFBRSxDQUFDO0lBQ1YsTUFBTSxFQUFFLENBQUM7SUFDVCx1REFBdUQ7R0FFMUQ7OztBQXRESCxBQXdERSxvQkF4RGtCLENBd0RsQixpQkFBaUIsQ0FBQztFQUNoQixPQUFPLEVBQUUsSUFBSTtDQUlkOztBdkRzS0ssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1RG5PcEMsQUF3REUsb0JBeERrQixDQXdEbEIsaUJBQWlCLENBQUM7SUFHZCxPQUFPLEVBQUUsU0FBUztHQUVyQjs7O0FBN0RILEFBZ0VJLG9CQWhFZ0IsQ0ErRGxCLGVBQWUsQ0FDYixZQUFZLENBQUM7RUFDWCxXQUFXLEVBQUUsQ0FBQztFQUNkLFlBQVksRUFBRSxDQUFDO0VBQ2YsV0FBVyxFQUFFLEdBQUc7Q0FDakI7O0FBcEVMLEFBc0VJLG9CQXRFZ0IsQ0ErRGxCLGVBQWUsQ0FPYixPQUFPLENBQUM7RUFDTixXQUFXLEVBQUUsR0FBRztDQUNqQjs7QUF4RUwsQUEwRUksb0JBMUVnQixDQStEbEIsZUFBZSxDQVdiLFFBQVEsQ0FBQztFQUNQLFdBQVcsRUFBRSxHQUFHO0NBU2pCOztBdkQrSUcsTUFBTSxFQUFFLFNBQVMsRUFBRSxJQUFJO0V1RG5PL0IsQUEwRUksb0JBMUVnQixDQStEbEIsZUFBZSxDQVdiLFFBQVEsQ0FBQztJQUdMLHNCQUFzQjtJQUN0QixXQUFXLEVBQUUsQ0FBQztJQUNkLE9BQU8sRUFBRSxLQUFLO0lwRG5FcEIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7SXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7SUFDbkMsdUJBQXVCLEVBQUUsU0FBUztJQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0lzQmlHekIsU0FBUyxFckJORSxJQUFJO0lxQlVmLFdBQVcsRUFwRUMsSUFBeUI7SW9EVW5DLFdBQVcsRUFBRSxHQUFHO0lBQ2hCLGFBQWEsRUFBRSxLQUFLO0dBRXZCOzs7QXZEK0lHLE1BQU0sQ0FBQyxLQUFLLE1BQUosU0FBUyxFQUFFLElBQUk7RXVEbk8vQixBQTBFSSxvQkExRWdCLENBK0RsQixlQUFlLENBV2IsUUFBUSxDQUFDO0lwRHBEVCxXQUFXLEV0QklXLFVBQVU7RzBFMEQvQjs7O0F2RCtJRyxNQUFNLEVBQUUsU0FBUyxFQUFFLElBQUksT0FBZixTQUFTLEVBQUUsU0FBUztFdURuT3BDLEFBMEVJLG9CQTFFZ0IsQ0ErRGxCLGVBQWUsQ0FXYixRQUFRLENBQUM7SXBEeUVMLFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHb0RhdEM7OztBdkQrSUcsTUFBTSxDQUFDLEtBQUssTUFBSixTQUFTLEVBQUUsSUFBSTtFdURuTy9CLEFBMEVJLG9CQTFFZ0IsQ0ErRGxCLGVBQWUsQ0FXYixRQUFRLENBQUM7SXBEb0VMLFNBQVMsRXJCTEEsSUFBSTtJcUJNYixXQUFXLEVyQkxBLElBQUk7R3lFdERsQjs7O0FBcEZMLEFBdUZFLG9CQXZGa0IsQ0F1RmxCLG9CQUFvQixDQUFDO0VBQ25CLFVBQVUsRUFBRSxHQUFHO0NBQ2hCOztBQXpGSCxBQTJGRSxvQkEzRmtCLENBMkZsQixhQUFhLENBQUM7RUFDWixLQUFLLEVBQUUsSUFBSTtDQUNaOztBQTdGSCxBQStGRSxvQkEvRmtCLENBK0ZsQixnQkFBZ0IsQ0FBQztFQUNmLE1BQU0sRUFBRSxDQUFDO0NBQ1Y7O0FBakdILEFBbUdFLG9CQW5Ha0IsQ0FtR2xCLGdDQUFnQyxDQUFDLEtBQUssQ0FBQSxBQUFBLElBQUMsQ0FBSyxRQUFRLEFBQWIsRUFBZTtFQUNwRCxPQUFPLEVBQUUsS0FBSztFQUNkLEtBQUssRUFBRSxJQUFJO0VBQ1gsS0FBSyxFQUFFLElBQUk7RUFDWCxhQUFhLEVBQUUsS0FBSztFQUNwQixRQUFRLEVBQUUsTUFBTTtDQUNqQjs7QXZEMEhLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFdURuT3BDLEFBbUdFLG9CQW5Ha0IsQ0FtR2xCLGdDQUFnQyxDQUFDLEtBQUssQ0FBQSxBQUFBLElBQUMsQ0FBSyxRQUFRLEFBQWIsRUFRaUI7SUFDcEQsYUFBYSxFQUFFLEtBQUs7R0FDckI7OztBQTdHTCxBQWdIRSxvQkFoSGtCLENBZ0hsQixnQ0FBZ0MsQ0FBQywyQkFBMkIsQ0FBQztFQUMzRCxPQUFPLEVBQUUsSUFBSTtDQUNkOztBdkRpSEssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1RG5PcEMsQUFnSEUsb0JBaEhrQixDQWdIbEIsZ0NBQWdDLENBQUMsMkJBQTJCLENBSUc7SUFDM0QsT0FBTyxFQUFFLE9BQU87R0FDakI7RUF0SEwsQUF3SEksb0JBeEhnQixDQXdIaEIsS0FBSyxDQUFBLEFBQUEsSUFBQyxDQUFLLFFBQVEsQUFBYixFQUFlO0lBQ25CLFVBQVUsRUFBRSxLQUFLO0dBQ2xCO0VBMUhMLEFBNEhJLG9CQTVIZ0IsQ0E0SGhCLGNBQWMsQ0FBQztJQUNiLFFBQVEsRUFBRSxRQUFRO0lBQ2xCLElBQUksRUFBRSxJQUFJO0lBQ1YsV0FBVyxFQUFFLElBQUk7R0FDbEI7RUFoSUwsQUFtR0Usb0JBbkdrQixDQW1HbEIsZ0NBQWdDLENBQUMsS0FBSyxDQUFBLEFBQUEsSUFBQyxDQUFLLFFBQVEsQUFBYixFQStCaUI7SUFDcEQsUUFBUSxFQUFFLG1CQUFtQjtJQUM3QixHQUFHLEVBQUUsS0FBSztJQUNWLElBQUksRUFBRSxLQUFLO0lBQ1gsVUFBVSxFQUFFLElBQUk7R0FDakI7RUF2SUwsQUF5SUksb0JBeklnQixDQXlJaEIsZ0NBQWdDLENBQUMsa0JBQWtCLENBQUM7SUFDbEQsT0FBTyxFQUFFLFlBQVk7SUFDckIsS0FBSyxFQUFFLElBQUk7SUFDWCxLQUFLLEVBQUUsSUFBSTtJQUNYLGFBQWEsRUFBRSxJQUFJO0lBQ25CLFFBQVEsRUFBRSxNQUFNO0dBQ2pCO0VBL0lMLEFBaUpJLG9CQWpKZ0IsQ0FpSmhCLGdDQUFnQyxDQUFDLGNBQWMsQ0FBQztJQUM5QyxPQUFPLEVBQUUsTUFBTTtJQUNmLEtBQUssRUFBRSxJQUFJO0lBQ1gsS0FBSyxFQUFFLElBQUk7SUFDWCxhQUFhLEVBQUUsSUFBSTtJQUNuQixRQUFRLEVBQUUsTUFBTTtHQUNqQjs7O0FBdkpMLEFBNkpJLG9CQTdKZ0IsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FDdEIsS0FBSyxDQUFDLEVBQUUsQ0FBQztFQUNQLE9BQU8sRUFBRSxTQUFTO0NBTW5COztBQXBLTCxBQWdLTSxvQkFoS2MsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FDdEIsS0FBSyxDQUFDLEVBQUUsQ0FHTixFQUFFLEFBQUEsZ0JBQWdCO0FBaEt4QixvQkFBb0IsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FDdEIsS0FBSyxDQUFDLEVBQUUsQ0FJTixFQUFFLEFBQUEsZ0JBQWdCLENBQUM7RUFDakIsTUFBTSxFQUFFLENBQUM7Q0FDVjs7QUFuS1AsQUFzS0ksb0JBdEtnQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQVV0QixFQUFFLEFBQUEsMkJBQTJCLENBQUM7RUFDNUIsS0FBSyxFQUFFLEdBQUc7Q0FDWDs7QUF4S0wsQUEwS0ksb0JBMUtnQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQWN0QixFQUFFLEFBQUEsZUFBZSxDQUFDO0VBQ2hCLEtBQUssRUFBRSxFQUFFO0VBQ1QsV0FBVyxFQUFFLEtBQUs7RUFDbEIsY0FBYyxFQUFFLENBQUM7Q0FDbEI7O0FBOUtMLEFBZ0xJLG9CQWhMZ0IsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FvQnRCLEVBQUUsQUFBQSxNQUFNLENBQUMsRUFBRSxDQUFDO0VBQ1YsV0FBVyxFQUFFLEdBQUc7Q0FDakI7O0FBbExMLEFBb0xJLG9CQXBMZ0IsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0F3QnRCLEVBQUUsQUFBQSxRQUFRLENBQUM7RUFDVCxXQUFXLEVBQUUsT0FBTztFQUNwQixTQUFTLEVBQUUsT0FBTztFQUNsQixhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUF4TEwsQUEwTEksb0JBMUxnQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQThCdEIsRUFBRSxBQUFBLE1BQU07QUExTFosb0JBQW9CLENBNEpsQixLQUFLLEFBQUEsbUJBQW1CLENBK0J0QixFQUFFLEFBQUEsTUFBTSxDQUFDO0VBQ1AsS0FBSyxFQUFFLEdBQUc7Q0FDWDs7QUE3TEwsQUFvTUksb0JBcE1nQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQXdDdEIsRUFBRSxBQUFBLFNBQVM7QUFwTWYsb0JBQW9CLENBNEpsQixLQUFLLEFBQUEsbUJBQW1CLENBeUN0QixFQUFFLEFBQUEsU0FBUyxDQUFDO0VBQ1YsS0FBSyxFQUFFLEVBQUU7Q0FDVjs7QUF2TUwsQUF5TUksb0JBek1nQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQTZDdEIsRUFBRSxBQUFBLGdCQUFnQixDQUFDLEVBQUU7QUF6TXpCLG9CQUFvQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQThDdEIsRUFBRSxBQUFBLGdCQUFnQixDQUFDLEVBQUUsQ0FBQztFQUNwQixLQUFLLEVqRi9LQyxPQUFPO0NpRmdMZDs7QUE1TUwsQUE4TUksb0JBOU1nQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQWtEdEIsaUJBQWlCLENBQUM7RUFDaEIsS0FBSyxFQUFFLE9BQU87RUFDZCxPQUFPLEVBQUUsS0FBSztFQUNkLE1BQU0sRUFBRSxNQUFNO0VBQ2QsU0FBUyxFQUFFLEdBQUc7Q0FDZjs7QUFuTkwsQUFxTkksb0JBck5nQixDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQXlEdEIsZ0JBQWdCLENBQUM7RUFDZixLQUFLLEVqRmxNQyxPQUFPO0VpRm1NYixPQUFPLEVBQUUsS0FBSztFQUNkLE1BQU0sRUFBRSxNQUFNO0VBQ2QsU0FBUyxFQUFFLEtBQUs7Q0FDakI7O0FBMU5MLEFBNE5JLG9CQTVOZ0IsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FnRXRCLGNBQWMsQ0FBQztFQUNiLE9BQU8sRUFBRSxpQkFBaUI7Q0FpQjNCOztBQTlPTCxBQStOTSxvQkEvTmMsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FnRXRCLGNBQWMsQ0FHWixnQkFBZ0IsQ0FBQyxDQUFDLENBQUM7RUFDakIsVUFBVSxFQUFFLElBQUk7Q0FDakI7O0FBak9QLEFBbU9NLG9CQW5PYyxDQTRKbEIsS0FBSyxBQUFBLG1CQUFtQixDQWdFdEIsY0FBYyxDQU9aLG1CQUFtQixDQUFDLENBQUMsQ0FBQztFQUNwQixVQUFVLEVBQUUsS0FBSztDQUNsQjs7QUFyT1AsQUF1T00sb0JBdk9jLENBNEpsQixLQUFLLEFBQUEsbUJBQW1CLENBZ0V0QixjQUFjLENBV1osYUFBYSxDQUFDLENBQUMsQ0FBQztFQUNkLFVBQVUsRUFBRSxLQUFLO0NBQ2xCOztBQXpPUCxBQTJPTSxvQkEzT2MsQ0E0SmxCLEtBQUssQUFBQSxtQkFBbUIsQ0FnRXRCLGNBQWMsQ0FlWixhQUFhLENBQUMsQ0FBQyxDQUFDO0VBQ2QsVUFBVSxFQUFFLEtBQUs7Q0FDbEI7O0F2RFZDLE1BQU0sRUFBRSxTQUFTLEVBQUUsSUFBSTtFdURlN0IsQUFDRSxjQURZLENBQ1osZ0JBQWdCLENBQUM7SUFDZixLQUFLLEVBQUUsR0FBRztJQUNWLE9BQU8sRUFBRSxZQUFZO0dBQ3RCO0VBSkgsQUFNRSxjQU5ZLENBTVosaUJBQWlCLENBQUM7SUFDaEIsS0FBSyxFQUFFLEdBQUc7SUFDVixPQUFPLEVBQUUsWUFBWTtHQUN0QjtFQVRILEFBV0UsY0FYWSxDQVdaLG1CQUFtQixDQUFDO0lBQ2xCLEtBQUssRUFBRSxHQUFHO0lBQ1YsT0FBTyxFQUFFLFlBQVk7R0FDdEI7OztBQUlMLEFBQ0UsS0FERyxBQUFBLHlCQUF5QixDQUM1QixFQUFFLEFBQUEsY0FBYyxDQUFDO0VBQ2YsV0FBVyxFQUFFLE1BQU07RUFDbkIsS0FBSyxFQUFFLEdBQUc7Q0FPWDs7QXZEM0NLLE1BQU0sRUFBRSxTQUFTLEVBQUUsSUFBSTtFdURpQy9CLEFBS00sS0FMRCxBQUFBLHlCQUF5QixDQUM1QixFQUFFLEFBQUEsY0FBYyxDQUlaLENBQUMsQ0FBQztJQUNBLGFBQWEsRUFBRSxLQUFLO0lBQ3BCLEtBQUssRUFBRSxLQUFLO0dBQ2I7OztBQVJQLEFBWUUsS0FaRyxBQUFBLHlCQUF5QixDQVk1QixFQUFFLEFBQUEsS0FBSyxDQUFDO0VBQ04sS0FBSyxFQUFFLEdBQUc7Q0FDWDs7QUFHSCxBQUFBLHVCQUF1QixDQUFDO0VBQ3RCLFVBQVUsRUFBRSxDQUFDO0NBQ2Q7O0FBRUQsQUFBQSxlQUFlLENBQUM7RUFDZCxjQUFjLEVBQUUsQ0FBQztFQUNqQixVQUFVLEVBQUUsS0FBSztFQUNqQixPQUFPLEVBQUUsS0FBSztDQTJCZjs7QUE5QkQsQUFLRSxlQUxhLENBS2IsQ0FBQyxDQUFDO0VBQ0EsS0FBSyxFakYvUUEsT0FBTztDaUZnUmI7O0FBUEgsQUFTRSxlQVRhLENBU2IsT0FBTyxDQUFDO0VBQ04sZ0JBQWdCLEVqRm5SWCxPQUFPO0VpRm9SWixhQUFhLEVBQUUsR0FBRztDQUtuQjs7QUFoQkgsQUFhSSxlQWJXLENBU2IsT0FBTyxBQUlKLE1BQU0sQ0FBQztFQUNOLGdCQUFnQixFQXpTRCxPQUFPO0NBMFN2Qjs7QUFmTCxBQWtCRSxlQWxCYSxDQWtCYixVQUFVLENBQUM7RUFDVCxLQUFLLEVqRm5SQyxPQUFPO0VpRm9SYixnQkFBZ0IsRUFBRSxXQUFXO0VBQzdCLFVBQVUsRUFBRSxJQUFJO0VBQ2hCLGVBQWUsRUFBRSxTQUFTO0NBTzNCOztBQTdCSCxBQXdCSSxlQXhCVyxDQWtCYixVQUFVLEFBTVAsTUFBTSxDQUFDO0VBQ04sZ0JBQWdCLEVBQUUsV0FBVztFQUM3QixVQUFVLEVBQUUsSUFBSTtFQUNoQixLQUFLLEVqRjVSSyxPQUFPO0NpRjZSbEI7O0F2RGxGRyxNQUFNLEVBQUUsU0FBUyxFQUFFLElBQUk7RXVEc0QvQixBQVNFLGVBVGEsQ0FTYixPQUFPLENBd0JHO0lBQ04sVUFBVSxFQUFFLEtBQUs7SUFDakIsV0FBVyxFQUFFLFlBQVk7R0FDMUI7OztBQUtMLEFBQ0UsYUFEVyxDQUNYLEtBQUssQUFBQSxTQUFTLENBQUM7RUFDYixVQUFVLEVBQUUsR0FBRztDQXNEaEI7O0FBeERILEFBSUksYUFKUyxDQUNYLEtBQUssQUFBQSxTQUFTLENBR1osRUFBRSxDQUFDLEVBQUUsQ0FBQztFcEQxVFIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJRRSxJQUFJO0VxQkpmLFdBQVcsRUFwRUMsT0FBeUI7Q29EMlF0Qzs7QXZEL0dHLE1BQU0sQ0FBQyxLQUFLO0V1RCtGcEIsQUFJSSxhQUpTLENBQ1gsS0FBSyxBQUFBLFNBQVMsQ0FHWixFQUFFLENBQUMsRUFBRSxDQUFDO0lwRGhUTixXQUFXLEV0QklXLFVBQVU7RzBFd1QvQjs7O0F2RC9HRyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVEK0ZwQyxBQUlJLGFBSlMsQ0FDWCxLQUFLLEFBQUEsU0FBUyxDQUdaLEVBQUUsQ0FBQyxFQUFFLENBQUM7SXBEbkxGLFNBQVMsRXJCQUEsSUFBSTtJcUJJYixXQUFXLEVBaEZELElBQXlCO0dvRDJRdEM7OztBdkQvR0csTUFBTSxDQUFDLEtBQUs7RXVEK0ZwQixBQUlJLGFBSlMsQ0FDWCxLQUFLLEFBQUEsU0FBUyxDQUdaLEVBQUUsQ0FBQyxFQUFFLENBQUM7SXBEeExGLFNBQVMsRXJCU0EsSUFBSTtJcUJSYixXQUFXLEVyQlNBLEdBQUc7R3lFMExqQjs7O0FBaEJMLEFBT00sYUFQTyxDQUNYLEtBQUssQUFBQSxTQUFTLENBR1osRUFBRSxDQUFDLEVBQUUsQ0FHSCxNQUFNLEFBQUEsT0FBTyxDQUFDO0VBQ1osV0FBVyxFQUFFLEdBQUc7RUFDaEIsU0FBUyxFQUFFLEtBQUs7Q0FDakI7O0FBVlAsQUFZTSxhQVpPLENBQ1gsS0FBSyxBQUFBLFNBQVMsQ0FHWixFQUFFLENBQUMsRUFBRSxDQVFILENBQUMsQ0FBQztFQUNBLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLFNBQVMsRUFBRSxLQUFLO0NBQ2pCOztBQWZQLEFBa0JJLGFBbEJTLENBQ1gsS0FBSyxBQUFBLFNBQVMsQ0FpQlosRUFBRSxDQUFDLEVBQUUsQ0FBQztFQUNKLFdBQVcsRUFBRSxNQUFNO0NBQ3BCOztBQXBCTCxBQXVCTSxhQXZCTyxDQUNYLEtBQUssQUFBQSxTQUFTLENBcUJaLEVBQUUsQ0FDQSxFQUFFLEFBQUEsWUFBWSxDQUFDO0VBQ2IsS0FBSyxFQUFFLEdBQUc7Q0FDWDs7QUF6QlAsQUEyQk0sYUEzQk8sQ0FDWCxLQUFLLEFBQUEsU0FBUyxDQXFCWixFQUFFLENBS0EsRUFBRSxBQUFBLE9BQU8sQ0FBQztFQUNSLEtBQUssRUFBRSxHQUFHO0VBQ1YsVUFBVSxFQUFFLElBQUk7Q0FDakI7O0FBOUJQLEFBZ0NNLGFBaENPLENBQ1gsS0FBSyxBQUFBLFNBQVMsQ0FxQlosRUFBRSxDQVVBLEVBQUUsQUFBQSxRQUFRLENBQUM7RUFDVCxLQUFLLEVBQUUsR0FBRztFQUNWLFVBQVUsRUFBRSxJQUFJO0NBQ2pCOztBQW5DUCxBQXFDTSxhQXJDTyxDQUNYLEtBQUssQUFBQSxTQUFTLENBcUJaLEVBQUUsQ0FlQSxFQUFFLEFBQUEsY0FBYyxDQUFDO0VBQ2YsYUFBYSxFQUFFLEdBQUc7Q0FFbkI7O0FBeENQLEFBMENNLGFBMUNPLENBQ1gsS0FBSyxBQUFBLFNBQVMsQ0FxQlosRUFBRSxDQW9CQSxPQUFPLENBQUM7RUFDTixXQUFXLEVBQUUsSUFBSTtDQUVsQjs7QUE3Q1AsQUErQ00sYUEvQ08sQ0FDWCxLQUFLLEFBQUEsU0FBUyxDQXFCWixFQUFFLENBeUJBLFNBQVMsQ0FBQztFQUNSLEtBQUssRWpGbFdKLE9BQU87RWlGbVdSLFdBQVcsRUFBRSxNQUFNO0NBS3BCOztBQXREUCxBQW1EUSxhQW5ESyxDQUNYLEtBQUssQUFBQSxTQUFTLENBcUJaLEVBQUUsQ0F5QkEsU0FBUyxDQUlQLGVBQWUsQ0FBQztFQUNkLGdCQUFnQixFQUFFLDRDQUE0QztDQUMvRDs7QUFyRFQsQUEwREUsYUExRFcsQ0EwRFgsV0FBVyxDQUFDO0VBQ1YsYUFBYSxFQUFFLEdBQUc7RUFDbEIsZ0JBQWdCLEVqRi9WUixPQUFPO0VpRmdXZixPQUFPLEVBQUUsR0FBRztFQUNaLEtBQUssRUFBRSxJQUFJO0NBb0JaOztBQWxGSCxBQWdFSSxhQWhFUyxDQTBEWCxXQUFXLENBTVQsZ0JBQWdCLENBQUM7RUFDZixVQUFVLEVBQUUsQ0FBQztDQU1kOztBQXZFTCxBQW1FTSxhQW5FTyxDQTBEWCxXQUFXLENBTVQsZ0JBQWdCLENBR2QsSUFBSSxDQUFDO0VwRHpYVCxXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQk5FLElBQUk7RXFCVWYsV0FBVyxFQXBFQyxJQUF5QjtFb0RnVW5DLE9BQU8sRUFBRSxLQUFLO0NBQ2Y7O0F2RHJLQyxNQUFNLENBQUMsS0FBSztFdUQrRnBCLEFBbUVNLGFBbkVPLENBMERYLFdBQVcsQ0FNVCxnQkFBZ0IsQ0FHZCxJQUFJLENBQUM7SXBEL1dQLFdBQVcsRXRCSVcsVUFBVTtHMEU4VzdCOzs7QXZEcktDLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFdUQrRnBDLEFBbUVNLGFBbkVPLENBMERYLFdBQVcsQ0FNVCxnQkFBZ0IsQ0FHZCxJQUFJLENBQUM7SXBEbFBILFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHb0RpVXBDOzs7QXZEcktDLE1BQU0sQ0FBQyxLQUFLO0V1RCtGcEIsQUFtRU0sYUFuRU8sQ0EwRFgsV0FBVyxDQU1ULGdCQUFnQixDQUdkLElBQUksQ0FBQztJcER2UEgsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHeUU4UGhCOzs7QUF0RVAsQUEwRU0sYUExRU8sQ0EwRFgsV0FBVyxBQWVSLFNBQVMsQ0FDUixPQUFPLENBQUM7RUFDTixLQUFLLEVqRjdYSixPQUFPO0NpRmtZVDs7QUFoRlAsQUE2RVEsYUE3RUssQ0EwRFgsV0FBVyxBQWVSLFNBQVMsQ0FDUixPQUFPLENBR0wsZUFBZSxDQUFDO0VBQ2QsZ0JBQWdCLEVBQUUsNENBQTRDO0NBQy9EOztBQS9FVCxBQXFGSSxhQXJGUyxDQW9GWCxlQUFlLENBQ2IsTUFBTSxDQUFDO0VBQ0wsT0FBTyxFQUFFLEtBQUs7Q0FLZjs7QUEzRkwsQUF3Rk0sYUF4Rk8sQ0FvRlgsZUFBZSxDQUNiLE1BQU0sQ0FHSixDQUFDLEFBQUEsY0FBYyxDQUFDO0VBQ2QsYUFBYSxFQUFFLEdBQUc7Q0FDbkI7O0FBMUZQLEFBNkZJLGFBN0ZTLENBb0ZYLGVBQWUsQ0FTYixZQUFZLENBQUM7RUFDWCxXQUFXLEVBQUUsTUFBTTtFQUNuQixhQUFhLEVBQUUsR0FBRztFcERyWnRCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCTkUsSUFBSTtFcUJVZixXQUFXLEVBcEVDLElBQXlCO0NvRGtXdEM7O0F2RHRNRyxNQUFNLENBQUMsS0FBSztFdUQrRnBCLEFBNkZJLGFBN0ZTLENBb0ZYLGVBQWUsQ0FTYixZQUFZLENBQUM7SXBEelliLFdBQVcsRXRCSVcsVUFBVTtHMEUrWS9COzs7QXZEdE1HLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFdUQrRnBDLEFBNkZJLGFBN0ZTLENBb0ZYLGVBQWUsQ0FTYixZQUFZLENBQUM7SXBENVFULFNBQVMsRXJCZEEsSUFBSTtJcUJrQmIsV0FBVyxFQWhGRCxPQUF5QjtHb0RrV3RDOzs7QXZEdE1HLE1BQU0sQ0FBQyxLQUFLO0V1RCtGcEIsQUE2RkksYUE3RlMsQ0FvRlgsZUFBZSxDQVNiLFlBQVksQ0FBQztJcERqUlQsU0FBUyxFckJMQSxJQUFJO0lxQk1iLFdBQVcsRXJCTEEsSUFBSTtHeUUrUmxCOzs7QUF2R0wsQUFrR00sYUFsR08sQ0FvRlgsZUFBZSxDQVNiLFlBQVksQ0FLVixJQUFJLENBQUM7RUFDSCxPQUFPLEVBQUUsS0FBSztFcER6WnBCLFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCcEJFLElBQUk7RXFCd0JmLFdBQVcsRUFwRUMsT0FBeUI7RW9EZ1duQyxXQUFXLEVBQUUsR0FBRztDQUNqQjs7QXZEck1DLE1BQU0sQ0FBQyxLQUFLO0V1RCtGcEIsQUFrR00sYUFsR08sQ0FvRlgsZUFBZSxDQVNiLFlBQVksQ0FLVixJQUFJLENBQUM7SXBEOVlQLFdBQVcsRXRCSVcsVUFBVTtHMEU4WTdCOzs7QXZEck1DLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFdUQrRnBDLEFBa0dNLGFBbEdPLENBb0ZYLGVBQWUsQ0FTYixZQUFZLENBS1YsSUFBSSxDQUFDO0lwRGpSSCxTQUFTLEVyQjVCQSxJQUFJO0lxQmdDYixXQUFXLEVBaEZELElBQXlCO0dvRGlXcEM7OztBdkRyTUMsTUFBTSxDQUFDLEtBQUs7RXVEK0ZwQixBQWtHTSxhQWxHTyxDQW9GWCxlQUFlLENBU2IsWUFBWSxDQUtWLElBQUksQ0FBQztJcER0UkgsU0FBUyxFckJuQkEsSUFBSTtJcUJvQmIsV0FBVyxFckJuQkEsSUFBSTtHeUU0U2hCOzs7QUF0R1AsQUEyR0ksYUEzR1MsQ0EwR1gsU0FBUyxDQUNQLG1CQUFtQixDQUFDO0VBQ2xCLEtBQUssRUFBRSxHQUFHO0NBQ1g7O0FBN0dMLEFBK0dJLGFBL0dTLENBMEdYLFNBQVMsQ0FLUCxpQkFBaUIsQ0FBQztFQUNoQixLQUFLLEVBQUUsR0FBRztDQUNYOztBQWpITCxBQW1ISSxhQW5IUyxDQTBHWCxTQUFTLENBU1AsY0FBYyxDQUFDO0VBQ2IsS0FBSyxFQUFFLEdBQUc7Q0FDWDs7QUFySEwsQUF1SEksYUF2SFMsQ0EwR1gsU0FBUyxDQWFQLGVBQWUsQ0FBQztFQUNkLEtBQUssRUFBRSxHQUFHO0NBVVg7O0FBbElMLEFBMEhNLGFBMUhPLENBMEdYLFNBQVMsQ0FhUCxlQUFlLENBR2IsTUFBTSxDQUFDO0VBQ0wsV0FBVyxFQUFFLE1BQU07RUFDbkIsU0FBUyxFQUFFLEtBQUs7Q0FLakI7O0FBaklQLEFBOEhRLGFBOUhLLENBMEdYLFNBQVMsQ0FhUCxlQUFlLENBR2IsTUFBTSxDQUlKLENBQUMsQUFBQSxjQUFjLENBQUM7RUFDZCxhQUFhLEVBQUUsQ0FBQztDQUNqQjs7QUFoSVQsQUFxSUUsYUFySVcsQ0FxSVgsQ0FBQyxBQUFBLFdBQVcsQ0FBQztFQUNYLFNBQVMsRUFBRSxlQUFlO0VBQzFCLEtBQUssRWpGemFFLE9BQU87RWlGMGFkLGdCQUFnQixFakZqYlYsT0FBTztFaUZrYmIsZUFBZSxFQUFFLElBQUk7RUFDckIsT0FBTyxFQUFFLE9BQU87RUFDaEIsT0FBTyxFQUFFLFlBQVk7RUFDckIsTUFBTSxFQUFFLGVBQWU7Q0FNeEI7O0FBbEpILEFBOElJLGFBOUlTLENBcUlYLENBQUMsQUFBQSxXQUFXLEFBU1QsTUFBTSxFQTlJWCxhQUFhLENBcUlYLENBQUMsQUFBQSxXQUFXLEFBVVQsTUFBTSxDQUFDO0VBQ04sZ0JBQWdCLEVqRjFiTixPQUFPO0NpRjJibEI7O0FBS0wsQUFBQSxDQUFDLEFBQUEsT0FBTyxBQUFBLFFBQVEsQ0FBQztFQUNmLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0FBRUQsQUFBQSxXQUFXLENBQUMsZ0JBQWdCLENBQUMsS0FBSyxDQUFDO0VBQ2pDLGFBQWEsRUFBRSxLQUFLO0NBQ3JCOztBQUVELEFBQUEsQ0FBQyxBQUFBLGdCQUFnQixDQUFDO0VBQ2hCLFNBQVMsRUFBRSxLQUFLO0NBQ2pCOztBQUVELEFBQ0UsZUFEYSxDQUNiLE9BQU8sQ0FBQztFQUNOLE1BQU0sRUFBRSxhQUFhO0NBS3RCOztBQVBILEFBSUksZUFKVyxDQUNiLE9BQU8sQ0FHTCxPQUFPLENBQUM7RUFDTixXQUFXLEVBQUUsTUFBTTtDQUNwQjs7QUFJTCxBQUFBLEVBQUUsQ0FBQyxPQUFPO0FBQ1YsRUFBRSxDQUFDLE9BQU87QUFDVixFQUFFLENBQUMsT0FBTyxDQUFDO0VBQ1QsU0FBUyxFQUFFLElBQUk7RUFDZixZQUFZLEVBQUUsR0FBRztFQUNqQixRQUFRLEVBQUUsUUFBUTtFQUNsQixHQUFHLEVBQUUsS0FBSztDQUNYOztBQUVELEFBQUEsV0FBVyxDQUFDO0VwRDNlVixXQUFXLEV2QkxXLEtBQUssRUFBRSxLQUFLLEVBQUUsVUFBVTtFdUJNOUMsc0JBQXNCLEVBQUUsV0FBVztFQUNuQyx1QkFBdUIsRUFBRSxTQUFTO0VBaUNsQyxXQUFXLEV0QlRlLEdBQUc7RXNCaUd6QixTQUFTLEVyQlFFLElBQUk7RXFCSmYsV0FBVyxFQXBFQyxPQUF5QjtFb0RrYnpDLEtBQUssRWpGN2RLLE9BQU87RWlGOGRqQixPQUFPLEVBQUUsS0FBSztDQUNmOztBdkR4Uk8sTUFBTSxDQUFDLEtBQUs7RXVEb1JwQixBQUFBLFdBQVcsQ0FBQztJcERqZVIsV0FBVyxFdEJJVyxVQUFVO0cwRWllbkM7OztBdkR4Uk8sTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1RG9ScEMsQUFBQSxXQUFXLENBQUM7SXBEcFdKLFNBQVMsRXJCQUEsSUFBSTtJcUJJYixXQUFXLEVBaEZELElBQXlCO0dvRG9iMUM7OztBdkR4Uk8sTUFBTSxDQUFDLEtBQUs7RXVEb1JwQixBQUFBLFdBQVcsQ0FBQztJcER6V0osU0FBUyxFckJTQSxJQUFJO0lxQlJiLFdBQVcsRXJCU0EsR0FBRztHeUVtV3JCOzs7QUFFRCxBQUFBLGtCQUFrQixDQUFDO0VwRGpmakIsV0FBVyxFdkJMVyxLQUFLLEVBQUUsS0FBSyxFQUFFLFVBQVU7RXVCTTlDLHNCQUFzQixFQUFFLFdBQVc7RUFDbkMsdUJBQXVCLEVBQUUsU0FBUztFQWlDbEMsV0FBVyxFdEJUZSxHQUFHO0VzQmlHekIsU0FBUyxFckJsQ0UsSUFBSTtFcUJzQ2YsV0FBVyxFQXBFQyxPQUF5QjtFb0R3YnpDLEtBQUssRWpGbmVLLE9BQU87RWlGb2VqQixPQUFPLEVBQUUsS0FBSztDQUVmOztBdkQvUk8sTUFBTSxDQUFDLEtBQUs7RXVEMFJwQixBQUFBLGtCQUFrQixDQUFDO0lwRHZlZixXQUFXLEV0QklXLFVBQVU7RzBFd2VuQzs7O0F2RC9STyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVEMFJwQyxBQUFBLGtCQUFrQixDQUFDO0lwRDFXWCxTQUFTLEVyQjFDQSxJQUFJO0lxQjhDYixXQUFXLEVBaEZELE9BQXlCO0dvRDJiMUM7OztBdkQvUk8sTUFBTSxDQUFDLEtBQUs7RXVEMFJwQixBQUFBLGtCQUFrQixDQUFDO0lwRC9XWCxTQUFTLEVyQmpDQSxJQUFJO0lxQmtDYixXQUFXLEVyQmpDQSxJQUFJO0d5RW9adEI7OztBdkQvUk8sTUFBTSxFQUFFLFNBQVMsRUFBRSxJQUFJO0V1RGlTN0IsOENBQThDO0VBQzlDLEFBRUUsS0FGRyxDQUFDLGlCQUFpQixDQUVyQixrQkFBa0IsQ0FBQztJQUNqQixNQUFNLEVBQUUsU0FBUztHQUNsQjs7O0FBSUwsQUFBQSxzQkFBc0IsQ0FBQztFQUNyQixHQUFHLEVBQUUsSUFBSTtFQUNULFFBQVEsRUFBRSxRQUFRO0VBQ2xCLGdCQUFnQixFQUFFLE9BQWlDO0VBQ25ELE1BQU0sRUFBRSxHQUFHLENBQUMsS0FBSyxDakY3ZlAsT0FBTztFaUY4ZmpCLEtBQUssRUFBRSxJQUFJO0VBQ1gsTUFBTSxFQUFFLElBQUk7RUFDWixPQUFPLEVBQUUsS0FBSztFQUNkLGFBQWEsRUFBRSxLQUFLO0NBS3JCOztBQWJELEFBVUUsc0JBVm9CLENBVWxCLENBQUMsQ0FBQztFQUNGLE1BQU0sRUFBRSxDQUFDO0NBQ1Y7O0FBR0gsQUFBQSxzQkFBc0IsQUFBQSxNQUFNO0FBQzVCLHNCQUFzQixBQUFBLE9BQU8sQ0FBQztFQUM1QixNQUFNLEVBQUUsSUFBSTtFQUNaLE1BQU0sRUFBRSxpQkFBaUI7RUFDekIsT0FBTyxFQUFFLEdBQUc7RUFDWixNQUFNLEVBQUUsQ0FBQztFQUNULEtBQUssRUFBRSxDQUFDO0VBQ1IsUUFBUSxFQUFFLFFBQVE7RUFDbEIsY0FBYyxFQUFFLElBQUk7Q0FDckI7O0FBRUQsQUFBQSxzQkFBc0IsQUFBQSxNQUFNLENBQUM7RUFDM0IsWUFBWSxFQUFFLHNCQUFzQjtFQUNwQyxtQkFBbUIsRUFBRSxPQUFpQztFQUN0RCxZQUFZLEVBQUUsSUFBSTtFQUNsQixJQUFJLEVBQUUsR0FBRztFQUNULFdBQVcsRUFBRSxLQUFLO0NBQ25COztBQUVELEFBQUEsc0JBQXNCLEFBQUEsT0FBTyxDQUFDO0VBQzVCLFlBQVksRUFBRSxzQkFBc0I7RUFDcEMsbUJBQW1CLEVqRjdoQlQsT0FBTztFaUY4aEJqQixZQUFZLEVBQUUsSUFBSTtFQUNsQixJQUFJLEVBQUUsR0FBRztFQUNULFdBQVcsRUFBRSxLQUFLO0NBQ25COztBQUVELEFBQUEsYUFBYSxDQUFDO0VBQ1osZ0JBQWdCLEVqRi9oQlIsT0FBTztFaUZnaUJmLE9BQU8sRUFBRSxPQUFPO0VBQ2hCLFdBQVcsRUFBRSxLQUFLO0VBQ2xCLEtBQUssRWpGM2hCSSxPQUFPO0NpRmtpQmpCOztBQVhELEFBTUUsYUFOVyxBQU1WLG1CQUFtQixDQUFDO0VBQ25CLE9BQU8sRUFBRSxLQUFLO0VBQ2QsV0FBVyxFQUFFLENBQUM7RUFDZCxhQUFhLEVBQUUsR0FBRztDQUNuQjs7QUFHSCxBQUFBLEVBQUUsQ0FBQyxJQUFJLEFBQUEsT0FBTyxDQUFDO0VBQ2IsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFQUFFLEtBQUs7Q0FDWDs7QUFFRCxBQUFBLGtCQUFrQixDQUFDLElBQUksQUFBQSxPQUFPLENBQUM7RUFDN0IsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFQUFFLEtBQUs7Q0FDWDs7QUFFRCxBQUFBLGVBQWUsQ0FBQztFQUNkLGdCQUFnQixFQUFFLHdDQUF3QztDQUMzRDs7QUFFRCxBQUFBLG1CQUFtQixDQUFDO0VBQ2xCLGdCQUFnQixFQUFFLDRDQUE0QztDQUMvRDs7QUFFRCxBQUNFLG9CQURrQixDQUNsQixXQUFXLENBQUM7RUFDVixNQUFNLEVBQUUsV0FBVztDQUNwQjs7QUFISCxBQUtFLG9CQUxrQixDQUtsQixFQUFFLENBQUMsSUFBSSxDQUFDO0VBQ04sWUFBWSxFQUFFLEtBQUs7RUFDbkIsYUFBYSxFQUFFLEdBQUc7Q0FDbkI7O0FBSUgsQUFBQSxZQUFZLENBQUM7RUFDWCxXQUFXLEVBQUUsS0FBSztDQUtuQjs7QUFORCxBQUdFLFlBSFUsQ0FHVixRQUFRLEFBQUEsYUFBYSxDQUFDO0VBQ3BCLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0F2RHBZSyxNQUFNLEVBQUUsU0FBUyxFQUFFLElBQUk7RXVEK1gvQixBQUFBLFlBQVksQ0FRRztJQUNYLFdBQVcsRUFBRSxZQUFZO0dBQzFCOzs7QUFJSCxBQUFBLG1CQUFtQixDQUFDO0VBQ2xCLFFBQVEsRUFBRSxLQUFLO0VBQ2YsTUFBTSxFQUFFLENBQUM7RUFDVCxJQUFJLEVBQUUsQ0FBQztFQUNQLGdCQUFnQixFakZ4bEJOLE9BQU87RWlGeWxCakIsS0FBSyxFQUFFLGlCQUFpQjtFQUN4QixLQUFLLEVBQUUsSUFBSTtFQUNYLE9BQU8sRUFBRSxhQUFhO0VBQ3RCLE1BQU0sRUFBRSxHQUFHO0NBS1o7O0FBYkQsQUFVRSxtQkFWaUIsQ0FVakIsR0FBRyxDQUFDO0VBQ0YsVUFBVSxFQUFFLE1BQU07Q0FDbkI7O0FBSUgsQUFBQSxFQUFFLENBQUMsTUFBTSxDQUFDO0VBQ1IsU0FBUyxFQUFFLEtBQUs7RUFDaEIsTUFBTSxFQUFFLEtBQUs7Q0FDZDs7QUFFRCxBQUFBLEVBQUUsQ0FBQyxNQUFNLENBQUM7RUFDUixTQUFTLEVBQUUsS0FBSztFQUNoQixNQUFNLEVBQUUsS0FBSztDQUNkOztBQVFELEFBQUEsTUFBTSxDQUFDLFNBQVMsQ0FBQztFQUVmLGFBQWEsRUFBRSxJQUFJO0NBQ3BCOztBQUNELE1BQU0sRUFBRSxTQUFTLEVBQUUsS0FBSztFQXBCeEIsQUFBQSxFQUFFLENBQUMsTUFBTSxDQXFCRztJQUNSLFNBQVMsRUFBRSxLQUFLO0dBQ2pCO0VBbEJILEFBQUEsRUFBRSxDQUFDLE1BQU0sQ0FvQkc7SUFDUixTQUFTLEVBQUUsS0FBSztHQUNqQjs7O0FBSUgsQUFBQSxXQUFXLENBQUM7RUFDVixNQUFNLEVBQUUsR0FBRyxDQUFDLEtBQUssQ2pGbm9CUCxPQUFPO0VpRm9vQmpCLGdCQUFnQixFakZub0JOLE9BQU87RWlGb29CakIsT0FBTyxFQUFFLEdBQUc7RUFDWixPQUFPLEVBQUUsS0FBSztFQUNkLE1BQU0sRUFBRSxVQUFVO0NBU25COztBQWRELEFBT0UsV0FQUyxDQU9ULEVBQUUsQ0FBQztFQUNELFVBQVUsRUFBRSxDQUFDO0NBQ2Q7O0FBVEgsQUFXRSxXQVhTLENBV1QsT0FBTyxDQUFDO0VBQ04sTUFBTSxFQUFFLFNBQVM7Q0FDbEI7O0FBRUgsTUFBTSxFQUFFLFNBQVMsRUFBRSxLQUFLO0VBQ3RCLEFBQ0UsV0FEUyxDQUNULE9BQU8sQUFBQSxjQUFjLENBQUM7SUFDcEIsYUFBYSxFQUFFLEdBQUc7R0FDbkI7OztBQUtMLEFBQUEscUJBQXFCLENBQUM7RUFDcEIsR0FBRyxFQUFFLElBQUk7RUFDVCxLQUFLLEVBQUUsSUFBSTtFQUNYLFFBQVEsRUFBRSxRQUFRO0VBQ2xCLGdCQUFnQixFakZ2cUJOLE9BQU87RWlGd3FCakIsS0FBSyxFakZqcUJJLE9BQU87RWlGa3FCaEIsT0FBTyxFQUFFLFNBQVM7RUFDbEIsYUFBYSxFQUFFLElBQUk7Q0FDcEI7O0FBRUQsQUFBQSxhQUFhLENBQUM7RUFDWixVQUFVLEVqRjlxQkEsT0FBTztFaUYrcUJqQixLQUFLLEVqRnhxQkksT0FBTztFaUZ5cUJoQixPQUFPLEVBQUUsWUFBWTtFQUNyQixLQUFLLEVBQUUsS0FBSztFQUNaLFFBQVEsRUFBRSxRQUFRO0VBQ2xCLEdBQUcsRUFBRSxLQUFLO0VBQ1YsS0FBSyxFQUFFLElBQUk7RUFDWCxLQUFLLEVBQUUsSUFBSTtFQUNYLE9BQU8sRUFBRSxXQUFXO0VBQ3BCLFVBQVUsRUFBRSxNQUFNO0NBQ25COztBQUVELEFBQUEsYUFBYSxBQUFBLE9BQU8sQ0FBQztFQUNuQixVQUFVLEVBQUUsSUFBSSxDQUFDLEtBQUssQ2pGM3JCWixPQUFPO0VpRjRyQmpCLFdBQVcsRUFBRSxzQkFBc0I7RUFDbkMsWUFBWSxFQUFFLHNCQUFzQjtFQUNwQyxPQUFPLEVBQUUsRUFBRTtFQUNYLE1BQU0sRUFBRSxDQUFDO0VBQ1QsSUFBSSxFQUFFLEdBQUc7RUFDVCxRQUFRLEVBQUUsUUFBUTtFQUNsQixNQUFNLEVBQUUsS0FBSztFQUNiLEtBQUssRUFBRSxDQUFDO0NBQ1Q7O0FBR0QsQUFDRSx3QkFEc0IsQ0FDdEIsS0FBSyxDQUFDO0VBQ0osYUFBYSxFQUFFLEtBQUs7Q0FDckI7O0FBSUgsQUFBQSxhQUFhLENBQUM7RUFDWixNQUFNLEVBQUUsS0FBSztFQUNiLGFBQWEsRUFBRSxpQkFBaUI7RUFDaEMsTUFBTSxFQUFFLEtBQUs7Q0FDZDs7QUFHRCxBQUFBLGFBQWEsQ0FBQztFQUNaLFVBQVUsRUFBRSxDQUFDO0NBQ2Q7O0FBR0QsQUFBQSxzQkFBc0IsQ0FBQztFQUNyQixnQkFBZ0IsRWpGaHRCTixPQUFPO0VpRml0QmpCLE1BQU0sRUFBRSxJQUFJLENBQUMsS0FBSyxDakZudEJSLE9BQU87RWlGb3RCakIsT0FBTyxFQUFFLFNBQVM7RUFDbEIsVUFBVSxFQUFFLEdBQUc7Q0FDaEI7O0FBRUQsQUFBQSxPQUFPLENBQUM7RUFDTixRQUFRLEVBQUUseUJBQXlCO0VBQ25DLFFBQVEsRUFBRSxpQkFBaUI7RUFDM0IsR0FBRyxFQUFFLENBQUM7Q0FDUDs7QUFFRCxBQUFBLFlBQVksQ0FBQztFQUNYLFFBQVEsRUFBRSxRQUFRO0NBYW5COztBQWRELEFBR0UsWUFIVSxDQUdWLEdBQUcsQ0FBQztFQUNGLE1BQU0sRUFBRSxJQUFJO0NBQ2I7O0FBTEgsQUFPRSxZQVBVLENBT1Ysa0JBQWtCLENBQUM7RUFDakIsYUFBYSxFQUFFLENBQUM7RUFDaEIsVUFBVSxFQUFFLElBQUk7RUFDaEIsU0FBUyxFQUFFLEtBQUs7RUFDaEIsUUFBUSxFQUFFLFFBQVE7RUFDbEIsT0FBTyxFQUFFLENBQUM7Q0FDWDs7QUFHSCxBQUFBLEdBQUcsQUFBQSxXQUFXLENBQUM7RUFDYixXQUFXLEVBQUUsR0FBRztFQUNoQixVQUFVLEVBQUUsSUFBSTtFQUNoQixVQUFVLEVBQUUsSUFBSTtFQUNoQixXQUFXLEVBQUUsR0FBRztFQUNoQixjQUFjLEVBQUUsTUFBTTtDQUN2Qjs7QUFJRCxBQUFBLGlCQUFpQjtBQUNqQixhQUFhLENBQUM7RUFDWixVQUFVLEVBQUUsVUFBVTtFQUN0QixPQUFPLEVBQUUsS0FBSztDQUNmOztBQUpELEFBQUEsaUJBQWlCO0FBQ2pCLGFBQWEsQ0FNQztFQUNaLEtBQUssRUFBRSxJQUFJO0NBS1o7O0F2RC9qQk8sTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1RGtqQnBDLEFBQUEsaUJBQWlCO0VBQ2pCLGFBQWEsQ0FNQztJQUdWLEtBQUssRUFBRSxLQUFLO0lBQ1osS0FBSyxFQUFFLElBQUk7R0FFZDs7O0FBR0QsQUFBQSxhQUFhO0FBQ2IsaUJBQWlCLENBQUM7RUFDaEIsVUFBVSxFQUFFLFVBQVU7RUFDdEIsT0FBTyxFQUFFLE1BQU07Q0FDaEI7O0FBSkQsQUFBQSxhQUFhO0FBQ2IsaUJBQWlCLENBTUM7RUFDaEIsS0FBSyxFQUFFLElBQUk7Q0FLWjs7QXZEL2tCTyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVEa2tCcEMsQUFBQSxhQUFhO0VBQ2IsaUJBQWlCLENBTUM7SUFHZCxLQUFLLEVBQUUsR0FBRztJQUNWLEtBQUssRUFBRSxJQUFJO0dBRWQ7OztBQUVELEFBQUEsa0JBQWtCLENBQUM7RUFDakIsZ0JBQWdCLEVqRjV4QlIsT0FBTztFaUY2eEJmLEtBQUssRWpGdHhCSSxPQUFPO0VpRnV4QmhCLE9BQU8sRUFBRSxpQkFBaUI7Q0FVM0I7O0FBYkQsQUFLRSxrQkFMZ0IsQ0FLaEIsQ0FBQyxDQUFDO0VBQ0EsS0FBSyxFakYxeEJFLE9BQU87Q2lGMnhCZjs7QUFQSCxBQVNFLGtCQVRnQixDQVNoQixDQUFDLEFBQUEsTUFBTTtBQVRULGtCQUFrQixDQVVoQixDQUFDLEFBQUEsTUFBTSxDQUFDO0VBQ04sS0FBSyxFakZ2eUJPLE9BQU87Q2lGd3lCcEI7O0FBSUgsQUFDRSxlQURhLENBQ2IsRUFBRSxBQUFBLGVBQWUsQUFBQSxjQUFjLENBQUM7RUFDOUIsVUFBVSxFQUFFLElBQUk7Q0FDakI7O0FBSEgsQUFLRSxlQUxhLENBS2IsSUFBSSxBQUFBLHlCQUF5QixDQUFDO0VBQzVCLEtBQUssRUFBRSxJQUFJO0NBQ1o7O0FBUEgsQUFTRSxlQVRhLENBU2IsTUFBTSxBQUFBLGVBQWUsQ0FBQztFQUNwQixLQUFLLEVBQUUsS0FBSztDQUNiOztBQUlILEFBQUEsa0JBQWtCLENBQUM7RUFDakIsTUFBTSxFQUFFLEtBQUs7RUFDYixLQUFLLEVBQUUsS0FBSztFQUNaLGdCQUFnQixFakZ0ekJQLE9BQU87RWlGdXpCaEIsS0FBSyxFakY1ekJJLE9BQU87RWlGNnpCaEIsYUFBYSxFQUFFLEdBQUc7RUFDbEIsT0FBTyxFQUFFLFlBQVk7RUFDckIsT0FBTyxFQUFFLEtBQUs7RUFDZCxVQUFVLEVBQUUsTUFBTTtFQUNsQixXQUFXLEVBQUUsSUFBSTtFQUNqQixNQUFNLEVBQUUsZ0JBQWdCO0NBQ3pCOztBQUVELEFBQUEsa0JBQWtCLENBQUM7RUFDakIsTUFBTSxFQUFFLEtBQUs7RUFDYixLQUFLLEVBQUUsS0FBSztFQUNaLGdCQUFnQixFakZ4MEJQLE9BQU87RWlGeTBCaEIsS0FBSyxFakZwMEJJLE9BQU87RWlGcTBCaEIsYUFBYSxFQUFFLEdBQUc7RUFDbEIsT0FBTyxFQUFFLFlBQVk7RUFDckIsT0FBTyxFQUFFLEtBQUs7RUFDZCxVQUFVLEVBQUUsTUFBTTtFQUNsQixXQUFXLEVBQUUsSUFBSTtFQUNqQixNQUFNLEVBQUUsa0JBQWtCO0NBQzNCOztBQUVELEFBQUEsa0JBQWtCLENBQUM7RUFDakIsT0FBTyxFQUFFLE9BQU87RUFDaEIsVUFBVSxFakZ0MUJGLE9BQU8sQ2lGczFCZ0Isa0VBQWtFLENBQUMsU0FBUyxDQUFDLEdBQUcsQ0FBQyxHQUFHO0NBMEZwSDs7QUE1RkQsQUFJRSxrQkFKZ0IsQUFJZix3QkFBd0IsQ0FBQztFQUN4QixVQUFVLEVqRnoxQkosT0FBTyxDaUZ5MUJrQixvQ0FBb0MsQ0FBQyxTQUFTLENBQUMsR0FBRyxDQUFDLElBQUk7Q0FDdkY7O0F2RGhwQkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V1RDBvQnBDLEFBQUEsa0JBQWtCLENBQUM7SUFRZixnQkFBZ0IsRUFBRSxlQUFlO0dBb0ZwQzs7O0FBNUZELEFBV0Usa0JBWGdCLEFBV2YsMkJBQTJCLENBQUM7RUFDM0IsVUFBVSxFakZoMkJKLE9BQU8sQ2lGZzJCa0IscURBQXFELENBQUMsU0FBUyxDQUFDLEdBQUcsQ0FBQyxHQUFHO0NBQ3ZHOztBdkR2cEJLLE1BQU0sRUFBRSxTQUFTLEVBQUUsU0FBUztFdUQwb0JwQyxBQUFBLGtCQUFrQixDQUFDO0lBZWYsZ0JBQWdCLEVBQUUsZUFBZTtHQTZFcEM7OztBQTVGRCxBQWtCRSxrQkFsQmdCLEFBa0JmLGdDQUFnQyxDQUFDO0VBQ2hDLFVBQVUsRWpGdjJCSixPQUFPLENpRnUyQmtCLG1EQUFtRCxDQUFDLFNBQVMsQ0FBQyxHQUFHLENBQUMsR0FBRztDQUNyRzs7QXZEOXBCSyxNQUFNLEVBQUUsU0FBUyxFQUFFLFNBQVM7RXVEMG9CcEMsQUFBQSxrQkFBa0IsQ0FBQztJQXNCZixnQkFBZ0IsRUFBRSxlQUFlO0dBc0VwQzs7O0FBNUZELEFBeUJFLGtCQXpCZ0IsQ0F5QmhCLGFBQWEsQ0FBQztFQUNaLGdCQUFnQixFakZ2MkJULE9BQU87RWlGdzJCZCxLQUFLLEVqRjcyQkUsT0FBTztDaUZrM0JmOztBQWhDSCxBQTZCSSxrQkE3QmMsQ0F5QmhCLGFBQWEsQUFJVixNQUFNLENBQUM7RUFDTixnQkFBZ0IsRWpGNzJCVixPQUFPO0NpRjgyQmQ7O0FBL0JMLEFBa0NFLGtCQWxDZ0IsQ0FrQ2hCLEVBQUUsQ0FBQztFQUNELEtBQUssRWpGaDNCRSxPQUFPO0NpRmkzQmY7O0FBcENILEFBc0NFLGtCQXRDZ0IsQ0FzQ2hCLEVBQUUsQ0FBQztFQUNELE9BQU8sRUFBRSxNQUFNO0VBQ2YsS0FBSyxFakZyM0JFLE9BQU87Q2lGczNCZjs7QUF6Q0gsQUEyQ0Usa0JBM0NnQixDQTJDaEIsRUFBRSxDQUFDO0VBQ0QsS0FBSyxFQUFFLEdBQUc7RUFDVixPQUFPLEVBQUUsT0FBTztDQXFCakI7O0F2RDVzQkssTUFBTSxFQUFFLFNBQVMsRUFBRSxJQUFJO0V1RDBvQi9CLEFBMkNFLGtCQTNDZ0IsQ0EyQ2hCLEVBQUUsQ0FBQztJQUlDLEtBQUssRUFBRSxJQUFJO0lBQ1gsVUFBVSxFQUFFLEtBQUs7R0FrQnBCOzs7QUFsRUgsQUFvRE0sa0JBcERZLENBMkNoQixFQUFFLENBUUEsRUFBRSxDQUNBLEVBQUUsQ0FBQztFQUNELGNBQWMsRUFBRSxHQUFHO0VBQ25CLE9BQU8sRUFBRSxZQUFZO0VBQ3JCLEtBQUssRUFBRSxHQUFHO0VBQ1YsTUFBTSxFQUFFLFdBQVc7Q0FJcEI7O0F2RHRzQkMsTUFBTSxFQUFFLFNBQVMsRUFBRSxJQUFJO0V1RDBvQi9CLEFBb0RNLGtCQXBEWSxDQTJDaEIsRUFBRSxDQVFBLEVBQUUsQ0FDQSxFQUFFLENBQUM7SUFNQyxLQUFLLEVBQUUsR0FBRztHQUViOzs7QUE1RFAsQUE4RE0sa0JBOURZLENBMkNoQixFQUFFLENBUUEsRUFBRSxDQVdBLElBQUksQ0FBQztFQUNILGNBQWMsRUFBRSxHQUFHO0NBQ3BCOztBQWhFUCxBQW9FRSxrQkFwRWdCLENBb0VoQixDQUFDLEFBQUEsS0FBSztBQXBFUixrQkFBa0IsQ0FxRWhCLENBQUMsQUFBQSxRQUFRLENBQUM7RUFDUixLQUFLLEVqRm41QkUsT0FBTyxDaUZtNUJlLFVBQVU7Q0FDeEM7O0FBdkVILEFBeUVFLGtCQXpFZ0IsQ0F5RWhCLE9BQU8sQ0FBQztFQUNOLGdCQUFnQixFakZ2NUJULE9BQU87RWlGdzVCZCxLQUFLLEVqRi81QkMsT0FBTztFaUZnNkJiLFdBQVcsRUFBRSxHQUFHO0NBT2pCOztBQW5GSCxBQThFSSxrQkE5RWMsQ0F5RWhCLE9BQU8sQUFLSixNQUFNLEVBOUVYLGtCQUFrQixDQXlFaEIsT0FBTyxBQU1KLE1BQU0sQ0FBQztFQUNOLGdCQUFnQixFakYvNUJWLE9BQU87RWlGZzZCYixLQUFLLEVqRnI2QkQsT0FBTztDaUZzNkJaOztBQWxGTCxBQXFGRSxrQkFyRmdCLENBcUZoQixhQUFhLENBQUM7RUFDWixnQkFBZ0IsRWpGbjZCVCxPQUFPO0VpRm82QmQsS0FBSyxFakZ6NkJFLE9BQU87RWlGMDZCZCxZQUFZLEVBQUUsS0FBSztFQUNuQixRQUFRLEVBQUUsUUFBUTtFQUNsQixHQUFHLEVBQUUsS0FBSztDQUNYOztBQUdILEFBQUEsWUFBWSxDQUFDO0VBQ1gsS0FBSyxFQUFFLEtBQUs7Q0FDYjs7QUM5OEJELEFBQUEsZUFBZSxDQUFDO0VBQ2QsVUFBVSxFQUFDLElBQUk7Q0FDaEI7O0FBQ0QsQUFBQSxlQUFlLENBQUM7RUFDZCxNQUFNLEVBQUUsV0FBVztDQVFwQjs7QUFURCxBQUVFLGVBRmEsQ0FFYixDQUFDLENBQUM7RUFDQSxZQUFZLEVBQUUsSUFBSTtDQUNuQjs7QUFKSCxBQUtFLGVBTGEsQ0FLYixDQUFDLEFBQUEsOEJBQThCLENBQUM7RUFDOUIsVUFBVSxFQUFDLElBQUk7RUFDZixPQUFPLEVBQUMsWUFBWTtDQUNyQjs7QUFFSCxNQUFNLEVBQUUsU0FBUyxFQUFFLEtBQUs7RUFieEIsQUFBQSxlQUFlLENBY0c7SUFDZCxVQUFVLEVBQUMsZUFBZTtHQUMzQjtFQWJILEFBQUEsZUFBZSxDQWNHO0lBQ2QsYUFBYSxFQUFDLENBQUM7R0FRaEI7RUF2QkgsQUFFRSxlQUZhLENBRWIsQ0FBQyxDQWNHO0lBQ0EsYUFBYSxFQUFDLENBQUM7R0FDaEI7RUFsQkwsQUFLRSxlQUxhLENBS2IsQ0FBQyxBQUFBLDhCQUE4QixDQWNHO0lBQzlCLFVBQVUsRUFBRSxNQUFNO0lBQ2xCLE9BQU8sRUFBRSxLQUFLO0dBQ2Y7RUFFSCxBQUFBLE9BQU8sQ0FBQyxZQUFZLENBQUMsS0FBSztFQUMxQixRQUFRLENBQUMsWUFBWSxDQUFDLEtBQUssQ0FBQztJQUMxQixLQUFLLEVBQUUsR0FBRztHQUNYO0VBQ0QsQUFBQSxPQUFPLENBQUMsQ0FBQyxBQUFBLEtBQUs7RUFDZCxRQUFRLENBQUMsQ0FBQyxBQUFBLEtBQUssQ0FBQztJQUNkLEtBQUssRUFBRSxLQUFLO0dBQ2I7OztBQ2xDSCxBQUNFLGNBRFksQ0FDWixDQUFDLEFBQUEsS0FBSyxDQUFDO0VBQ0wsZ0JBQWdCLEVBQUUsa0RBQWtEO0VBQ3BFLG1CQUFtQixFQUFFLFFBQVE7RUFDN0IsZUFBZSxFQUFFLFNBQVM7RUFDMUIsT0FBTyxFQUFFLGNBQWM7RUFDdkIsS0FBSyxFQUFFLEtBQUs7Q0FDYjs7QUFQSCxBQVNFLGNBVFksQ0FTWixDQUFDLEFBQUEsaUJBQWlCLENBQUM7RUFDakIsWUFBWSxFQUFFLEdBQUc7RUFDakIsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFQUFFLE1BQU07Q0FDWjs7QUFHSCxBQUFBLE9BQU8sQ0FBQztFQUNOLFdBQVcsRUFBRSxNQUFNO0NBQ3BCOztBQUVELEFBQUEsRUFBRSxBQUFBLFdBQVcsQ0FBQztFQUNaLGFBQWEsRUFBRSxHQUFHLENBQUMsS0FBSyxDbkZTZCxPQUFPO0VtRlJqQixTQUFTLEVBQUUsS0FBSztFQUNoQixNQUFNLEVBQUUsT0FBTztFQUNmLE9BQU8sRUFBRSxPQUFPO0VBQ2hCLFVBQVUsRUFBRSxLQUFLO0NBUWxCOztBQWJELEFBT0UsRUFQQSxBQUFBLFdBQVcsQ0FPWCxFQUFFLENBQUM7RUFDRCxPQUFPLEVBQUUsTUFBTTtFQUNmLE9BQU8sRUFBRSxXQUFXO0VBQ3BCLFdBQVcsRUFBRSxZQUFZO0VBQ3pCLFNBQVMsRUFBRSxJQUFJO0NBQ2hCOztBQUdILEFBQUEsT0FBTyxDQUFDO0VBQ04sVUFBVSxFQUFFLE1BQU07Q0FDbkI7O0FBRUQsQUFBQSxrQkFBa0IsQ0FBQztFQUNqQixVQUFVLEVuRlRBLE9BQU8sQ21GUzJCLElBQUksQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO0VBQ2xFLE9BQU8sRUFBRSxhQUFhO0VBQ3RCLGFBQWEsRUFBRSxJQUFJO0NBQ3BCOztBQUVELEFBQUEsZ0JBQWdCLENBQUM7RUFDZixTQUFTLEVBQUUsSUFBSTtFQUNmLFdBQVcsRUFBRSxHQUFHO0VBQ2hCLE1BQU0sRUFBRSxJQUFJO0VBQ1osV0FBVyxFQUFFLE9BQU87RUFDcEIsTUFBTSxFQUFFLENBQUM7RUFDVCxPQUFPLEVBQUUsVUFBVTtFQUNuQixjQUFjLEVBQUUsSUFBSTtFQUNwQixLQUFLLEVBQUUsR0FBRztDQUNYOztBQUVELEFBQUEsb0JBQW9CLENBQUM7RUFDbkIsZ0JBQWdCLEVuRi9CUixPQUFPO0VtRmdDZixnQkFBZ0IsRUFBRSx1Q0FBdUM7RUFDekQsbUJBQW1CLEVBQUUsVUFBVTtFQUMvQixpQkFBaUIsRUFBRSxTQUFTO0VBQzVCLGFBQWEsRUFBRSxDQUFDO0VBQ2hCLEtBQUssRW5GN0JJLE9BQU87RW1GOEJoQixNQUFNLEVBQUUsSUFBSTtFQUNaLFFBQVEsRUFBRSxNQUFNO0VBQ2hCLFdBQVcsRUFBRSxPQUFPO0VBQ3BCLEtBQUssRUFBRSxJQUFJO0VBQ1gsT0FBTyxFQUFFLENBQUM7RUFDVixhQUFhLEVBQUUsR0FBRztDQU1uQjs7QUFsQkQsQUFjRSxvQkFka0IsQUFjakIsTUFBTSxFQWRULG9CQUFvQixBQWVqQixNQUFNLENBQUM7RUFDTixnQkFBZ0IsRUFBRSxPQUFPO0NBQzFCOztBQUdILEFBQUEsR0FBRyxBQUFBLE1BQU0sQ0FBQztFQUNSLEtBQUssRW5GL0RZLE9BQU87RW1GZ0V4QixPQUFPLEVBQUUsWUFBWTtFQUNyQixTQUFTLEVBQUUsS0FBSztFQUNoQixXQUFXLEVBQUUsR0FBRztDQUNqQjs7QUFFRCxBQUFBLEVBQUUsQUFBQSxZQUFZLENBQUM7RUFDYixhQUFhLEVBQUUsR0FBRyxDQUFDLEtBQUssQ25GdERkLE9BQU87RW1GdURqQixhQUFhLEVBQUUsSUFBSTtFQUNuQixRQUFRLEVBQUUsSUFBSTtFQUNkLE9BQU8sRUFBRSxDQUFDO0NBc0JYOztBQTFCRCxBQU1FLEVBTkEsQUFBQSxZQUFZLENBTVosRUFBRSxDQUFDO0VBQ0QsS0FBSyxFQUFFLElBQUk7RUFDWCxlQUFlLEVBQUUsSUFBSTtFQUNyQixNQUFNLEVBQUUsVUFBVTtFQUNsQixPQUFPLEVBQUUsVUFBVTtDQWVwQjs7QUF6QkgsQUFZSSxFQVpGLEFBQUEsWUFBWSxDQU1aLEVBQUUsQUFNQyxPQUFPLENBQUM7RUFDUCxhQUFhLEVBQUUsR0FBRyxDQUFDLEtBQUssQ25GdEVwQixPQUFPO0NtRnVFWjs7QUFkTCxBQWdCSSxFQWhCRixBQUFBLFlBQVksQ0FNWixFQUFFLENBVUEsQ0FBQyxDQUFDO0VBQ0EsZUFBZSxFQUFFLElBQUk7Q0FPdEI7O0FBeEJMLEFBbUJNLEVBbkJKLEFBQUEsWUFBWSxDQU1aLEVBQUUsQ0FVQSxDQUFDLEFBR0UsTUFBTSxFQW5CYixFQUFFLEFBQUEsWUFBWSxDQU1aLEVBQUUsQ0FVQSxDQUFDLEFBSUUsTUFBTSxFQXBCYixFQUFFLEFBQUEsWUFBWSxDQU1aLEVBQUUsQ0FVQSxDQUFDLEFBS0UsUUFBUSxDQUFDO0VBQ1IsS0FBSyxFbkYvRUgsT0FBTztDbUZnRlY7O0FBS1AsQUFDRSxJQURFLEFBQUEsT0FBTyxDQUFDLGFBQWEsQ0FDdkIsQ0FBQyxDQUFDO0VBQ0EsU0FBUyxFQUFFLElBQUk7RUFDZixXQUFXLEVBQUUsSUFBSTtFQUNqQixNQUFNLEVBQUUsQ0FBQztFQUNULE9BQU8sRUFBRSxDQUFDO0VBQ1YsY0FBYyxFQUFFLElBQUk7Q0FRckI7O0FBZEgsQUFRSSxJQVJBLEFBQUEsT0FBTyxDQUFDLGFBQWEsQ0FDdkIsQ0FBQyxBQU9FLEtBQUssQ0FBQztFQUNMLEtBQUssRW5GM0ZDLE9BQU87RW1GNEZiLFNBQVMsRUFBRSxJQUFJO0VBQ2YsT0FBTyxFQUFFLE9BQU87RUFDaEIsU0FBUyxFQUFFLFVBQVU7Q0FDdEI7O0FBYkwsQUFnQkUsSUFoQkUsQUFBQSxPQUFPLENBQUMsYUFBYSxDQWdCdkIsRUFBRSxDQUFDO0VBQ0QsT0FBTyxFQUFFLFFBQVE7Q0FDbEI7O0FBbEJILEFBb0JFLElBcEJFLEFBQUEsT0FBTyxDQUFDLGFBQWEsQ0FvQnZCLEVBQUUsQ0FBQztFQUNELE9BQU8sRUFBRSxDQUFDO0VBQ1YsTUFBTSxFQUFFLENBQUM7Q0FlVjs7QUFyQ0gsQUF3QkksSUF4QkEsQUFBQSxPQUFPLENBQUMsYUFBYSxDQW9CdkIsRUFBRSxDQUlBLENBQUMsQ0FBQztFQUNBLEtBQUssRW5GOUdELE9BQU87RW1GK0dYLFNBQVMsRUFBRSxJQUFJO0VBQ2YsV0FBVyxFQUFFLE1BQU07RUFDbkIsZUFBZSxFQUFFLElBQUk7Q0FRdEI7O0FBcENMLEFBOEJNLElBOUJGLEFBQUEsT0FBTyxDQUFDLGFBQWEsQ0FvQnZCLEVBQUUsQ0FJQSxDQUFDLEFBTUUsTUFBTSxFQTlCYixJQUFJLEFBQUEsT0FBTyxDQUFDLGFBQWEsQ0FvQnZCLEVBQUUsQ0FJQSxDQUFDLEFBT0UsTUFBTSxFQS9CYixJQUFJLEFBQUEsT0FBTyxDQUFDLGFBQWEsQ0FvQnZCLEVBQUUsQ0FJQSxDQUFDLEFBUUUsUUFBUSxDQUFDO0VBQ1IsS0FBSyxFbkZ2SEcsT0FBTztFbUZ3SGYsZUFBZSxFQUFFLFNBQVM7Q0FDM0I7O0FBS1AsQUFBQSxFQUFFLEFBQUEsTUFBTSxDQUFDO0VBQ1AsV0FBVyxFQUFFLEdBQUc7Q0FRakI7O0FBVEQsQUFHRSxFQUhBLEFBQUEsTUFBTSxDQUdOLEVBQUUsQ0FBQztFQUNELE9BQU8sRUFBRSxNQUFNO0VBQ2YsS0FBSyxFQUFFLElBQUk7RUFDWCxNQUFNLEVBQUUsQ0FBQztFQUNULE9BQU8sRUFBRSxXQUFXO0NBQ3JCOztBQUdILEFBQUEsS0FBSztBQUNMLENBQUM7QUFDRCxNQUFNLENBQUM7RUFDTCxXQUFXLEVBQUUsSUFBSTtFQUNqQixNQUFNLEVBQUUsQ0FBQztDQUNWOztBQUVELEFBQUEsS0FBSyxDQUFDO0VBQ0osT0FBTyxFQUFFLElBQUk7Q0FLZDs7QUFORCxBQUdFLEtBSEcsQUFHRixPQUFPLENBQUM7RUFDUCxPQUFPLEVBQUUsS0FBSztDQUNmOztBQUdILEFBQUEsUUFBUSxDQUFDLEVBQUUsQ0FBQztFQUNWLGFBQWEsRUFBRSxJQUFJO0NBQ3BCOztBQUVELEFBQUEsYUFBYSxBQUFBLE9BQU8sQ0FBQztFQUNuQixLQUFLLEVBQUUsSUFBSTtFQUNYLE9BQU8sRUFBRSxFQUFFO0VBQ1gsT0FBTyxFQUFFLEtBQUs7Q0FDZjs7QUFFRCxBQUFBLGFBQWEsQ0FBQztFQUNaLGFBQWEsRUFBRSxHQUFHLENBQUMsS0FBSyxDbkY5SmQsT0FBTztFbUYrSmpCLE1BQU0sRUFBRSxPQUFPO0NBQ2hCOztBQUNELE1BQU0sRUFBRSxTQUFTLEVBQUUsS0FBSztFQUp4QixBQUFBLGFBQWEsQ0FLRztJQUNaLGFBQWEsRUFBRSxXQUFXO0lBQzFCLE1BQU0sRUFBRSxNQUFNO0dBQ2Y7OztBQUdILEFBQUEsYUFBYSxDQUFDLEVBQUUsQ0FBQztFQUNmLE1BQU0sRUFBRSxDQUFDO0VBQ1QsT0FBTyxFQUFFLENBQUM7RUFDVixRQUFRLEVBQUUsUUFBUTtFQUNsQixHQUFHLEVBQUUsR0FBRztDQUNUOztBQUVELEFBQUEsYUFBYSxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBQUM7RUFDbEIsT0FBTyxFQUFFLE1BQU07RUFDZixLQUFLLEVBQUUsSUFBSTtFQUNYLFVBQVUsRUFBRSxpQkFBaUI7RUFDN0IsTUFBTSxFQUFFLENBQUM7RUFDVCxPQUFPLEVBQUUsQ0FBQztDQUtYOztBQVZELEFBT0UsYUFQVyxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBT2pCLEVBQUUsQ0FBQztFQUNELE1BQU0sRUFBRSxDQUFDO0NBQ1Y7O0FBRUgsTUFBTSxFQUFFLFNBQVMsRUFBRSxLQUFLO0VBWHhCLEFBQUEsYUFBYSxDQUFDLEVBQUUsQ0FBQyxFQUFFLENBWUc7SUFDbEIsT0FBTyxFQUFFLEtBQUs7SUFDZCxLQUFLLEVBQUUsSUFBSTtHQUNaOzs7QUFHSCxBQUFBLGFBQWEsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDO0VBQ2pCLHlCQUF5QixFQUFFLElBQUk7RUFDL0IsdUJBQXVCLEVBQUUsSUFBSTtFQUM3Qix3QkFBd0IsRUFBRSxJQUFJO0VBQzlCLHNCQUFzQixFQUFFLElBQUk7RUFDNUIsVUFBVSxFbkZyTUEsT0FBTyxDbUZxTTJCLElBQUksQ0FBQyxNQUFNLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO0VBQ2xFLFlBQVksRW5GdE1GLE9BQU8sQ0FBUCxPQUFPLENtRnNNNkQsbUJBQW1CO0VBQ2pHLFlBQVksRUFBRSxJQUFJO0VBQ2xCLFlBQVksRUFBRSxnQkFBZ0I7RUFDOUIsWUFBWSxFQUFFLGNBQWM7RUFDNUIsT0FBTyxFQUFFLEtBQUs7RUFDZCxTQUFTLEVBQUUsSUFBSTtFQUNmLFdBQVcsRUFBRSxJQUFJO0VBQ2pCLFdBQVcsRUFBRSxPQUFPO0VBQ3BCLE1BQU0sRUFBRSxhQUFhO0VBQ3JCLFFBQVEsRUFBRSxNQUFNO0VBQ2hCLE9BQU8sRUFBRSxLQUFLO0VBQ2QsZUFBZSxFQUFFLElBQUk7RUFDckIsY0FBYyxFQUFFLElBQUk7Q0FTckI7O0FBM0JELEFBb0JFLGFBcEJXLENBQUMsRUFBRSxDQUFDLENBQUMsQUFvQmYsUUFBUSxDQUFDO0VBQ1IsS0FBSyxFbkYxTkMsT0FBTztDbUYyTmQ7O0FBdEJILEFBd0JFLGFBeEJXLENBQUMsRUFBRSxDQUFDLENBQUMsQUF3QmYsTUFBTSxDQUFDO0VBQ04sS0FBSyxFbkYvTk8sT0FBTztDbUZnT3BCOztBQUVILE1BQU0sRUFBRSxTQUFTLEVBQUUsS0FBSztFQTVCeEIsQUFBQSxhQUFhLENBQUMsRUFBRSxDQUFDLENBQUMsQ0E2Qkc7SUFDakIsU0FBUyxFQUFFLElBQUk7SUFDZixXQUFXLEVBQUUsSUFBSTtHQUNsQjs7O0FBR0gsQUFBQSxhQUFhLENBQUMsRUFBRSxDQUFDLENBQUMsQUFBQSxNQUFNLENBQUMsTUFBTTtBQUMvQixhQUFhLENBQUMsRUFBRSxDQUFDLENBQUMsQUFBQSxNQUFNLENBQUMsTUFBTSxDQUFDO0VBQzlCLGVBQWUsRUFBRSxTQUFTO0NBQzNCOztBQUNELE1BQU0sRUFBRSxTQUFTLEVBQUUsS0FBSztFQXZDeEIsQUFBQSxhQUFhLENBQUMsRUFBRSxDQUFDLENBQUMsQ0F3Q0c7SUFDakIsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENuRjFPaEIsT0FBTztJbUYyT2YsU0FBUyxFQUFFLElBQUk7SUFDZixXQUFXLEVBQUUsTUFBTTtJQUNuQixXQUFXLEVBQUUsSUFBSTtJQUNqQixNQUFNLEVBQUUsT0FBTztJQUNmLE9BQU8sRUFBRSxhQUFhO0lBQ3RCLGVBQWUsRUFBRSxTQUFTO0lBQzFCLGNBQWMsRUFBRSxJQUFJO0lBQ3BCLEtBQUssRUFBRSxpQkFBaUI7R0FDekI7OztBQUVILE1BQU0sRUFBRSxTQUFTLEVBQUUsS0FBSyxPQUFPLFNBQVMsRUFBRSxLQUFLO0VBcEQvQyxBQUFBLGFBQWEsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQXFERztJQUNqQixTQUFTLEVBQUUsSUFBSTtJQUNmLFdBQVcsRUFBRSxPQUFPO0dBQ3JCOzs7QUFFSCxNQUFNLEVBQUUsU0FBUyxFQUFFLEtBQUs7RUExRHhCLEFBQUEsYUFBYSxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBMkRHO0lBQ2pCLE9BQU8sRUFBRSxpQkFBaUI7R0FDM0I7OztBQUdILEFBQUEsYUFBYSxDQUFDLEVBQUUsQ0FBQyxFQUFFLEFBQUEsT0FBTyxDQUFDLENBQUMsQ0FBQztFQUMzQixVQUFVLEVuRi9QRCxPQUFPLENtRitQa0IsSUFBSSxDQUFDLE1BQU0sQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUM7RUFDeEQsWUFBWSxFbkZuUUYsT0FBTztFbUZvUWpCLE1BQU0sRUFBRSxTQUFTO0VBQ2pCLE9BQU8sRUFBRSxRQUFRO0NBQ2xCOztBQUNELE1BQU0sRUFBRSxTQUFTLEVBQUUsS0FBSztFQU54QixBQUFBLGFBQWEsQ0FBQyxFQUFFLENBQUMsRUFBRSxBQUFBLE9BQU8sQ0FBQyxDQUFDLENBT0c7SUFDM0IsYUFBYSxFQUFFLEdBQUcsQ0FBQyxLQUFLLENuRnpRaEIsT0FBTztJbUYwUWYsV0FBVyxFQUFFLElBQUk7SUFDakIsTUFBTSxFQUFFLE9BQU87SUFDZixPQUFPLEVBQUUsYUFBYTtJQUN0QixlQUFlLEVBQUUsSUFBSTtJQUNyQixLQUFLLEVBQUUsaUJBQWlCO0dBQ3pCOzs7QUFFSCxNQUFNLEVBQUUsU0FBUyxFQUFFLEtBQUs7RUFoQnhCLEFBQUEsYUFBYSxDQUFDLEVBQUUsQ0FBQyxFQUFFLEFBQUEsT0FBTyxDQUFDLENBQUMsQ0FpQkc7SUFDM0IsT0FBTyxFQUFFLG1CQUFtQjtHQUM3Qjs7O0FBR0gsQUFBQSxhQUFhLENBQUMsRUFBRSxDQUFDLEVBQUUsQUFBQSxPQUFPLENBQUMsQ0FBQyxBQUFBLE1BQU0sQ0FBQztFQUNqQyxPQUFPLEVBQUUsV0FBVztDQUNyQjs7QUFFRCxBQUFBLGFBQWEsQ0FBQyxFQUFFLENBQUMsRUFBRSxBQUFBLE9BQU8sQ0FBQyxDQUFDLENBQUMsTUFBTSxDQUFDO0VBQ2xDLGVBQWUsRUFBRSxJQUFJO0NBQ3RCOztBQUVELEFBQUEsYUFBYSxDQUFDLEVBQUUsQUFBQSxTQUFTLENBQUMsRUFBRSxDQUFDO0VBQzNCLEtBQUssRUFBRSxHQUFHO0NBQ1g7O0FBQ0QsTUFBTSxFQUFFLFNBQVMsRUFBRSxLQUFLO0VBSHhCLEFBQUEsYUFBYSxDQUFDLEVBQUUsQUFBQSxTQUFTLENBQUMsRUFBRSxDQUlHO0lBQzNCLFNBQVMsRUFBRSxPQUFPO0lBQ2xCLEtBQUssRUFBRSxJQUFJO0dBQ1o7OztBQUdILEFBQUEsYUFBYSxBQUFBLFdBQVcsQ0FBQyxlQUFlLENBQUMsRUFBRSxDQUFDLEVBQUUsQ0FBQyxDQUFDLENBQUM7RUFDL0MsZ0JBQWdCLEVuRnZTUCxPQUFPO0VtRndTaEIsTUFBTSxFQUFFLFdBQVc7RUFDbkIsV0FBVyxFQUFFLE1BQU07RUFDbkIsZUFBZSxFQUFFLFNBQVM7Q0FDM0I7O0FBRUQsQUFBQSxhQUFhLEFBQUEsV0FBVyxDQUFDLGVBQWUsQ0FBQyxFQUFFLENBQUMsRUFBRSxBQUFBLE9BQU8sQ0FBQyxDQUFDLENBQUM7RUFDdEQseUJBQXlCLEVBQUUsSUFBSTtFQUMvQix1QkFBdUIsRUFBRSxJQUFJO0VBQzdCLHdCQUF3QixFQUFFLElBQUk7RUFDOUIsc0JBQXNCLEVBQUUsSUFBSTtFQUM1QixZQUFZLEVuRnBURixPQUFPLENBQVAsT0FBTyxDbUZvVDZELG1CQUFtQjtFQUNqRyxZQUFZLEVBQUUsSUFBSTtFQUNsQixZQUFZLEVBQUUsZ0JBQWdCO0VBQzlCLFlBQVksRUFBRSxjQUFjO0NBQzdCOztBQUVELEFBQUEsZUFBZSxDQUFDO0VBQ2QsVUFBVSxFQUFFLEdBQUc7Q0FDaEI7O0FGNFBELEFBS0Usb0JBTGtCLENBS2xCLEVBQUUsQ0FBQyxJQUFJLENFL1BvQjtFQUMzQixZQUFZLEVBQUUsS0FBSztFQUNuQixhQUFhLEVBQUUsR0FBRztDQUNuQjs7QUFFRCxBQUNFLEVBREEsQUFBQSxrQkFBa0IsQ0FDbEIsQ0FBQyxDQUFDO0VBQ0EsWUFBWSxFQUFFLEtBQUs7RUFDbkIsUUFBUSxFQUFFLFFBQVE7RUFDbEIsR0FBRyxFQUFFLEtBQUs7Q0FDWDs7QUFHSCxBQUFBLFlBQVksQ0FBQyxZQUFZLENBQUM7RUFDeEIsT0FBTyxFQUFFLEtBQUs7RUFDZCxTQUFTLEVBQUUsSUFBSTtFQUNmLGdCQUFnQixFQUFFLEdBQUc7RUFDckIsV0FBVyxFQUFFLEdBQUc7RUFDaEIsV0FBVyxFQUFFLElBQUk7RUFDakIsVUFBVSxFQUFFLEtBQUs7RUFDakIsU0FBUyxFQUFFLElBQUk7RUFDZixjQUFjLEVBQUUsSUFBSTtDQUNyQjs7QUFFRCxBQUNFLFVBRFEsQ0FDUixFQUFFLENBQUM7RXREeldILFdBQVcsRXZCTFcsS0FBSyxFQUFFLEtBQUssRUFBRSxVQUFVO0V1Qk05QyxzQkFBc0IsRUFBRSxXQUFXO0VBQ25DLHVCQUF1QixFQUFFLFNBQVM7RUFpQ2xDLFdBQVcsRXRCVGUsR0FBRztFc0JpR3pCLFNBQVMsRXJCUUUsSUFBSTtFcUJKZixXQUFXLEVBcEVDLE9BQXlCO0VzRGdUdkMsV0FBVyxFQUFFLEdBQUc7Q0FLakI7O0F6RHpKSyxNQUFNLENBQUMsS0FBSztFeURpSnBCLEFBQ0UsVUFEUSxDQUNSLEVBQUUsQ0FBQztJdEQvVkQsV0FBVyxFdEJJVyxVQUFVO0c0RWtXakM7OztBekR6SkssTUFBTSxFQUFFLFNBQVMsRUFBRSxTQUFTO0V5RGlKcEMsQUFDRSxVQURRLENBQ1IsRUFBRSxDQUFDO0l0RGxPRyxTQUFTLEVyQkFBLElBQUk7SXFCSWIsV0FBVyxFQWhGRCxJQUF5QjtHc0RxVHhDOzs7QXpEekpLLE1BQU0sQ0FBQyxLQUFLO0V5RGlKcEIsQUFDRSxVQURRLENBQ1IsRUFBRSxDQUFDO0l0RHZPRyxTQUFTLEVyQlNBLElBQUk7SXFCUmIsV0FBVyxFckJTQSxHQUFHO0cyRW9PbkI7OztBQVJILEFBS0ksVUFMTSxDQUNSLEVBQUUsQ0FJQSxFQUFFLENBQUM7RUFDRCxjQUFjLEVBQUUsR0FBRztDQUNwQjs7QUFQTCxBQVVFLFVBVlEsQ0FVUixLQUFLLENBQUM7RUFDSixnQkFBZ0IsRW5GaFdSLE9BQU87RW1GaVdmLE1BQU0sRUFBRSxLQUFLO0NBVWQ7O0FBdEJILEFBY0ksVUFkTSxDQVVSLEtBQUssQ0FJSCxFQUFFLENBQUM7RUFDRCxnQkFBZ0IsRW5GcldWLE9BQU87RW1Gc1diLE9BQU8sRUFBRSxPQUFPO0NBQ2pCOztBQWpCTCxBQW1CSSxVQW5CTSxDQVVSLEtBQUssQ0FTSCxFQUFFLENBQUM7RUFDRCxPQUFPLEVBQUUsU0FBUztDQUNuQjs7QUFJTCxBQUFBLG1CQUFtQixDQUFDLEVBQUUsQ0FBQztFQUNyQixjQUFjLEVBQUUsS0FBSztDQUN0Qjs7QUFFRCxBQUFBLFlBQVksQ0FBQztFQUNYLFNBQVMsRUFBRSxJQUFJO0VBQ2YsT0FBTyxFQUFFLEtBQUs7RUFDZCxXQUFXLEVBQUUsS0FBSztFQUNsQixTQUFTLEVBQUUsSUFBSTtDQUNoQjs7QUFFRCxBQUFBLE9BQU8sQ0FBQztFQUNOLE9BQU8sRUFBRSxJQUFJO0VBQ2IsVUFBVSxFQUFFLE1BQU07Q0FDbkI7O0FBRUQsQUFBQSxVQUFVLENBQUM7RUFDVCxjQUFjLEVBQUUsU0FBUztDQUMxQiJ9 */

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -4,19 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <title layout:title-pattern="$CONTENT_TITLE"></title>
-    <link
-        th:href="@{{cdnUrl}/stylesheets/assets-digital-cabinet-office-gov-uk-static/govuk-template.css?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="screen" rel="stylesheet" type="text/css" />
-    <link
-        th:href="@{{cdnUrl}/stylesheets/application.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="all" rel="stylesheet" type="text/css" />
-    <link
-        th:href="@{{cdnUrl}/stylesheets/ch-accounts.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        media="all" rel="stylesheet" type="text/css" />
-    <link
-        rel="icon"
-        th:href="@{{cdnUrl}/images/favicon.ico?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
-        type="image/x-icon" />
+
+    <!--Static stylesheet for accounts until cdn update is complete-->
+    <link th:href="@{{/application.css}}" media="all" rel="stylesheet" type="text/css" />
+    
 </head>
 <body>
     <div class="entire-wrapper">

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -5,9 +5,10 @@
     <meta charset="UTF-8">
     <title layout:title-pattern="$CONTENT_TITLE"></title>
 
-    <!--Static stylesheet for accounts until cdn update is complete-->
-    <link th:href="@{{/application.css}}" media="all" rel="stylesheet" type="text/css" />
-    
+    <link
+        th:href="@{{cdnUrl}/stylesheets/small-full-ch-accounts.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        media="all" rel="stylesheet" type="text/css" />
+
 </head>
 <body>
     <div class="entire-wrapper">


### PR DESCRIPTION
Add static css stylesheets for the accounts web incorporating new govuk styles.

Remove references to old cdn stylesheets

_*Temporary measure until cdn is updated with new gov uk stylesheets*_

SFA-336