### PR TITLE
Added the script include for body-js-enable.js

### DIFF
--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -18,6 +18,7 @@
     
 </head>
 <body>
+    <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <div class="entire-wrapper">
         <div th:replace="fragments/header :: header"></div>
         <div class="govuk-width-container">


### PR DESCRIPTION
Added the include for the`body-js-enable.js` file to prevent the flickering of objects rendering for a split second before disappearing when using the javascript on journey.

See also: https://github.com/companieshouse/cdn.ch.gov.uk/pull/290

Helps solve: SFA-964