### PR TITLE
Add js functionality to Balance Sheet

### DIFF
--- a/src/main/resources/templates/fragments/numberInput.html
+++ b/src/main/resources/templates/fragments/numberInput.html
@@ -12,7 +12,7 @@
                 <input th:field="*{__${id}__}"
                      th:id="${id}"
                      th:name="${id}"
-                     class="govuk-input"
+                       th:class="${class}"
                      type="text">
             </label>
         </div>

--- a/src/main/resources/templates/fragments/totalInput.html
+++ b/src/main/resources/templates/fragments/totalInput.html
@@ -10,8 +10,8 @@
                <input th:field="*{__${id}__}"
                      th:id="${id}"
                      th:name="${id}"
-                     class="govuk-input"
-                     type="text">
+                     th:class="${class}"
+               >
            </label>
        </div>
    </body>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -35,6 +35,7 @@
     <script th:src="@{{cdnUrl}/javascripts/vendor/selection-buttons.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/application.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/balance-sheet.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <div th:replace="fragments/piwik :: piwik"></div>
 </body>
 </html>

--- a/src/main/resources/templates/smallfull/balanceSheet.html
+++ b/src/main/resources/templates/smallfull/balanceSheet.html
@@ -56,6 +56,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'calledUpShareCapitalNotPaid.currentAmount',
                                 text = 'Called up share capital not paid',
+                                class= 'govuk-input',
                                 )">
                             </div>
                         </div>
@@ -74,6 +75,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'fixedAssets.tangibleAssets.currentAmount',
                                 text = 'Tangible assets',
+                                class= 'govuk-input current-fixed-assets-add',
                                 )">
                             </div>
                         </div>
@@ -88,6 +90,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'fixedAssets.totalFixedAssets',
                                 text = 'Tangible assets',
+                                class= 'govuk-input current-fixed-assets-total',
                                 )">
                             </div>
                         </div>


### PR DESCRIPTION
Add balance sheet javascript to baselayout
Make total fields readonly if javascript is enabled
Autocalculate fixed assets fields based on class names added

Corresponds with CDN change:  https://github.com/companieshouse/cdn.ch.gov.uk/pull/273

SFA-331