### PR TITLE
Update SDK version to the latest major release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>2.0.1-rc3</api-sdk-java.version>
+        <api-sdk-java.version>3.0.0-rc1</api-sdk-java.version>
 
         <sdk-manager-java.version>1.0.0-rc1</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/CalledUpShareCapitalNotPaid.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/CalledUpShareCapitalNotPaid.java
@@ -7,5 +7,5 @@ import lombok.Setter;
 @Setter
 public class CalledUpShareCapitalNotPaid {
 
-    private Integer currentAmount;
+    private Long currentAmount;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/FixedAssets.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/FixedAssets.java
@@ -9,6 +9,6 @@ public class FixedAssets {
 
     private TangibleAssets tangibleAssets;
 
-    private Integer totalFixedAssets;
+    private Long totalFixedAssets;
 
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/TangibleAssets.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/TangibleAssets.java
@@ -7,6 +7,6 @@ import lombok.Setter;
 @Setter
 public class TangibleAssets {
 
-    private Integer currentAmount;
+    private Long currentAmount;
 
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
@@ -2,8 +2,10 @@ package uk.gov.companieshouse.web.accounts.service.company.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
@@ -15,6 +17,9 @@ public class CompanyServiceImpl implements CompanyService {
     @Autowired
     ApiClientService apiClientService;
 
+    private static final UriTemplate GET_COMPANY_URI =
+            new UriTemplate("/company/{companyNumber}");
+
     @Override
     public CompanyProfileApi getCompanyProfile(String companyNumber) throws ServiceException {
 
@@ -22,11 +27,16 @@ public class CompanyServiceImpl implements CompanyService {
 
         CompanyProfileApi companyProfileApi;
 
+        String uri = GET_COMPANY_URI.expand(companyNumber).toString();
+
         try {
-            companyProfileApi = apiClient.company(companyNumber).get();
+            companyProfileApi = apiClient.company().get(uri).execute();
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException("Error retieving company profile", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for company resource", e);
         }
 
         return companyProfileApi;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
@@ -5,9 +5,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
+import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccountsService;
@@ -20,6 +23,12 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
 
     private static final Pattern COMPANY_ACCOUNTS_ID_MATCHER = Pattern.compile("/company-accounts/(.*)");
 
+    private static final UriTemplate CREATE_COMPANY_ACCOUNTS_URI =
+            new UriTemplate("/transactions/{transactionId}/company-accounts");
+
+    private static final UriTemplate CREATE_SMALL_FULL_URI =
+            new UriTemplate("/transactions/{transactionId}/company-accounts/{companyAccountsId}/small-full");
+
     @Override
     public String createCompanyAccounts(String transactionId, DateTime periodEndOn) throws ServiceException {
 
@@ -28,11 +37,16 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
         CompanyAccountsApi companyAccounts = new CompanyAccountsApi();
         companyAccounts.setPeriodEndOn(periodEndOn);
 
+        String uri = CREATE_COMPANY_ACCOUNTS_URI.expand(transactionId).toString();
+
         try {
-            companyAccounts = apiClient.transaction(transactionId).companyAccounts().create(companyAccounts);
+            companyAccounts = apiClient.companyAccounts().create(uri, companyAccounts).execute();
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException("Error creating company account", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for company accounts resource", e);
         }
 
         String selfLink = companyAccounts.getLinks().get("self");
@@ -48,11 +62,16 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
+        String uri = CREATE_SMALL_FULL_URI.expand(transactionId, companyAccountsId).toString();
+
         try {
-            apiClient.transaction(transactionId).companyAccount(companyAccountsId).smallFull().create();
+            apiClient.smallFull().create(uri, new SmallFullApi()).execute();
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException("Error creating small full accounts", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for company accounts resource", e);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
@@ -2,8 +2,11 @@ package uk.gov.companieshouse.web.accounts.service.transaction.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.transaction.TransactionsResourceHandler;
 import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.api.model.transaction.TransactionStatus;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
@@ -15,6 +18,9 @@ public class TransactionServiceImpl implements TransactionService {
 
     @Autowired
     ApiClientService apiClientService;
+
+    private static final UriTemplate CLOSE_TRANSACTIONS_URI =
+            new UriTemplate("/transactions/{transactionId}");
 
     /**
      * {@inheritDoc}
@@ -30,10 +36,13 @@ public class TransactionServiceImpl implements TransactionService {
         ApiClient apiClient = apiClientService.getApiClient();
 
         try {
-            transaction = apiClient.transactions().create(transaction);
+            transaction = apiClient.transactions().create("/transactions", transaction).execute();
         } catch (ApiErrorResponseException e) {
             
             throw new ServiceException("Error creating transaction", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for transactions resource", e);
         }
 
         return transaction.getId();
@@ -45,13 +54,18 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     public void closeTransaction(String transactionId) throws ServiceException {
 
+        String uri = CLOSE_TRANSACTIONS_URI.expand(transactionId).toString();
+
         try {
-            Transaction transaction = apiClientService.getApiClient().transaction(transactionId).get();
+            Transaction transaction = apiClientService.getApiClient().transactions().get(uri).execute();
             transaction.setStatus(TransactionStatus.CLOSED);
-            apiClientService.getApiClient().transaction(transactionId).update(transaction);
+            apiClientService.getApiClient().transactions().update(uri, transaction).execute();
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException("Error closing transaction", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for transactions resource", e);
         }
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,5 @@
-# Provides a 'catch all' for errors when casting text inputs from strings to integers
-typeMismatch.java.lang.Integer=Enter a value without commas, brackets or other symbols
+# Provides a 'catch all' for errors when casting text inputs from strings to longs
+typeMismatch.java.lang.Long=Enter a value without commas, brackets or other symbols
 
 # Balance Sheet
 # Called Up Share Capital

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
@@ -15,6 +15,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.company.CompanyResourceHandler;
+import uk.gov.companieshouse.api.handler.company.request.CompanyGet;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
@@ -33,24 +35,33 @@ public class CompanyServiceImplTests {
     @Mock
     private CompanyResourceHandler companyResourceHandler;
 
+    @Mock
+    private CompanyGet companyGet;
+
     @InjectMocks
     private CompanyService companyService = new CompanyServiceImpl();
 
     private static final String COMPANY_NUMBER = "companyNumber";
+
+    private static final String COMPANY_URI = "/company/" + COMPANY_NUMBER;
+
+    private static final String INVALID_COMPANY_URI = COMPANY_URI + "/blah";
 
     @BeforeEach
     private void init() {
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
 
-        when(apiClient.company(COMPANY_NUMBER)).thenReturn(companyResourceHandler);
+        when(apiClient.company()).thenReturn(companyResourceHandler);
+
+        when(companyResourceHandler.get(COMPANY_URI)).thenReturn(companyGet);
     }
 
     @Test
     @DisplayName("Get Company Profile - Success Path")
-    void getCompanyProfileSuccess() throws ServiceException, ApiErrorResponseException {
+    void getCompanyProfileSuccess() throws ServiceException, ApiErrorResponseException, URIValidationException {
 
-        when(companyResourceHandler.get()).thenReturn(new CompanyProfileApi());
+        when(companyGet.execute()).thenReturn(new CompanyProfileApi());
 
         CompanyProfileApi companyProfile = companyService.getCompanyProfile(COMPANY_NUMBER);
 
@@ -59,9 +70,19 @@ public class CompanyServiceImplTests {
 
     @Test
     @DisplayName("Get Company Profile - Throws ApiErrorResponseException")
-    void getBalanceSheetThrowsApiErrorResponseException() throws ApiErrorResponseException {
+    void getBalanceSheetThrowsApiErrorResponseException() throws ApiErrorResponseException, URIValidationException {
 
-        when(companyResourceHandler.get()).thenThrow(ApiErrorResponseException.class);
+        when(companyGet.execute()).thenThrow(ApiErrorResponseException.class);
+
+        assertThrows(ServiceException.class, () ->
+                companyService.getCompanyProfile(COMPANY_NUMBER));
+    }
+
+    @Test
+    @DisplayName("Get Company Profile - Throws URIValidationException")
+    void getBalanceSheetThrowsURIValidationException() throws ApiErrorResponseException, URIValidationException {
+
+        when(companyGet.execute()).thenThrow(URIValidationException.class);
 
         assertThrows(ServiceException.class, () ->
                 companyService.getCompanyProfile(COMPANY_NUMBER));

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/BalanceSheetTransformerTests.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BalanceSheetTransformerTests {
 
-    private Integer CALLED_UP_SHARE_CAPITAL = 1;
+    private Long CALLED_UP_SHARE_CAPITAL = Long.valueOf("1");
 
     private BalanceSheetTransformer transformer = new BalanceSheetTransformerImpl();
 


### PR DESCRIPTION
Update SDK version to the latest major release, and change model integers to longs to prevent type castings exceptions when overflowing an integer's size.

Resolves SFA-791 and SFA-790