### PR TITLE
Fix for other liabilities not appearing on review page

### DIFF
--- a/src/main/resources/templates/smallfull/review.html
+++ b/src/main/resources/templates/smallfull/review.html
@@ -128,7 +128,7 @@
 
                     <!-- Start Other Liabilities and Assets -->
 
-                    <th:block th:if="*{balanceSheet?.fixedAssets?.currentTotal != null or balanceSheet?.fixedAssets?.previousTotal != null}">
+                    <th:block th:if="*{balanceSheet?.otherLiabilitiesOrAssets?.totalNetAssets?.currentAmount != null or balanceSheet?.otherLiabilitiesOrAssets?.totalNetAssets?.previousAmount != null}">
 
                         <div th:replace="fragments/review/balanceSheetValueRow :: balanceSheetValueRow (
                             description = 'Prepayments and accrued income',


### PR DESCRIPTION
This change ensures that fields belonging to the 'Other liabilities or assets' section of the review page are visible when values are available.

Resolves: SFA-906