### PR TITLE
Add piwik to criteria page

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.accounts.controller;
 
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.web.accounts.CompanyAccountsWebApplication;
@@ -19,4 +20,7 @@ public abstract class BaseController {
 
         model.addAttribute("backButton", Navigator.getPreviousControllerPath(this.getClass(), pathVars));
     }
+
+    @ModelAttribute("templateName")
+    protected abstract String getTemplateName();
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -20,12 +20,15 @@ import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService
 @RequestMapping("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/approval")
 public class ApprovalController extends BaseController {
 
-    private static final String TEMPLATE = "smallfull/approval";
-
-    private static final UriTemplate CONFIRMATION_REDIRECT = new UriTemplate("/transaction/{transactionId}/confirmation");
+   private static final UriTemplate CONFIRMATION_REDIRECT = new UriTemplate("/transaction/{transactionId}/confirmation");
 
     @Autowired
     private TransactionService transactionService;
+
+    @Override
+    protected String getTemplateName() {
+        return "smallfull/approval";
+    }
 
     @GetMapping
     public String getApproval(@PathVariable String companyNumber,
@@ -35,7 +38,7 @@ public class ApprovalController extends BaseController {
 
         addBackPageAttributeToModel(model, companyNumber, transactionId, companyAccountsId);
 
-        return TEMPLATE;
+        return getTemplateName();
     }
 
     @PostMapping

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -28,13 +28,16 @@ import uk.gov.companieshouse.web.accounts.util.Navigator;
 @RequestMapping("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/balance-sheet")
 public class BalanceSheetController extends BaseController {
 
-    private static final String SMALL_FULL_BALANCE_SHEET = "smallfull/balanceSheet";
-
     @Autowired
     private BalanceSheetService balanceSheetService;
 
     @Autowired
     private CompanyService companyService;
+
+    @Override
+    protected String getTemplateName() {
+        return "smallfull/balanceSheet";
+    }
 
     @GetMapping
     public String getBalanceSheet(@PathVariable String companyNumber,
@@ -59,7 +62,7 @@ public class BalanceSheetController extends BaseController {
 
         addBackPageAttributeToModel(model, companyNumber, transactionId, companyAccountsId);
 
-        return SMALL_FULL_BALANCE_SHEET;
+        return getTemplateName();
     }
 
     @PostMapping
@@ -71,7 +74,7 @@ public class BalanceSheetController extends BaseController {
                                    HttpServletRequest request) {
 
         if (bindingResult.hasErrors()) {
-            return SMALL_FULL_BALANCE_SHEET;
+            return getTemplateName();
         }
 
         try {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaController.java
@@ -19,14 +19,17 @@ import uk.gov.companieshouse.web.accounts.util.Navigator;
 @RequestMapping("/company/{companyNumber}/small-full/criteria")
 public class CriteriaController extends BaseController {
 
-    private static final String TEMPLATE = "smallfull/criteria";
-
     @GetMapping
     public String getCriteria(Model model) {
 
         model.addAttribute("criteria", new Criteria());
 
-        return TEMPLATE;
+        return getTemplateName();
+    }
+
+    @Override
+    protected String getTemplateName() {
+        return "smallfull/criteria";
     }
 
     @PostMapping
@@ -35,12 +38,12 @@ public class CriteriaController extends BaseController {
                                BindingResult bindingResult) {
 
         if (bindingResult.hasErrors()) {
-            return TEMPLATE;
+            return getTemplateName();
         }
 
         if (!criteria.getIsCriteriaMet().equalsIgnoreCase("yes")) {
             // TODO: Temporarily return the criteria page until other routes are developed
-            return TEMPLATE;
+            return getTemplateName();
         }
 
         return Navigator.getNextControllerRedirect(this.getClass(), companyNumber);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -25,8 +25,6 @@ import uk.gov.companieshouse.web.accounts.util.Navigator;
 @RequestMapping("/company/{companyNumber}/small-full/steps-to-complete")
 public class StepsToCompleteController extends BaseController {
 
-    private static final String TEMPLATE = "smallfull/stepsToComplete";
-
     @Autowired
     private TransactionService transactionService;
 
@@ -36,13 +34,18 @@ public class StepsToCompleteController extends BaseController {
     @Autowired
     private CompanyAccountsService companyAccountsService;
 
+    @Override
+    protected String getTemplateName() {
+        return "smallfull/stepsToComplete";
+    }
+
     @GetMapping
     public String getStepsToComplete(@PathVariable String companyNumber,
                                      Model model) {
 
         addBackPageAttributeToModel(model, companyNumber);
 
-        return TEMPLATE;
+        return getTemplateName();
     }
 
     @PostMapping

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,5 @@ account.url=${ACCOUNT_LOCAL_URL}
 monitorGui.url=${CHS_MONITOR_GUI_URL}
 cdn.url=//${CDN_HOST}
 enquiries=mailto:enquiries@companieshouse.gov.uk
+piwik.url=${PIWIK_URL}
+piwik.siteId=${PIWIK_SITE_ID}

--- a/src/main/resources/templates/fragments/piwik.html
+++ b/src/main/resources/templates/fragments/piwik.html
@@ -7,7 +7,7 @@
 <div th:fragment="piwik">
   <script th:inline="javascript">
                 (function() {
-                    bindPiwikListener('web', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
+                    bindPiwikListener('company-accounts', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
                 })();
             </script>
   <noscript>

--- a/src/main/resources/templates/fragments/piwik.html
+++ b/src/main/resources/templates/fragments/piwik.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>Piwik</title>
+</head>
+<body>
+<div th:fragment="piwik">
+  <script th:inline="javascript">
+                (function() {
+                    bindPiwikListener('web', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
+                })();
+            </script>
+  <noscript>
+    <p>
+      <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${@environment.getProperty('piwik.url')},
+                             siteId=${@environment.getProperty('piwik.site.id')})}" style="border:0;" alt="" />
+    </p>
+  </noscript>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title layout:title-pattern="$CONTENT_TITLE"></title>
+    <div id="templateName" th:attr="data-id=${templateName}" hidden></div>
 
     <link
         th:href="@{{cdnUrl}/stylesheets/small-full-ch-accounts.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
@@ -33,5 +34,7 @@
     <script th:src="@{{cdnUrl}/javascripts/app/js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/selection-buttons.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/application.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <div th:replace="fragments/piwik :: piwik"></div>
 </body>
 </html>

--- a/src/main/resources/templates/smallfull/criteria.html
+++ b/src/main/resources/templates/smallfull/criteria.html
@@ -56,7 +56,8 @@
                                type="radio"
                                value="yes"
                                th:field="*{isCriteriaMet}"
-                               th:errorclass="error-message"/>Yes
+                               th:errorclass="error-message"
+                               class="piwik-event" data-event-id="Yes"/>Yes
                     </label>
 
                     <label class="block-label selection-button-radio" for="noAlternativeFilingButton" id="noAlternativeFilingButton-label">
@@ -64,7 +65,8 @@
                                type="radio"
                                value="noAlternativeFilingMethod"
                                th:field="*{isCriteriaMet}"
-                               th:errorclass="error-message"/>No - show me other ways to file full accounts
+                               th:errorclass="error-message"
+                               class="piwik-event" data-event-id="No other full"/>No - show me other ways to file full accounts
                     </label>
 
                     <label class="block-label selection-button-radio" for="noOtherAccountsButton" id="noButton-label">
@@ -72,7 +74,8 @@
                                type="radio"
                                value="noOtherAccounts"
                                th:field="*{isCriteriaMet}"
-                               th:errorclass="error-message"/>No - I'll file other types of accounts
+                               th:errorclass="error-message"
+                               class="piwik-event" data-event-id="No other accounts"/>No - I'll file other types of accounts
                     </label>
                 </div>
             </fieldset>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -55,6 +55,8 @@ public class ApprovalControllerTests {
 
     private static final String BACK_PAGE_MODEL_ATTR = "backButton";
 
+    private static final String TEMPLATE_NAME_MODEL_ATTR = "templateName";
+
     private static final String ERROR_VIEW = "error";
 
     @BeforeEach
@@ -68,7 +70,8 @@ public class ApprovalControllerTests {
         this.mockMvc.perform(get(APPROVAL_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(APPROVAL_VIEW))
-                .andExpect(model().attributeExists(BACK_PAGE_MODEL_ATTR));
+                .andExpect(model().attributeExists(BACK_PAGE_MODEL_ATTR))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -68,6 +68,8 @@ public class BalanceSheetControllerTests {
 
     private static final String BACK_BUTTON_MODEL_ATTR = "backButton";
 
+    private static final String TEMPLATE_NAME_MODEL_ATTR = "templateName";
+
     private static final String BALANCE_SHEET_VIEW = "smallfull/balanceSheet";
 
     private static final String ERROR_VIEW = "error";
@@ -93,7 +95,8 @@ public class BalanceSheetControllerTests {
                     .andExpect(status().isOk())
                     .andExpect(view().name(BALANCE_SHEET_VIEW))
                     .andExpect(model().attributeExists(BALANCE_SHEET_MODEL_ATTR))
-                    .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR));
+                    .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR))
+                    .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
 
         verify(companyService, times(1)).getCompanyProfile(COMPANY_NUMBER);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -135,7 +135,8 @@ public class BalanceSheetControllerTests {
 
         this.mockMvc.perform(get(BALANCE_SHEET_PATH))
                 .andExpect(status().isOk())
-                .andExpect(view().name(ERROR_VIEW));
+                .andExpect(view().name(ERROR_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
     @Test
@@ -158,7 +159,8 @@ public class BalanceSheetControllerTests {
 
         this.mockMvc.perform(post(BALANCE_SHEET_PATH))
                 .andExpect(status().isOk())
-                .andExpect(view().name(ERROR_VIEW));
+                .andExpect(view().name(ERROR_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
     @Test
@@ -172,7 +174,8 @@ public class BalanceSheetControllerTests {
         this.mockMvc.perform(post(BALANCE_SHEET_PATH)
                 .param(beanElement, invalidData))
                 .andExpect(status().isOk())
-                .andExpect(view().name(BALANCE_SHEET_VIEW));
+                .andExpect(view().name(BALANCE_SHEET_VIEW))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaControllerTests.java
@@ -36,6 +36,8 @@ public class CriteriaControllerTests {
 
     private static final String CRITERIA_MODEL_ATTR = "criteria";
 
+    private static final String TEMPLATE_NAME_MODEL_ATTR = "templateName";
+
     private static final String CRITERIA_VIEW = "smallfull/criteria";
 
     @BeforeEach
@@ -51,7 +53,8 @@ public class CriteriaControllerTests {
         this.mockMvc.perform(get(CRITERIA_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(CRITERIA_VIEW))
-                .andExpect(model().attributeExists(CRITERIA_MODEL_ATTR));
+                .andExpect(model().attributeExists(CRITERIA_MODEL_ATTR))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
@@ -68,6 +68,8 @@ public class StepsToCompleteControllerTests {
 
     private static final String BACK_BUTTON_MODEL_ATTR = "backButton";
 
+    private static final String TEMPLATE_NAME_MODEL_ATTR = "templateName";
+
     private static final String STEPS_TO_COMPLETE_VIEW = "smallfull/stepsToComplete";
 
     private static final String ERROR_VIEW = "error";
@@ -85,7 +87,8 @@ public class StepsToCompleteControllerTests {
         this.mockMvc.perform(get(STEPS_TO_COMPLETE_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(STEPS_TO_COMPLETE_VIEW))
-                .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR));
+                .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
     @Test


### PR DESCRIPTION
Code changes to add piwik to the criteria page when the radio buttons are clicked.
This change has followed similar changes made in the transaction web. See Pr for further info:  https://github.com/companieshouse/transactions.web.ch.gov.uk/pull/16)

Resolves: SFA-653