### PR TITLE
Adding Styling to criteria page

### DIFF
--- a/src/main/resources/templates/smallfull/criteria.html
+++ b/src/main/resources/templates/smallfull/criteria.html
@@ -22,7 +22,9 @@
 
         <h2 class="govuk-heading-m" id="criteria-sub-heading">Criteria</h2>
 
-        <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
+        <div class="govuk-inset-text">
+          <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
+        </div>
 
         <p id="criteria-list-heading">You can file full accounts here if:</p>
 

--- a/src/main/resources/templates/smallfull/criteria.html
+++ b/src/main/resources/templates/smallfull/criteria.html
@@ -22,9 +22,7 @@
 
         <h2 class="govuk-heading-m" id="criteria-sub-heading">Criteria</h2>
 
-        <div>
-          <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
-        </div>
+        <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
 
         <p id="criteria-list-heading">You can file full accounts here if:</p>
 
@@ -99,7 +97,7 @@
           </fieldset>
         </div>
 
-        <div>
+        <div class="govuk-form-group">
           <input id="next-button" class="govuk-button" type="submit" role="button" value="Continue"/>
         </div>
       </form>

--- a/src/main/resources/templates/smallfull/criteria.html
+++ b/src/main/resources/templates/smallfull/criteria.html
@@ -22,7 +22,7 @@
 
         <h2 class="govuk-heading-m" id="criteria-sub-heading">Criteria</h2>
 
-        <div class="panel panel-border-wide">
+        <div>
           <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
         </div>
 
@@ -99,7 +99,7 @@
           </fieldset>
         </div>
 
-        <div class="form-group">
+        <div>
           <input id="next-button" class="govuk-button" type="submit" role="button" value="Continue"/>
         </div>
       </form>

--- a/src/main/resources/templates/smallfull/criteria.html
+++ b/src/main/resources/templates/smallfull/criteria.html
@@ -38,7 +38,7 @@
             or 'creditors - amounts falling due after one year'</li>
         </ul>
 
-        <p id="criteria-additional-criteria-list-heading">Your full accounts must meet at least 2 of the following:</p>
+        <p id="criteria-additional-criteria-list-heading">Your company must also meet at least 2 of the following:</p>
 
         <ul class="govuk-list govuk-list--bullet" id="criteria-additional-criteria-list">
           <li>turnover is not over £10.2 million</li>

--- a/src/main/resources/templates/smallfull/criteria.html
+++ b/src/main/resources/templates/smallfull/criteria.html
@@ -4,86 +4,107 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/baseLayout}">
 
-    <head>
-      <title>Full Accounts Criteria</title>
-    </head>
-    <body>
-    <div id="criteria-main-content" layout:fragment="content">
-        <form id="criteria-form" th:action="@{''}" th:object="${criteria}" class="form" method="post">
+<head>
+  <title>Full Accounts Criteria</title>
+</head>
+<body>
+<div id="criteria-main-content" layout:fragment="content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-            <div th:replace="fragments/globalErrors :: globalErrors"></div>
+      <form id="criteria-form" th:action="@{''}" th:object="${criteria}" class="form" method="post">
+        <div th:replace="fragments/globalErrors :: globalErrors"></div>
+        <header>
+          <h1 id="page-title" class="govuk-heading-l">
+            File full accounts
+          </h1>
+        </header>
 
-            <h1 id="page-title" class="heading-xlarge">
-                File full accounts
-            </h1>
+        <h2 class="govuk-heading-m" id="criteria-sub-heading">Criteria</h2>
 
-            <h2 class="heading-medium" id="criteria-sub-heading">Criteria</h2>
+        <div class="panel panel-border-wide">
+          <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
+        </div>
 
-            <p id="criteria-overview">Check your prepared accounts to see if you meet the criteria.</p>
+        <p id="criteria-list-heading">You can file full accounts here if:</p>
 
-            <p id="criteria-list-heading">You can file full accounts here if:</p>
+        <ul class="govuk-list govuk-list--bullet" id="criteria-list">
+          <li>you don't need to include a directors' report or profit and loss account</li>
+          <li>you don't need to change the date the accounts are made up to</li>
+          <li>your balance sheet doesn’t have 'fixed asset investments', 'current asset investments',
+            'revaluation reserve', or 'intangible assets'</li>
+          <li>you only need to add notes (if applicable) for 'accounting policies', 'tangible assets',
+            'stocks', 'debtors', 'creditors - amounts falling due within one year',
+            or 'creditors - amounts falling due after one year'</li>
+        </ul>
 
-            <ul class="list list-bullet text" id="criteria-list">
-                <li>you don't need to include a directors' report or profit and loss account</li>
-                <li>you don't need to change the date the accounts are made up to</li>
-                <li>your balance sheet doesn’t have 'fixed asset investments', 'current asset investments',
-                    'revaluation reserve', or 'intangible assets'</li>
-                <li>you only need to add notes (if applicable) for 'accounting policies', 'tangible assets',
-                    'stocks', 'debtors', 'creditors - amounts falling due within one year',
-                    or 'creditors - amounts falling due after one year'</li>
-            </ul>
+        <p id="criteria-additional-criteria-list-heading">Your full accounts must meet at least 2 of the following:</p>
 
-            <p id="criteria-additional-criteria-list-heading">Your full accounts must meet at least 2 of the following:</p>
+        <ul class="govuk-list govuk-list--bullet" id="criteria-additional-criteria-list">
+          <li>turnover is not over £10.2 million</li>
+          <li>balance sheet total is not over £5.1 million</li>
+          <li>average number of employees is not over 50</li>
+        </ul>
 
