### PR TITLE
Adding Turnover Policy Service and updating tranformer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/TurnoverPolicy.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/TurnoverPolicy.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TurnoverPolicy {
+    @NotNull
+    private Boolean isIncludeTurnoverSelected;
+
+    private String turnoverPolicyDetails;
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/TurnoverPolicyService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/TurnoverPolicyService.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.web.accounts.service.smallfull;
+
+import java.util.List;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
+import uk.gov.companieshouse.web.accounts.validation.ValidationError;
+
+public interface TurnoverPolicyService {
+
+    TurnoverPolicy getTurnOverPolicy(String transactionId, String companyAccountsId)
+        throws ServiceException;
+
+    List<ValidationError> postTurnoverPolicy(String transactionId, String companyAccountsId,
+        TurnoverPolicy
+            turnoverPolicy) throws ServiceException;
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
@@ -1,0 +1,52 @@
+package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
+import uk.gov.companieshouse.web.accounts.service.smallfull.AccountingPoliciesService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.TurnoverPolicyService;
+import uk.gov.companieshouse.web.accounts.transformer.smallfull.AccountingPoliciesTransformer;
+import uk.gov.companieshouse.web.accounts.validation.ValidationError;
+
+@Service
+public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
+
+    private final AccountingPoliciesService accountingPoliciesService;
+    private final AccountingPoliciesTransformer accountingPoliciesTransformer;
+
+    @Autowired
+    public TurnoverPolicyServiceImpl(
+        AccountingPoliciesService accountingPoliciesService,
+        AccountingPoliciesTransformer accountingPoliciesTransformer) {
+        this.accountingPoliciesService = accountingPoliciesService;
+        this.accountingPoliciesTransformer = accountingPoliciesTransformer;
+    }
+
+    @Override
+    public TurnoverPolicy getTurnOverPolicy(String transactionId, String companyAccountsId)
+        throws ServiceException {
+
+        AccountingPoliciesApi accountingPoliciesApi =
+            accountingPoliciesService.getAccountingPoliciesApi(transactionId, companyAccountsId);
+
+        return accountingPoliciesTransformer.getTurnoverPolicy(accountingPoliciesApi);
+    }
+
+    @Override
+    public List<ValidationError> postTurnoverPolicy(String transactionId, String companyAccountsId,
+        TurnoverPolicy turnoverPolicy) throws ServiceException {
+
+        AccountingPoliciesApi accountingPoliciesApi =
+            accountingPoliciesService.getAccountingPoliciesApi(transactionId, companyAccountsId);
+
+        accountingPoliciesTransformer.setTurnoverPolicy(turnoverPolicy, accountingPoliciesApi);
+
+        return accountingPoliciesService
+            .updateAccountingPoliciesApi(transactionId, companyAccountsId,
+                accountingPoliciesApi);
+
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/AccountingPoliciesTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/AccountingPoliciesTransformer.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.web.accounts.transformer.smallfull;
 
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.BasisOfPreparation;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
 
 public interface AccountingPoliciesTransformer {
 
@@ -21,5 +22,22 @@ public interface AccountingPoliciesTransformer {
      */
     void setBasisOfPreparation(BasisOfPreparation basisOfPreparation,
             AccountingPoliciesApi accountingPoliciesApi);
+
+    /**
+     * Gets the turn over policy from the accounting policies API resource
+     *
+     * @param accountingPoliciesApi The accounting policies API resource
+     * @return {@link TurnoverPolicy}
+     */
+    TurnoverPolicy getTurnoverPolicy(AccountingPoliciesApi accountingPoliciesApi);
+
+    /**
+     * Updates the turn over policy on the accounting policies API resource
+     *
+     * @param turnoverPolicy Turnover Policy details
+     * @param accountingPoliciesApi The accounting policies API resource
+     */
+    void setTurnoverPolicy(TurnoverPolicy turnoverPolicy,
+        AccountingPoliciesApi accountingPoliciesApi);
 
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/AccountingPoliciesTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/AccountingPoliciesTransformerImpl.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.BasisOfPreparation;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.AccountingPoliciesTransformer;
 
 @Component
@@ -43,6 +44,33 @@ public class AccountingPoliciesTransformerImpl implements AccountingPoliciesTran
             accountingPoliciesApi.setBasisOfMeasurementAndPreparation(basisOfPreparation.getPreparedStatement());
         } else {
             accountingPoliciesApi.setBasisOfMeasurementAndPreparation(basisOfPreparation.getCustomStatement());
+        }
+    }
+
+    @Override
+    public TurnoverPolicy getTurnoverPolicy(AccountingPoliciesApi accountingPoliciesApi) {
+
+        TurnoverPolicy turnoverPolicy = new TurnoverPolicy();
+        if (accountingPoliciesApi == null) {
+            return turnoverPolicy;
+        }
+
+        if (accountingPoliciesApi.getTurnoverPolicy() != null) {
+            turnoverPolicy.setIsIncludeTurnoverSelected(true);
+            turnoverPolicy.setTurnoverPolicyDetails(accountingPoliciesApi.getTurnoverPolicy());
+        }
+
+        return turnoverPolicy;
+    }
+
+    @Override
+    public void setTurnoverPolicy(TurnoverPolicy turnoverPolicy,
+        AccountingPoliciesApi accountingPoliciesApi) {
+
+        if (turnoverPolicy.getIsIncludeTurnoverSelected()) {
+            accountingPoliciesApi.setTurnoverPolicy(turnoverPolicy.getTurnoverPolicyDetails());
+        } else {
+            accountingPoliciesApi.setTurnoverPolicy(null);
         }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
@@ -1,0 +1,104 @@
+package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
+import uk.gov.companieshouse.web.accounts.service.smallfull.AccountingPoliciesService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.TurnoverPolicyService;
+import uk.gov.companieshouse.web.accounts.transformer.smallfull.AccountingPoliciesTransformer;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class TurnoverPolicyServiceImplTest {
+
+    private static final String TURNOVER_POLICY_DETAILS = "Turnover policy details";
+    private static final String TRANSACTION_ID = "transactionId";
+    private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    @Mock
+    private AccountingPoliciesTransformer accountingPoliciesTransformerMock;
+    @Mock
+    private AccountingPoliciesService accountingPoliciesServiceMock;
+    @Mock
+    private AccountingPoliciesApi accountingPoliciesApiMock;
+
+    private TurnoverPolicyService turnoverPolicyService;
+
+    @BeforeEach
+    void setUpBeforeEach() {
+        turnoverPolicyService = new TurnoverPolicyServiceImpl(accountingPoliciesServiceMock,
+            accountingPoliciesTransformerMock);
+    }
+
+    @Test
+    @DisplayName("Get the turnoverPolicy")
+    void shouldGetTurnoverPolicy() throws ServiceException {
+
+        when(accountingPoliciesServiceMock
+            .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+            .thenReturn(accountingPoliciesApiMock);
+
+        TurnoverPolicy turnoverPolicyFromTransformer = createTurnOverPolicy();
+        when(accountingPoliciesTransformerMock.getTurnoverPolicy(accountingPoliciesApiMock))
+            .thenReturn(turnoverPolicyFromTransformer);
+
+        TurnoverPolicy turnOverPolicy =
+            turnoverPolicyService.getTurnOverPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        assertNotNull(turnOverPolicy);
+        assertEquals(turnoverPolicyFromTransformer, turnOverPolicy);
+    }
+
+    @Test
+    @DisplayName("Post a turnoverPolicy")
+    void shouldPostTurnoverPolicy() throws ServiceException {
+
+        when(accountingPoliciesServiceMock
+            .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+            .thenReturn(accountingPoliciesApiMock);
+
+        TurnoverPolicy turnoverPolicy = createTurnOverPolicy();
+
+        doNothing()
+            .when(accountingPoliciesTransformerMock)
+            .setTurnoverPolicy(turnoverPolicy, accountingPoliciesApiMock);
+
+        turnoverPolicyService
+            .postTurnoverPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, turnoverPolicy);
+
+        verify(accountingPoliciesTransformerMock, times(1))
+            .setTurnoverPolicy(turnoverPolicy, accountingPoliciesApiMock);
+
+        verify(accountingPoliciesServiceMock, times(1))
+            .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        verify(accountingPoliciesServiceMock, times(1))
+            .updateAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID,
+                accountingPoliciesApiMock);
+
+    }
+
+    private TurnoverPolicy createTurnOverPolicy() {
+        TurnoverPolicy turnoverPolicy = new TurnoverPolicy();
+
+        turnoverPolicy.setIsIncludeTurnoverSelected(true);
+        turnoverPolicy.setTurnoverPolicyDetails(TURNOVER_POLICY_DETAILS);
+
+        return turnoverPolicy;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/AccountingPoliciesTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/AccountingPoliciesTransformerImplTests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.BasisOfPreparation;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.impl.AccountingPoliciesTransformerImpl;
 
 @ExtendWith(MockitoExtension.class)
@@ -26,6 +27,7 @@ public class AccountingPoliciesTransformerImplTests {
                     + "Section 1A (Small Entities) of Financial Reporting Standard 102";
 
     private static final String BASIS_OF_PREPARATION_CUSTOM_STATEMENT = "customStatement";
+    private static final String TURNOVER_POLICY_DETAILS = "Turnover policy details";
 
     @Test
     @DisplayName("Get Basis of Preparation - Null AccountingPoliciesApi")
@@ -95,5 +97,78 @@ public class AccountingPoliciesTransformerImplTests {
         assertEquals(BASIS_OF_PREPARATION_CUSTOM_STATEMENT, accountingPoliciesApi.getBasisOfMeasurementAndPreparation());
     }
 
+    @Test
+    @DisplayName("Get TurnoverPolicy when accountingPoliciesApi is null")
+    void shouldGetTurnoverPolicyWhenAccountingPoliciesApiIsNull() {
+
+        TurnoverPolicy turnoverPolicy = transformer.getTurnoverPolicy(null);
+
+        assertNotNull(turnoverPolicy);
+        assertNull(turnoverPolicy.getIsIncludeTurnoverSelected());
+        assertNull(turnoverPolicy.getTurnoverPolicyDetails());
+    }
+
+    @Test
+    @DisplayName("Get TurnoverPolicy when accountingPoliciesApi is set and turnoverPolicy is null")
+    void shouldGetTurnoverPolicyWhenAccountingPoliciesApiIsSetAndTurnoverPolicyIsNull() {
+
+        TurnoverPolicy turnoverPolicy = transformer.getTurnoverPolicy(new AccountingPoliciesApi());
+
+        assertNotNull(turnoverPolicy);
+        assertNull(turnoverPolicy.getIsIncludeTurnoverSelected());
+        assertNull(turnoverPolicy.getTurnoverPolicyDetails());
+    }
+
+    @Test
+    @DisplayName("Get TurnoverPolicy when accountingPoliciesApi is set and turnoverPolicy is set")
+    void shouldGetTurnoverPolicyWhenAccountingPolicyApiAndTurnoverPolicySet() {
+
+        TurnoverPolicy turnoverPolicy = transformer.getTurnoverPolicy(createAccountingPoliciesApi());
+
+        assertNotNull(turnoverPolicy);
+        assertTrue(turnoverPolicy.getIsIncludeTurnoverSelected());
+        assertEquals(TURNOVER_POLICY_DETAILS, turnoverPolicy.getTurnoverPolicyDetails());
+    }
+
+    @Test
+    @DisplayName("TurnoverPolicyAPI is set successfully when include turnover is selected")
+    void shouldSetTurnoverPolicyAPIWhenIncludeTurnoverSelected() {
+
+        AccountingPoliciesApi accountingPoliciesApi = new AccountingPoliciesApi();
+
+        transformer.setTurnoverPolicy(createTurnOverPolicy(true), accountingPoliciesApi);
+
+        assertNotNull(accountingPoliciesApi);
+        assertNotNull(accountingPoliciesApi.getTurnoverPolicy());
+        assertEquals(TURNOVER_POLICY_DETAILS, accountingPoliciesApi.getTurnoverPolicy());
+    }
+
+    @Test
+    @DisplayName("TurnoverPolicyAPI is not set when include turnover is not selected")
+    void shouldNotSetTurnoverPolicyAPIWhenIncludeTurnoverNotSelected() {
+
+        AccountingPoliciesApi accountingPoliciesApi = new AccountingPoliciesApi();
+
+        transformer.setTurnoverPolicy(createTurnOverPolicy(false), accountingPoliciesApi);
+
+        assertNotNull(accountingPoliciesApi);
+        assertNull(accountingPoliciesApi.getTurnoverPolicy());
+    }
+
+    private AccountingPoliciesApi createAccountingPoliciesApi() {
+        AccountingPoliciesApi accountingPoliciesApi = new AccountingPoliciesApi();
+        accountingPoliciesApi.setTurnoverPolicy(TURNOVER_POLICY_DETAILS);
+
+        return accountingPoliciesApi;
+    }
+
+    private TurnoverPolicy createTurnOverPolicy(boolean IsIncludeTurnoverSelected) {
+        TurnoverPolicy turnoverPolicy = new TurnoverPolicy();
+
+        turnoverPolicy.setIsIncludeTurnoverSelected(IsIncludeTurnoverSelected);
+        turnoverPolicy.setTurnoverPolicyDetails(TURNOVER_POLICY_DETAILS);
+
+        return  turnoverPolicy;
+    }
 
 }


### PR DESCRIPTION
Changes to add turnover policies information: 
- turnover model
- add the turnover service 
- add  Turnover to the Accounting Policies transformer

Resolve: SFA-631