### PR TITLE
Changing displayed text in Prepare your accounts screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/BasisOfPreparation.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/accountingpolicies/BasisOfPreparation.java
@@ -17,8 +17,5 @@ public class BasisOfPreparation {
     @ValidationMapping("$.accounting_policies.basis_of_measurement_and_preparation")
     private String customStatement;
 
-    private String preparedStatement =
-            "These financial statements have been prepared in accordance with the provisions of "
-                    + "Section 1A (Small Entities) of Financial Reporting Standard 102";
-
+    private String preparedStatement = "These financial statements have been prepared in accordance with section 396 of the Companies Act";
 }

--- a/src/main/resources/templates/smallfull/basisOfPreparation.html
+++ b/src/main/resources/templates/smallfull/basisOfPreparation.html
@@ -45,9 +45,7 @@
 
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="basisOfPreparation-prepared-statement" data-target-text-field="basisOfPreparation-custom-statement-field" th:field="*{isPreparedInAccordanceWithStandards}" type="radio" value="1">
-                <label class="govuk-label govuk-radios__label" id="basisOfPreparation-prepared-statement-label" for="basisOfPreparation-prepared-statement">
-                  These financial statements have been prepared in accordance with the provisions of Section 1A (Small Entities) of Financial Reporting Standard 102
-                </label>
+                <label class="govuk-label govuk-radios__label" id="basisOfPreparation-prepared-statement-label" for="basisOfPreparation-prepared-statement" th:text="*{preparedStatement}"></label>
               </div>
 
               <div class="govuk-radios__item">

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/AccountingPoliciesTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/AccountingPoliciesTransformerImplTests.java
@@ -22,8 +22,7 @@ import uk.gov.companieshouse.web.accounts.transformer.smallfull.impl.AccountingP
 public class AccountingPoliciesTransformerImplTests {
 
     private static final String BASIS_OF_PREPARATION_PREPARED_STATEMENT =
-        "These financial statements have been prepared in accordance with the provisions of "
-            + "Section 1A (Small Entities) of Financial Reporting Standard 102";
+        "These financial statements have been prepared in accordance with section 396 of the Companies Act";
 
     private static final String BASIS_OF_PREPARATION_CUSTOM_STATEMENT = "customStatement";
     private static final String TURNOVER_POLICY_DETAILS = "turnoverPolicyDetails";


### PR DESCRIPTION
Changes to update the text in the Prepare your accounts screen's radio button. Changes: 
- in the model 
- in the html file to read the text from the model instead of hardcoding it
Resolves: SFA-940