### PR TITLE
Correct api error returned when entering an invalid character

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -12,7 +12,6 @@ public enum ValidationMessage {
 
     // API validation error to message key mappings
     VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside", true),
-    INVALID_CHARACTER("invalid_character", "validation.character.invalid", true),
     INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.invalidInputLength", false),
     INCORRECT_TOTAL("incorrect_total", "validation.total.invalid", true),
     INVALID_CHARACTERS_ENTERED("invalid_character", "validation.characters.invalid", false),

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -15,7 +15,7 @@ public enum ValidationMessage {
     INVALID_CHARACTER("invalid_character", "validation.character.invalid", true),
     INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.invalidInputLength", false),
     INCORRECT_TOTAL("incorrect_total", "validation.total.invalid", true),
-    INVALID_CHARACTERS_ENTERED("invalid_characters_entered", "validation.characters.invalid", false),
+    INVALID_CHARACTERS_ENTERED("invalid_character", "validation.characters.invalid", false),
     MANDATORY_ELEMENT_MISSING("mandatory_element_missing", "validation.element.missing", false),
     DATE_CANNOT_BE_FUTURE("date_cannot_be_in_future", "validation.date.cannotBeFuture", true),
     DATE_INVALID("date_is_invalid", "validation.date.invalid", false),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -61,7 +61,7 @@ date = Approval date:
 
 # Validation
 validation.range.outside = Enter a value between {0} and {1}
-validation.character.invalid = Enter a value without commas, brackets or other symbols
+validation.characters.invalid = Enter a value without commas, brackets or other symbols
 validation.total.invalid = Total provided is incorrect
 validation.date.cannotBeFuture = The date cannot be in the future
 validation.date.nonExistent = Enter a valid date

--- a/src/test/java/uk/gov/companieshouse/web/accounts/util/ValidationContextTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/util/ValidationContextTest.java
@@ -51,8 +51,8 @@ public class ValidationContextTest {
     private static final String JSON_PATH = "json.path";
     private static final String FIELD_PATH = "mockString";
     private static final String NESTED_FIELD_PATH = "mockValidationModel.mockString";
-    private static final String MESSAGE_KEY = "invalid_character";
-    private static final String WEB_ERROR_MESSAGE = "validation.character.invalid";
+    private static final String MESSAGE_KEY = "incorrect_total";
+    private static final String WEB_ERROR_MESSAGE = "validation.total.invalid";
     private static final String ERROR = "error";
     private static final Map<String, String> MESSAGE_ARGUMENTS = new HashMap<>();
 


### PR DESCRIPTION
Correct api error returned when an invalid character is entered

invalid_characters_entered to invalid_character.

Corresponding api change in https://github.com/companieshouse/company-accounts.api.ch.gov.uk/pull/159