### PR TITLE
Adding turnover policy controller

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationController.java
@@ -22,7 +22,7 @@ import uk.gov.companieshouse.web.accounts.util.Navigator;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @Controller
-@NextController(ReviewController.class)
+@NextController(TurnoverPolicyController.class)
 @PreviousController(StatementsController.class)
 @RequestMapping("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/basis-of-preparation")
 public class BasisOfPreparationController extends BaseController {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationController.java
@@ -81,7 +81,6 @@ public class BasisOfPreparationController extends BaseController {
         }
 
         return Navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
-
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ReviewController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ReviewController.java
@@ -19,7 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @Controller
 @NextController(ApprovalController.class)
-@PreviousController(BasisOfPreparationController.class)
+@PreviousController(TurnoverPolicyController.class)
 @RequestMapping("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/review")
 public class ReviewController extends BaseController {
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyController.java
@@ -23,7 +23,7 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @Controller
 @NextController(ReviewController.class)
-@PreviousController(BalanceSheetController.class)
+@PreviousController(BasisOfPreparationController.class)
 @RequestMapping("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/turnover-policy")
 public class TurnoverPolicyController extends BaseController {
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -13,7 +13,7 @@ public enum ValidationMessage {
     // API validation error to message key mappings
     VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside", true),
     INVALID_CHARACTER("invalid_character", "validation.character.invalid", true),
-    INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.invalid", false),
+    INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.maxExceeded", false),
     INCORRECT_TOTAL("incorrect_total", "validation.total.invalid", true),
     INVALID_CHARACTERS_ENTERED("invalid_characters_entered", "validation.characters.invalid", false),
     MANDATORY_ELEMENT_MISSING("mandatory_element_missing", "validation.element.missing", false),

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -13,6 +13,7 @@ public enum ValidationMessage {
     // API validation error to message key mappings
     VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside", true),
     INVALID_CHARACTER("invalid_character", "validation.character.invalid", true),
+    INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.invalid", false),
     INCORRECT_TOTAL("incorrect_total", "validation.total.invalid", true),
     INVALID_CHARACTERS_ENTERED("invalid_characters_entered", "validation.characters.invalid", false),
     MANDATORY_ELEMENT_MISSING("mandatory_element_missing", "validation.element.missing", false),

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -13,7 +13,7 @@ public enum ValidationMessage {
     // API validation error to message key mappings
     VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside", true),
     INVALID_CHARACTER("invalid_character", "validation.character.invalid", true),
-    INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.maxExceeded", false),
+    INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.invalidInputLength", false),
     INCORRECT_TOTAL("incorrect_total", "validation.total.invalid", true),
     INVALID_CHARACTERS_ENTERED("invalid_characters_entered", "validation.characters.invalid", false),
     MANDATORY_ELEMENT_MISSING("mandatory_element_missing", "validation.element.missing", false),

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/TurnoverPolicy.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/TurnoverPolicy.java
@@ -15,20 +15,4 @@ public class TurnoverPolicy {
 
     @ValidationMapping("$.accounting_policies.turnover_policy")
     private String turnoverPolicyDetails;
-
-    public Boolean getIsIncludeTurnoverSelected() {
-        return isIncludeTurnoverSelected;
-    }
-
-    public void setIsIncludeTurnoverSelected(Boolean isIncludeTurnoverSelected) {
-        this.isIncludeTurnoverSelected = isIncludeTurnoverSelected;
-    }
-
-    public String getTurnoverPolicyDetails() {
-        return turnoverPolicyDetails;
-    }
-
-    public void setTurnoverPolicyDetails(String turnoverPolicyDetails) {
-        this.turnoverPolicyDetails = turnoverPolicyDetails;
-    }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/TurnoverPolicy.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/TurnoverPolicy.java
@@ -3,12 +3,32 @@ package uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolic
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import uk.gov.companieshouse.web.accounts.validation.ValidationMapping;
+import uk.gov.companieshouse.web.accounts.validation.ValidationModel;
 
 @Getter
 @Setter
+@ValidationModel
 public class TurnoverPolicy {
     @NotNull(message = "{turnoverPolicy.selectionNotMade}")
     private Boolean isIncludeTurnoverSelected;
 
+    @ValidationMapping("$.accounting_policies.turnover_policy")
     private String turnoverPolicyDetails;
+
+    public Boolean getIsIncludeTurnoverSelected() {
+        return isIncludeTurnoverSelected;
+    }
+
+    public void setIsIncludeTurnoverSelected(Boolean isIncludeTurnoverSelected) {
+        this.isIncludeTurnoverSelected = isIncludeTurnoverSelected;
+    }
+
+    public String getTurnoverPolicyDetails() {
+        return turnoverPolicyDetails;
+    }
+
+    public void setTurnoverPolicyDetails(String turnoverPolicyDetails) {
+        this.turnoverPolicyDetails = turnoverPolicyDetails;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
@@ -70,8 +70,7 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
 
         List<ValidationError> validationErrors = new ArrayList<>();
 
-        if (turnoverPolicy.getIsIncludeTurnoverSelected() &&
-            IsRequiredFieldEmpty(turnoverPolicy.getTurnoverPolicyDetails())) {
+        if (isTurnoverPolicyDetailsEmpty(turnoverPolicy)) {
 
             ValidationError error = new ValidationError();
             error.setFieldPath(TURNOVER_POLICY_DETAILS_FIELD_PATH);
@@ -83,13 +82,15 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
     }
 
     /**
-     * Check if field contains invalid information when it is not null: empty or contain empty
-     * characters.
+     * Check if turnoverPolicy's required field does not contains invalid information: empty or
+     * contain empty characters.
      *
-     * @param turnoverPolicyDetails the string field that needs to be assessed
+     * @param turnoverPolicy the turnover policy information
      * @return
      */
-    private boolean IsRequiredFieldEmpty(String turnoverPolicyDetails) {
-        return turnoverPolicyDetails != null && StringUtils.trim(turnoverPolicyDetails).isEmpty();
+    private boolean isTurnoverPolicyDetailsEmpty(TurnoverPolicy turnoverPolicy) {
+        return turnoverPolicy.getIsIncludeTurnoverSelected()
+            && turnoverPolicy.getTurnoverPolicyDetails() != null
+            && StringUtils.trim(turnoverPolicy.getTurnoverPolicyDetails()).isEmpty();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
@@ -42,19 +42,10 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
         AccountingPoliciesApi accountingPoliciesApi =
             accountingPoliciesService.getAccountingPoliciesApi(transactionId, companyAccountsId);
 
-        //TODO remove when basis of preparation controller is there.
-        if (accountingPoliciesApi == null) {
-            accountingPoliciesApi = new AccountingPoliciesApi();
-            accountingPoliciesTransformer.setTurnoverPolicy(turnoverPolicy, accountingPoliciesApi);
+        accountingPoliciesTransformer.setTurnoverPolicy(turnoverPolicy, accountingPoliciesApi);
 
-            return accountingPoliciesService.createAccountingPoliciesApi(transactionId, companyAccountsId, accountingPoliciesApi);
-
-        } else {
-            accountingPoliciesTransformer.setTurnoverPolicy(turnoverPolicy, accountingPoliciesApi);
-            return accountingPoliciesService
-                .updateAccountingPoliciesApi(transactionId, companyAccountsId,
-                    accountingPoliciesApi);
-        }
+        return accountingPoliciesService.updateAccountingPoliciesApi(transactionId, companyAccountsId,
+                accountingPoliciesApi);
 
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPoliciesApi;
@@ -14,6 +16,8 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 @Service
 public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
 
+    private static final String TURNOVER_POLICY_DETAILS_FIELD_PATH = "turnoverPolicyDetails";
+    private static final String INVALID_STRING_SIZE_ERROR_MESSAGE = "validation.length.minInvalid.accounting_policies.turnover_policy";
     private final AccountingPoliciesService accountingPoliciesService;
     private final AccountingPoliciesTransformer accountingPoliciesTransformer;
 
@@ -39,6 +43,12 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
     public List<ValidationError> postTurnoverPolicy(String transactionId, String companyAccountsId,
         TurnoverPolicy turnoverPolicy) throws ServiceException {
 
+        List<ValidationError> validationErrors = validateTurnoverPolicyDetails(turnoverPolicy);
+
+        if (!validationErrors.isEmpty()) {
+            return validationErrors;
+        }
+
         AccountingPoliciesApi accountingPoliciesApi =
             accountingPoliciesService.getAccountingPoliciesApi(transactionId, companyAccountsId);
 
@@ -46,6 +56,39 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
 
         return accountingPoliciesService.updateAccountingPoliciesApi(transactionId, companyAccountsId,
                 accountingPoliciesApi);
-
     }
+
+    /**
+     * Validate the turnover policy details' length before calling the api. This string field should
+     * not be empty or contain empty characters.
+     *
+     * @param turnoverPolicy The turnover policy model that needs to be validated
+     * @return A list of validation errors. This will be empty fo
+     */
+    private List<ValidationError> validateTurnoverPolicyDetails(TurnoverPolicy turnoverPolicy) {
+
+        List<ValidationError> validationErrors = new ArrayList<>();
+
+        if (turnoverPolicy.getIsIncludeTurnoverSelected() &&
+            turnoverPolicy.getTurnoverPolicyDetails() != null &&
+            isInValidStringField(turnoverPolicy.getTurnoverPolicyDetails())) {
+
+            ValidationError error = new ValidationError();
+            error.setFieldPath(TURNOVER_POLICY_DETAILS_FIELD_PATH);
+            error.setMessageKey(INVALID_STRING_SIZE_ERROR_MESSAGE);
+            validationErrors.add(error);
+        }
+        return validationErrors;
+    }
+
+    /**
+     * Check if field contains invalid information: empty or contain empty characters.
+     *
+     * @param field the string field that needs to be assessed
+     * @return
+     */
+    private boolean isInValidStringField(String field) {
+        return StringUtils.trim(field).isEmpty();
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImpl.java
@@ -54,7 +54,8 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
 
         accountingPoliciesTransformer.setTurnoverPolicy(turnoverPolicy, accountingPoliciesApi);
 
-        return accountingPoliciesService.updateAccountingPoliciesApi(transactionId, companyAccountsId,
+        return accountingPoliciesService
+            .updateAccountingPoliciesApi(transactionId, companyAccountsId,
                 accountingPoliciesApi);
     }
 
@@ -63,32 +64,32 @@ public class TurnoverPolicyServiceImpl implements TurnoverPolicyService {
      * not be empty or contain empty characters.
      *
      * @param turnoverPolicy The turnover policy model that needs to be validated
-     * @return A list of validation errors. This will be empty fo
+     * @return A list of validation errors. Or empty when turnoverPolicy contains valid information
      */
     private List<ValidationError> validateTurnoverPolicyDetails(TurnoverPolicy turnoverPolicy) {
 
         List<ValidationError> validationErrors = new ArrayList<>();
 
         if (turnoverPolicy.getIsIncludeTurnoverSelected() &&
-            turnoverPolicy.getTurnoverPolicyDetails() != null &&
-            isInValidStringField(turnoverPolicy.getTurnoverPolicyDetails())) {
+            IsRequiredFieldEmpty(turnoverPolicy.getTurnoverPolicyDetails())) {
 
             ValidationError error = new ValidationError();
             error.setFieldPath(TURNOVER_POLICY_DETAILS_FIELD_PATH);
             error.setMessageKey(INVALID_STRING_SIZE_ERROR_MESSAGE);
             validationErrors.add(error);
         }
+
         return validationErrors;
     }
 
     /**
-     * Check if field contains invalid information: empty or contain empty characters.
+     * Check if field contains invalid information when it is not null: empty or contain empty
+     * characters.
      *
-     * @param field the string field that needs to be assessed
+     * @param turnoverPolicyDetails the string field that needs to be assessed
      * @return
      */
-    private boolean isInValidStringField(String field) {
-        return StringUtils.trim(field).isEmpty();
+    private boolean IsRequiredFieldEmpty(String turnoverPolicyDetails) {
+        return turnoverPolicyDetails != null && StringUtils.trim(turnoverPolicyDetails).isEmpty();
     }
-
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -75,3 +75,7 @@ validation.date.invalid.approval.date = The date cannot be on or before the end 
 validation.characters.invalid.accounting_policies.basis_of_measurement_and_preparation = Enter valid characters
 validation.element.missing.accounting_policies.basis_of_measurement_and_preparation = Give details of how your accounts were prepared
 validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_preparation = Basis of preparation must not exceed {0} characters
+
+validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
+validation.element.missing.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
+validation.length.maxExceeded.accounting_policies.turnover_policy = Turnover Policy must not exceed {0} characters

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -77,5 +77,5 @@ validation.element.missing.accounting_policies.basis_of_measurement_and_preparat
 validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_preparation = Basis of preparation must not exceed {0} characters
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
-validation.length.minInvalid.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
-validation.length.invalidInputLength.accounting_policies.turnover_policy = Turnover Policy must not exceed {1} characters
+validation.length.minInvalid.accounting_policies.turnover_policy = Give details of your 'turnover policy'
+validation.length.invalidInputLength.accounting_policies.turnover_policy = You must not exceed {1} characters

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -78,4 +78,4 @@ validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_prepa
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
 validation.length.minInvalid.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
-validation.length.maxExceeded.accounting_policies.turnover_policy = Turnover Policy must not exceed {0} characters
+validation.length.invalidInputLength.accounting_policies.turnover_policy = Turnover Policy must not exceed {1} characters

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -77,5 +77,5 @@ validation.element.missing.accounting_policies.basis_of_measurement_and_preparat
 validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_preparation = Basis of preparation must not exceed {0} characters
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
-validation.element.missing.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
+validation.length.invalid.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
 validation.length.maxExceeded.accounting_policies.turnover_policy = Turnover Policy must not exceed {0} characters

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -75,7 +75,6 @@ validation.date.invalid.approval.date = The date cannot be on or before the end 
 validation.characters.invalid.accounting_policies.basis_of_measurement_and_preparation = Enter valid characters
 validation.element.missing.accounting_policies.basis_of_measurement_and_preparation = Give details of how your accounts were prepared
 validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_preparation = You must not exceed {0} characters
-validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_preparation = Basis of preparation must not exceed {0} characters
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
 validation.length.minInvalid.accounting_policies.turnover_policy = Give details of your 'turnover policy'

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -77,5 +77,5 @@ validation.element.missing.accounting_policies.basis_of_measurement_and_preparat
 validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_preparation = Basis of preparation must not exceed {0} characters
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
-validation.length.invalid.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
+validation.length.minInvalid.accounting_policies.turnover_policy = Give details of how your 'turnover policy'
 validation.length.maxExceeded.accounting_policies.turnover_policy = Turnover Policy must not exceed {0} characters

--- a/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
+++ b/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title></title>
+</head>
+<body>
+<fieldset class="govuk-fieldset" th:fragment="inlineYesNoRadioButtons">
+
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+    <h1 class="govuk-fieldset__heading">
+      <span th:text=${legendText}></span>
+    </h1>
+  </legend>
+
+  <span class="govuk-error-message"
+        th:id="${radioButtonsFieldName} + '-errorId'"
+        th:if="${#fields.hasErrors('__${radioButtonsFieldName}__')}"
+        th:each="e : ${#fields.errors('__${radioButtonsFieldName}__')}" th:text="${e}">
+            </span>
+
+  <!-- Radio Buttons-->
+  <div class="govuk-radios govuk-radios--inline" data-module="radios">
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input show-text"
+             id="yesButton"
+             type="radio"
+             value="1"
+             name="${radioButtonsFieldName}"
+             th:field="*{__${radioButtonsFieldName}__}"
+             th:errorclass="govuk-error-message"
+             th:data-target-text-field="${dataTargetTextFieldName}"/>
+
+      <label class="govuk-label govuk-radios__label" for="yesButton" id="yesButton-label">
+        Yes
+      </label>
+    </div>
+
+    <div class="govuk-radios__item">
+      <input class="govuk-radios__input"
+             id="noButton"
+             type="radio"
+             value="0"
+             name="${radioButtonsFieldName}"
+             th:field="*{__${radioButtonsFieldName}__}"
+             th:errorclass="govuk-error-message"
+             th:data-target-text-field="${dataTargetTextFieldName}"/>
+
+      <label class="govuk-label govuk-radios__label" for="noButton" id="noButton-label">
+        No
+      </label>
+    </div>
+  </div>
+
+  <!-- Text Box Field -->
+  <div class="govuk-radios__conditional govuk-radios__conditional--hidden"
+       th:id="${dataTargetTextFieldName}">
+
+    <div class="govuk-form-group"
+         th:classappend="${#fields.hasErrors('__${textBoxFieldName}__')} ? 'govuk-form-group--error' : ''">
+
+      <span class="govuk-error-message"
+            th:id="${textBoxFieldName} + '-errorId'"
+            th:if="${#fields.hasErrors('__${textBoxFieldName}__')}"
+            th:each="e : ${#fields.errors('__${textBoxFieldName}__')}" th:text="${e}">
+      </span>
+
+      <label class="govuk-label" th:id="${textBoxFieldName} + '-label'"
+             th:for="${textBoxFieldName}"
+             th:if="${boxLabelText != null}" th:text="${boxLabelText}">
+      </label>
+
+      <textarea th:class="${textAreaClassName}"
+                th:id="${textBoxFieldName}"
+                name="${textBoxFieldName}"
+                rows="5"
+                th:field="*{__${textBoxFieldName}__}"
+                th:errorclass="govuk-error-message">
+      </textarea>
+
+    </div>
+  </div>
+
+</fieldset>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
+++ b/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
@@ -83,8 +83,7 @@
                 th:id="${textBoxFieldName}"
                 name="${textBoxFieldName}"
                 rows="5"
-                th:field="*{__${textBoxFieldName}__}"
-                th:errorclass="govuk-error-message">
+                th:field="*{__${textBoxFieldName}__}">
       </textarea>
 
     </div>

--- a/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
+++ b/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
@@ -9,7 +9,7 @@
 
   <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
     <h1 class="govuk-fieldset__heading">
-      <span th:text=${legendText}></span>
+      <span th:id="page-title-heading" th:text=${legendText}></span>
     </h1>
   </legend>
 

--- a/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
+++ b/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
@@ -19,7 +19,7 @@
         th:each="e : ${#fields.errors('__${radioButtonsFieldName}__')}" th:text="${e}">
             </span>
 
-  <!-- Radio Buttons-->
+  <!-- Radio Buttons -->
   <div class="govuk-radios govuk-radios--inline" data-module="radios">
 
     <div class="govuk-radios__item">
@@ -66,9 +66,17 @@
             th:each="e : ${#fields.errors('__${textBoxFieldName}__')}" th:text="${e}">
       </span>
 
+      <!--label text will be different based on javascript switched on or off-->
       <label class="govuk-label" th:id="${textBoxFieldName} + '-label'"
-             th:for="${textBoxFieldName}"
-             th:if="${boxLabelText != null}" th:text="${boxLabelText}">
+             th:for="${textBoxFieldName}">
+
+        <span th:if="${boxLabelTextJavaScriptOn != null}"
+              th:id="${textBoxFieldName} + '-javascript-on-span'" hidden="true" class="onlyJS"
+              th:text="${boxLabelTextJavaScriptOn}"></span>
+
+        <span th:if="${boxLabelTextJavaScriptOff != null}"
+              th:id="${textBoxFieldName} + '-javascript-off-span'" class="hideWhenOnlyJS"
+              th:text="${boxLabelTextJavaScriptOff}"></span>
       </label>
 
       <textarea th:class="${textAreaClassName}"

--- a/src/main/resources/templates/smallfull/turnoverPolicy.html
+++ b/src/main/resources/templates/smallfull/turnoverPolicy.html
@@ -12,93 +12,33 @@
 <div id="turn-over-policy-main-content" layout:fragment="content">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-      <form id="statements-form" class="form" th:action="@{''}" th:object="${turnoverPolicy}" method="post">
+      <form id="statements-form" class="form" th:action="@{''}" th:object="${turnoverPolicy}"
+            method="post">
 
         <div th:replace="fragments/globalErrors :: globalErrors"></div>
 
-        <div class="govuk-form-group" th:classappend="${#fields.hasErrors('isIncludeTurnoverSelected')} ? 'govuk-form-group--error' : ''">
+        <div class="govuk-form-group"
+             th:classappend="${#fields.hasErrors('isIncludeTurnoverSelected')} ? 'govuk-form-group--error' : ''">
 
-          <fieldset class="govuk-fieldset">
+          <div th:replace="fragments/inlineYesNoRadioButtons :: inlineYesNoRadioButtons (
+              legendText = 'Do your prepared accounts include a \'turnover\' policy?',
+              boxLabelText = 'If yes, enter your \'turnover\' policy',
+              radioButtonsFieldName = 'isIncludeTurnoverSelected',
+              textBoxFieldName = 'turnoverPolicyDetails',
+              dataTargetTextFieldName = 'turnover-policy-text-box',
+              textAreaClassName = 'govuk-textarea'
+              )">
+          </div>
 
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-              <h1 class="govuk-fieldset__heading">
-                Do your prepared accounts include a 'turnover' policy?
-              </h1>
-            </legend>
-
-            <span class="govuk-error-message"
-                  id="isIncludeTurnoverSelected-errorId"
-                  th:if="${#fields.hasErrors('isIncludeTurnoverSelected')}"
-                  th:each="e : ${#fields.errors('isIncludeTurnoverSelected')}" th:text="${e}">
-            </span>
-
-            <div class="govuk-radios govuk-radios--inline" data-module="radios">
-
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input show-text"
-                       id="yesButton"
-                       type="radio"
-                       value="1"
-                       name="addTurnoverPolicy"
-                       th:field="*{isIncludeTurnoverSelected}"
-                       th:errorclass="govuk-error-message"
-                       data-target-text-field="turnover-policy-field"/>
-                <label class="govuk-label govuk-radios__label" for="yesButton" id="yesButton-label">
-                  Yes
-                </label>
-              </div>
-
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input"
-                       id="noButton"
-                       type="radio"
-                       value="0"
-                       name="addTurnoverPolicy"
-                       th:field="*{isIncludeTurnoverSelected}"
-                       th:errorclass="govuk-error-message"
-                       data-target-text-field="turnover-policy-field"/>
-                <label class="govuk-label govuk-radios__label" for="noButton" id="noButton-label">
-                  No
-                </label>
-              </div>
-            </div>
-
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="turnover-policy-field">
-
-              <div class="govuk-form-group" th:classappend="${#fields.hasErrors('turnoverPolicyDetails')} ? 'govuk-form-group--error' : ''">
-
-                  <span class="govuk-error-message"
-                        id="customStatement-errorId"
-                        th:if="${#fields.hasErrors('turnoverPolicyDetails')}"
-                        th:each="e : ${#fields.errors('turnoverPolicyDetails')}" th:text="${e}" >
-                  </span>
-
-                <label class="govuk-label govuk-visually-hidden" for="turnover-policy-details">
-                  Enter your 'turnover' policy
-                </label>
-
-                <textarea class="govuk-textarea"
-                          id="turnover-policy-details"
-                          name="small-full-turnover-policy"
-                          rows="5"
-                          th:field="*{turnoverPolicyDetails}"
-                          th:errorclass="govuk-error-message">
-                  </textarea>
-
-              </div>
-            </div>
-
-          </fieldset>
 
         </div>
 
         <div class="govuk-form-group">
-          <input id="next-button" class="govuk-button" type="submit" role="button" value="Save and continue"/>
+          <input id="next-button" class="govuk-button" type="submit" role="button"
+                 value="Save and continue"/>
         </div>
 
       </form>
-
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/smallfull/turnoverPolicy.html
+++ b/src/main/resources/templates/smallfull/turnoverPolicy.html
@@ -22,7 +22,8 @@
 
           <div th:replace="fragments/inlineYesNoRadioButtons :: inlineYesNoRadioButtons (
               legendText = 'Do your prepared accounts include a \'turnover\' policy?',
-              boxLabelText = 'If yes, enter your \'turnover\' policy',
+              boxLabelTextJavaScriptOn = 'Give details of your \'turnover\' policy',
+              boxLabelTextJavaScriptOff = 'If yes, enter your \'turnover\' policy javascript off',
               radioButtonsFieldName = 'isIncludeTurnoverSelected',
               textBoxFieldName = 'turnoverPolicyDetails',
               dataTargetTextFieldName = 'turnover-policy-text-box',

--- a/src/main/resources/templates/smallfull/turnoverPolicy.html
+++ b/src/main/resources/templates/smallfull/turnoverPolicy.html
@@ -23,7 +23,7 @@
           <div th:replace="fragments/inlineYesNoRadioButtons :: inlineYesNoRadioButtons (
               legendText = 'Do your prepared accounts include a \'turnover\' policy?',
               boxLabelTextJavaScriptOn = 'Give details of your \'turnover\' policy',
-              boxLabelTextJavaScriptOff = 'If yes, enter your \'turnover\' policy javascript off',
+              boxLabelTextJavaScriptOff = 'If yes, enter your \'turnover\' policy',
               radioButtonsFieldName = 'isIncludeTurnoverSelected',
               textBoxFieldName = 'turnoverPolicyDetails',
               dataTargetTextFieldName = 'turnover-policy-text-box',

--- a/src/main/resources/templates/smallfull/turnoverPolicy.html
+++ b/src/main/resources/templates/smallfull/turnoverPolicy.html
@@ -5,7 +5,7 @@
     layout:decorate="~{layouts/baseLayout}">
 
 <head>
-  <title id="page-title-heading">
+  <title>
     Do your prepared accounts include a 'turnover' policy?
   </title>
 </head>

--- a/src/main/resources/templates/smallfull/turnoverPolicy.html
+++ b/src/main/resources/templates/smallfull/turnoverPolicy.html
@@ -68,6 +68,12 @@
 
               <div class="govuk-form-group" th:classappend="${#fields.hasErrors('turnoverPolicyDetails')} ? 'govuk-form-group--error' : ''">
 
+                  <span class="govuk-error-message"
+                        id="customStatement-errorId"
+                        th:if="${#fields.hasErrors('turnoverPolicyDetails')}"
+                        th:each="e : ${#fields.errors('turnoverPolicyDetails')}" th:text="${e}" >
+                  </span>
+
                 <label class="govuk-label govuk-visually-hidden" for="turnover-policy-details">
                   Enter your 'turnover' policy
                 </label>
@@ -88,8 +94,7 @@
         </div>
 
         <div class="govuk-form-group">
-          <input id="next-button" class="govuk-button" type="submit" role="button"
-                 value="Save and continue"/>
+          <input id="next-button" class="govuk-button" type="submit" role="button" value="Save and continue"/>
         </div>
 
       </form>

--- a/src/main/resources/templates/smallfull/turnoverPolicy.html
+++ b/src/main/resources/templates/smallfull/turnoverPolicy.html
@@ -5,7 +5,7 @@
     layout:decorate="~{layouts/baseLayout}">
 
 <head>
-  <title>
+  <title id="page-title-heading">
     Do your prepared accounts include a 'turnover' policy?
   </title>
 </head>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationControllerTests.java
@@ -22,7 +22,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
-import uk.gov.companieshouse.web.accounts.controller.smallfull.BasisOfPreparationController;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.BasisOfPreparation;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BasisOfPreparationService;
@@ -56,7 +55,7 @@ public class BasisOfPreparationControllerTests {
 
     private static final String BASIS_OF_PREPARATION_PATH = SMALL_FULL_PATH + "/basis-of-preparation";
 
-    private static final String REVIEW_PATH = SMALL_FULL_PATH + "/review";
+    private static final String TURNOVER_POLICY_PATH = SMALL_FULL_PATH + "/turnover-policy";
 
     private static final String BACK_BUTTON_MODEL_ATTR = "backButton";
 
@@ -111,7 +110,7 @@ public class BasisOfPreparationControllerTests {
 
         this.mockMvc.perform(postRequestWithValidData())
                 .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + REVIEW_PATH));
+                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + TURNOVER_POLICY_PATH));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationControllerTests.java
@@ -49,15 +49,14 @@ public class BasisOfPreparationControllerTests {
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
-    private static final String BASIS_OF_PREPARATION_PATH = "/company/" + COMPANY_NUMBER +
-                                                            "/transaction/" + TRANSACTION_ID +
-                                                            "/company-accounts/" + COMPANY_ACCOUNTS_ID +
-                                                            "/small-full/basis-of-preparation";
+    private static final String SMALL_FULL_PATH = "/company/" + COMPANY_NUMBER +
+                                                    "/transaction/" + TRANSACTION_ID +
+                                                    "/company-accounts/" + COMPANY_ACCOUNTS_ID +
+                                                    "/small-full";
 
-    private static final String REVIEW_PATH = "/company/" + COMPANY_NUMBER +
-                                                "/transaction/" + TRANSACTION_ID +
-                                                "/company-accounts/" + COMPANY_ACCOUNTS_ID +
-                                                "/small-full/review";
+    private static final String BASIS_OF_PREPARATION_PATH = SMALL_FULL_PATH + "/basis-of-preparation";
+
+    private static final String REVIEW_PATH = SMALL_FULL_PATH + "/review";
 
     private static final String BACK_BUTTON_MODEL_ATTR = "backButton";
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyControllerTest.java
@@ -100,7 +100,6 @@ public class TurnoverPolicyControllerTest {
             .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
-
     @Test
     @DisplayName("Post Turnover Policy call is successful")
     void shouldPostTurnoverPolicy() throws Exception {
@@ -168,7 +167,6 @@ public class TurnoverPolicyControllerTest {
             .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
             .andExpect(model().attributeExists(TURNOVER_POLICY_MODEL_ATTR));
     }
-
 
     /**
      * Add the information to the post request. Where the parameter will control if data to be set

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyControllerTest.java
@@ -178,8 +178,8 @@ public class TurnoverPolicyControllerTest {
     private MockHttpServletRequestBuilder createPostRequestWithParam(boolean addInvalidData) {
 
         String beanElement = "isIncludeTurnoverSelected";
-        String validData = addInvalidData ? null : "1";
+        String data = addInvalidData ? null : "1";
 
-        return post(TURNOVER_POLICY_PATH).param(beanElement, validData);
+        return post(TURNOVER_POLICY_PATH).param(beanElement, data);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
@@ -1,12 +1,14 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.service.smallfull.AccountingPoliciesService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.TurnoverPolicyService;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.AccountingPoliciesTransformer;
+import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -29,6 +32,10 @@ public class TurnoverPolicyServiceImplTest {
     private static final String TURNOVER_POLICY_DETAILS = "Turnover policy details";
     private static final String TRANSACTION_ID = "transactionId";
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
+
+    private static final String TURNOVER_POLICY_DETAILS_FIELD_PATH = "turnoverPolicyDetails";
+    private static final String INVALID_STRING_SIZE_ERROR_MESSAGE = "validation.length.minInvalid.accounting_policies.turnover_policy";
+
 
     @Mock
     private AccountingPoliciesTransformer accountingPoliciesTransformerMock;
@@ -53,7 +60,8 @@ public class TurnoverPolicyServiceImplTest {
             .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
             .thenReturn(accountingPoliciesApiMock);
 
-        TurnoverPolicy turnoverPolicyFromTransformer = createTurnOverPolicy();
+        TurnoverPolicy turnoverPolicyFromTransformer = createTurnOverPolicy(
+            TURNOVER_POLICY_DETAILS);
         when(accountingPoliciesTransformerMock.getTurnoverPolicy(accountingPoliciesApiMock))
             .thenReturn(turnoverPolicyFromTransformer);
 
@@ -65,14 +73,14 @@ public class TurnoverPolicyServiceImplTest {
     }
 
     @Test
-    @DisplayName("Post a turnoverPolicy")
+    @DisplayName("Post a turnoverPolicy containing the valid information")
     void shouldPostTurnoverPolicy() throws ServiceException {
 
         when(accountingPoliciesServiceMock
             .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
             .thenReturn(accountingPoliciesApiMock);
 
-        TurnoverPolicy turnoverPolicy = createTurnOverPolicy();
+        TurnoverPolicy turnoverPolicy = createTurnOverPolicy(TURNOVER_POLICY_DETAILS);
 
         doNothing()
             .when(accountingPoliciesTransformerMock)
@@ -87,17 +95,42 @@ public class TurnoverPolicyServiceImplTest {
         verify(accountingPoliciesServiceMock, times(1))
             .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
-        verify(accountingPoliciesServiceMock, times(1))
-            .updateAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID,
-                accountingPoliciesApiMock);
 
     }
 
-    private TurnoverPolicy createTurnOverPolicy() {
+    @Test
+    @DisplayName("Post a turnoverPolicy fails as turnoverPolicyDetails is empty")
+    void shouldFailAsTurnoverPolicyDetailsIsEmpty() throws ServiceException {
+
+        TurnoverPolicy turnoverPolicy = createTurnOverPolicy("");
+
+        List<ValidationError> validationErrors = turnoverPolicyService
+            .postTurnoverPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, turnoverPolicy);
+
+        assertFalse(validationErrors.isEmpty());
+        assertEquals(validationErrors.get(0).getFieldPath(), TURNOVER_POLICY_DETAILS_FIELD_PATH);
+        assertEquals(validationErrors.get(0).getMessageKey(), INVALID_STRING_SIZE_ERROR_MESSAGE);
+    }
+
+    @Test
+    @DisplayName("Post a turnoverPolicy fails as turnoverPolicyDetails contains empty characters")
+    void shouldFailAsTurnoverPolicyDetailsContainsEmptyCharacters() throws ServiceException {
+
+        TurnoverPolicy turnoverPolicy = createTurnOverPolicy("    ");
+
+        List<ValidationError> validationErrors = turnoverPolicyService
+            .postTurnoverPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, turnoverPolicy);
+
+        assertFalse(validationErrors.isEmpty());
+        assertEquals(validationErrors.get(0).getFieldPath(), TURNOVER_POLICY_DETAILS_FIELD_PATH);
+        assertEquals(validationErrors.get(0).getMessageKey(), INVALID_STRING_SIZE_ERROR_MESSAGE);
+    }
+
+    private TurnoverPolicy createTurnOverPolicy(String turnoverPolicyDetails) {
         TurnoverPolicy turnoverPolicy = new TurnoverPolicy();
 
         turnoverPolicy.setIsIncludeTurnoverSelected(true);
-        turnoverPolicy.setTurnoverPolicyDetails(TURNOVER_POLICY_DETAILS);
+        turnoverPolicy.setTurnoverPolicyDetails(turnoverPolicyDetails);
 
         return turnoverPolicy;
     }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
@@ -93,8 +93,6 @@ public class TurnoverPolicyServiceImplTest {
 
         verify(accountingPoliciesServiceMock, times(1))
             .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
-
-
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
@@ -36,7 +36,6 @@ public class TurnoverPolicyServiceImplTest {
     private static final String TURNOVER_POLICY_DETAILS_FIELD_PATH = "turnoverPolicyDetails";
     private static final String INVALID_STRING_SIZE_ERROR_MESSAGE = "validation.length.minInvalid.accounting_policies.turnover_policy";
 
-
     @Mock
     private AccountingPoliciesTransformer accountingPoliciesTransformerMock;
     @Mock

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/TurnoverPolicyServiceImplTest.java
@@ -96,6 +96,30 @@ public class TurnoverPolicyServiceImplTest {
     }
 
     @Test
+    @DisplayName("Post a turnoverPolicy containing the valid information, turnover policy details is null)")
+    void shouldPostTurnoverPolicyWhenPolicyDetailsIsNull() throws ServiceException {
+
+        when(accountingPoliciesServiceMock
+            .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+            .thenReturn(accountingPoliciesApiMock);
+
+        TurnoverPolicy turnoverPolicy = createTurnOverPolicy(null);
+
+        doNothing()
+            .when(accountingPoliciesTransformerMock)
+            .setTurnoverPolicy(turnoverPolicy, accountingPoliciesApiMock);
+
+        turnoverPolicyService
+            .postTurnoverPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, turnoverPolicy);
+
+        verify(accountingPoliciesTransformerMock, times(1))
+            .setTurnoverPolicy(turnoverPolicy, accountingPoliciesApiMock);
+
+        verify(accountingPoliciesServiceMock, times(1))
+            .getAccountingPoliciesApi(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+    }
+
+    @Test
     @DisplayName("Post a turnoverPolicy fails as turnoverPolicyDetails is empty")
     void shouldFailAsTurnoverPolicyDetailsIsEmpty() throws ServiceException {
 

--- a/start.sh
+++ b/start.sh
@@ -28,6 +28,3 @@ else
 fi
 
 exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.web.ch.gov.uk.jar"
-
-# debug settings
-#exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.web.ch.gov.uk.jar"

--- a/start.sh
+++ b/start.sh
@@ -28,3 +28,6 @@ else
 fi
 
 exec java ${JAVA_MEM_ARGS} -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.web.ch.gov.uk.jar"
+
+# debug settings
+#exec java -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=21095 -jar -Dserver.port="${PORT}" "${APP_DIR}/company-accounts.web.ch.gov.uk.jar"


### PR DESCRIPTION
Code changes to add the turnover policy controller. 
- `turnoverPolicy model` 
Adding missing validation in the `turnover policy model`

- `ValidationMessages.properties` and `messages.properties`
Adding new error messages for the turnover policy validation.
- `ValidationMessage`
Adding new entry in the enumeration error mappings to cater for the latest `api's changes`. The api will trigger the same error, `invalid_input_length`, when string fields are either equals to the `min length` or `exceeds the max length`.  
The returned `invalid_input_length` from the api needs to map to `validation.length.maxExceeded`.  
- `Turnover Policy Service` 
Changes to cater for the latest `api's changes`. Validation added to check the `turnoverPolicy` model before sending it to the api. We should not send it to the api if it is `empty` or `contains multiple empty spaces`
- `turnoverPolicy` html and fragment `inlineYesNoRadioButtons` html
New fragment has been created for the `radio buttons` and for `the text box`. Not only will this be used by `turnoverPolicy.html` but also by other 3 accounting policy's screens. 
- JUnit test added for the controller
- `BasisOfPreparationController` and its JUnit test (`BasisOfPreparationControllerTests`) 
it had to change since it now leads to the `turnoverPolicy screen` instead of the `check your answer's screen`
- `ReviewScreenController` 
`PreviousController` had to change since it is now `turnoverPolicyController` instead of `BasisOfPreparationController`
- DisplayName's changes in `AccountingPoliciesTransformerImplTests.java` to make them more descriptive.

Resolves: SFA-631

Reliant on:
https://github.com/companieshouse/cdn.ch.gov.uk/pull/286