### PR TITLE
Add exception, enumeration, and annotation classes for API validation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -13,6 +13,7 @@ import java.util.Map;
  */
 public enum ValidationMessage {
 
+    // API validation error to message key mappings
     VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside"),
     INVALID_CHARACTER("invalid_character", "validation.character.invalid");
 
@@ -41,6 +42,12 @@ public enum ValidationMessage {
         return key;
     }
 
+    /**
+     * Returns a map of API validation error strings mapped to message key
+     * strings.
+     *
+     * @return a map of validation error strings and message keys
+     */
     private static Map<String, String> initializeMapping() {
         HashMap<String, String> mapping = new HashMap<>();
         for (ValidationMessage validationMessage : ValidationMessage.values()) {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -26,6 +26,13 @@ public enum ValidationMessage {
         this.messageKey = messageKey;
     }
 
+    /**
+     * Returns a message key associated with the {@code apiError} parameter
+     * for use when binding API validation errors to model object fields.
+     *
+     * @param apiError the api validation error string
+     * @return         the message key
+     */
     public static String getMessageKeyForApiError(String apiError) {
         String key = mapping.get(apiError);
         if (key == null || key.isEmpty()) {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.enumeration;
 
+import org.apache.commons.lang.StringUtils;
 import uk.gov.companieshouse.web.accounts.exception.MissingMessageKeyException;
 
 import java.util.HashMap;
@@ -36,7 +37,7 @@ public enum ValidationMessage {
      */
     public static String getMessageKeyForApiError(String apiError) {
         String key = mapping.get(apiError);
-        if (key == null || key.isEmpty()) {
+        if (StringUtils.isBlank(key)) {
             throw new MissingMessageKeyException("No message key mapping for API validation error: " + apiError);
         }
         return key;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -43,10 +43,9 @@ public enum ValidationMessage {
     }
 
     /**
-     * Returns a map of API validation error strings mapped to message key
-     * strings.
+     * Returns a map of API validation error strings mapped to message keys.
      *
-     * @return a map of validation error strings and message keys
+     * @return a map of validation errors mapped to message keys
      */
     private static Map<String, String> initializeMapping() {
         HashMap<String, String> mapping = new HashMap<>();

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.web.accounts.enumeration;
+
+import uk.gov.companieshouse.web.accounts.exception.MissingMessageKeyException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * The {@code ValidationMessage} enumeration provides mappings between API
+ * validation error strings and validation message keys, for use when
+ * binding validation errors.
+ */
+public enum ValidationMessage {
+
+    VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside"),
+    INVALID_CHARACTER("invalid_character", "validation.character.invalid");
+
+    private String messageKey;
+    private String apiError;
+
+    private static Map<String, String> mapping = initializeMapping();
+
+    ValidationMessage(String apiError, String messageKey) {
+        this.apiError = apiError;
+        this.messageKey = messageKey;
+    }
+
+    public static String getMessageKeyForApiError(String apiError) {
+        String key = mapping.get(apiError);
+        if (key == null || key.isEmpty()) {
+            throw new MissingMessageKeyException("No message key mapping for API validation error: " + apiError);
+        }
+        return key;
+    }
+
+    private static Map<String, String> initializeMapping() {
+        HashMap<String, String> mapping = new HashMap<>();
+        for (ValidationMessage validationMessage : ValidationMessage.values()) {
+            mapping.put(validationMessage.apiError, validationMessage.messageKey);
+        }
+        return mapping;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/MissingMessageKeyException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/MissingMessageKeyException.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.web.accounts.exception;
+
+/**
+ * The class {@code MissingMessageKeyException} is a form of
+ * {@code RuntimeException} that should be used to indicate a missing message
+ * key mapping for an API validation error.
+ *
+ * @see uk.gov.companieshouse.web.accounts.enumeration.ValidationMessage
+ */
+public class MissingMessageKeyException extends RuntimeException {
+
+    /**
+     * Constructs a new {@code MissingMessageKeyException} with a custom
+     * message.
+     *
+     * @param message a custom message
+     */
+    public MissingMessageKeyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/MissingValidationMappingException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/MissingValidationMappingException.java
@@ -1,0 +1,19 @@
+package uk.gov.companieshouse.web.accounts.exception;
+
+/**
+ * The class {@code MissingValidationMappingException} is a form of
+ * {@code RuntimeException} that indicates when no mappings are found for a
+ * validation error or that the mappings have yet to be initialised.
+ */
+public class MissingValidationMappingException extends RuntimeException {
+
+    /**
+     * Constructs a new {@code MissingValidationMappingException} with a custom
+     * message.
+     *
+     * @param message a custom message
+     */
+    public MissingValidationMappingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/validation/ValidationError.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/validation/ValidationError.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.web.accounts.validation;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+/**
+ * The {@code ValidationError} class encapsulates the data that represents
+ * an API validation error, and is used when binding validation errors to
+ * presentation model fields.
+ */
+@Getter
+@Setter
+public class ValidationError {
+
+    private String messageKey;
+    private Map<String, String> messageArguments;
+    private String fieldPath;
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/validation/ValidationMapping.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/validation/ValidationMapping.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.web.accounts.validation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Use the {@code ValidationMapping} annotation to associate an API error
+ * JSON path with a model object field for the purposes of validation.
+ *
+ * @see ValidationModel
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidationMapping {
+
+    String value();
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/validation/ValidationModel.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/validation/ValidationModel.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.web.accounts.validation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Use the {@code ValidationModel} annotation to indicate a model class whose
+ * fields should be scanned for field-level validation mappings annotated with
+ * {@code ValidationMapping}.
+ *
+ * @see ValidationMapping
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidationModel {
+}


### PR DESCRIPTION
The changes in this pull-request introduce support classes for the addition of API validation functionality to this service. Additional pull-requests will be raised once these changes have been merged to `develop`.

The following changes are included:

- Adds a `ValidationMessage` enumeration for mapping JSON error strings to message keys
- Adds `MissingMessageKeyException` and `MissingValidationMappingException`
- Adds a `ValidationError` model for encapsulating validation errors
- Adds `ValidationMapping` and `ValidationModel` annotations for annotating model object classes