-            <ul class="list list-bullet text" id="criteria-additional-criteria-list">
-                <li>turnover is not over £10.2 million</li>
-                <li>balance sheet total is not over £5.1 million</li>
-                <li>average number of employees is not over 50</li>
-            </ul>
+        <h2 class="govuk-heading-m" id="criteria-submit-heading">Do your prepared full accounts meet the criteria?</h2>
 
-            <h2 class="heading-medium" id="criteria-submit-heading">Do your prepared full accounts meet the criteria?</h2>
+        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('isCriteriaMet')} ? 'govuk-form-group--error' : ''">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-visually-hidden">Do your prepared full accounts meet the criteria?</legend>
 
-            <fieldset class="form-group" th:classappend="${#fields.hasErrors('isCriteriaMet')} ? 'error' : ''">
-                <legend class="visuallyhidden">Full accounts criteria radio buttons"</legend>
-                <div class="form-group">
-                    <span id="isCriteriaMet-errorId"
-                          th:if="${#fields.hasErrors('isCriteriaMet')}"
-                          th:each="e : ${#fields.errors('isCriteriaMet')}" th:text="${e}" class="error-message">
-                    </span>
+            <span class="govuk-error-message"
+                  id="isCriteriaMet-errorId"
+                  th:if="${#fields.hasErrors('isCriteriaMet')}"
+                  th:each="e : ${#fields.errors('isCriteriaMet')}" th:text="${e}" >
+                            </span>
 
-                    <label class="block-label selection-button-radio" for="yesButton" id="yesButton-label">
-                        <input id="yesButton"
-                               type="radio"
-                               value="yes"
-                               th:field="*{isCriteriaMet}"
-                               th:errorclass="error-message"
-                               class="piwik-event" data-event-id="Yes"/>Yes
-                    </label>
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <input id="yesButton"
+                       type="radio"
+                       value="yes"
+                       th:field="*{isCriteriaMet}"
+                       th:errorclass="govuk-error-message"
+                       class="govuk-radios__input piwik-event" data-event-id="Yes"/>
+                <label class="govuk-label govuk-radios__label" for="yesButton" id="yesButton-label">
+                  Yes
+                </label>
+              </div>
 
-                    <label class="block-label selection-button-radio" for="noAlternativeFilingButton" id="noAlternativeFilingButton-label">
-                        <input id="noAlternativeFilingButton"
-                               type="radio"
-                               value="noAlternativeFilingMethod"
-                               th:field="*{isCriteriaMet}"
-                               th:errorclass="error-message"
-                               class="piwik-event" data-event-id="No other full"/>No - show me other ways to file full accounts
-                    </label>
+              <div class="govuk-radios__item">
+                <input id="noAlternativeFilingButton"
+                       type="radio"
+                       value="noAlternativeFilingMethod"
+                       th:field="*{isCriteriaMet}"
+                       th:errorclass="govuk-error-message"
+                       class="govuk-radios__input piwik-event" data-event-id="No other full"/>
+                <label class="govuk-label govuk-radios__label" for="noAlternativeFilingButton" id="noAlternativeFilingButton-label">
+                  No - show me other ways to file full accounts
+                </label>
+              </div>
 
-                    <label class="block-label selection-button-radio" for="noOtherAccountsButton" id="noButton-label">
-                        <input id="noOtherAccountsButton"
-                               type="radio"
-                               value="noOtherAccounts"
-                               th:field="*{isCriteriaMet}"
-                               th:errorclass="error-message"
-                               class="piwik-event" data-event-id="No other accounts"/>No - I'll file other types of accounts
-                    </label>
-                </div>
-            </fieldset>
+              <div class="govuk-radios__item">
+                <input id="noOtherAccountsButton"
+                       type="radio"
+                       value="noOtherAccounts"
+                       th:field="*{isCriteriaMet}"
+                       th:errorclass="govuk-error-message"
+                       class="govuk-radios__input piwik-event" data-event-id="No other accounts"/>
+                <label class="govuk-label govuk-radios__label" for="noOtherAccountsButton" id="noButton-label">
+                  No - I'll file other types of accounts
+                </label>
+              </div>
 
-            <div class="form-group">
-              <input id="next-button" class="button" type="submit" role="button" value="Continue"/>
             </div>
-        </form>
+          </fieldset>
+        </div>
+
+        <div class="form-group">
+          <input id="next-button" class="govuk-button" type="submit" role="button" value="Continue"/>
+        </div>
+      </form>
     </div>
-    </body>
+  </div>
+</div>
+</body>
 </html>


### PR DESCRIPTION
I have to create this new PR for a PR (https://github.com/companieshouse/company-accounts.web.ch.gov.uk/pull/83) that was approved and reversed as it was merged by mistake.

Changes to update the styling on criteria page to match prototype:
- Change the order of some  elements: `labels'` tag placed after `input` tags
- New `div` elements have been added based on the prototype: `govuk-grid-row`, `govuk-grid-column-two-thirds`, `govuk-radio`, `govuk-radios__item`, etc
- Some of the class attributes have been changed based on the prototype. 
- The text in the `legend` element has been updated to match prototype: `Do your prepared full accounts meet the criteria?`
- New error class used by small-full:  I've followed GDS error message stype: https://design-system.service.gov.uk/components/error-message/

Resolves: SFA-760