### PR TITLE
Fix error message mappings for API error: 'invalid_character'

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -12,10 +12,9 @@ public enum ValidationMessage {
 
     // API validation error to message key mappings
     VALUE_OUTSIDE_RANGE("value_outside_range", "validation.range.outside", true),
-    INVALID_CHARACTER("invalid_character", "validation.character.invalid", true),
+    INVALID_CHARACTER("invalid_character", "validation.characters.invalid", false),
     INVALID_INPUT_LENGTH("invalid_input_length", "validation.length.invalidInputLength", false),
     INCORRECT_TOTAL("incorrect_total", "validation.total.invalid", true),
-    INVALID_CHARACTERS_ENTERED("invalid_characters_entered", "validation.characters.invalid", false),
     MANDATORY_ELEMENT_MISSING("mandatory_element_missing", "validation.element.missing", false),
     DATE_CANNOT_BE_FUTURE("date_cannot_be_in_future", "validation.date.cannotBeFuture", true),
     DATE_INVALID("date_is_invalid", "validation.date.invalid", false),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -61,7 +61,6 @@ date = Approval date:
 
 # Validation
 validation.range.outside = Enter a value between {0} and {1}
-validation.character.invalid = Enter a value without commas, brackets or other symbols
 validation.total.invalid = Total provided is incorrect
 validation.date.cannotBeFuture = The date cannot be in the future
 validation.date.nonExistent = Enter a valid date

--- a/src/test/java/uk/gov/companieshouse/web/accounts/util/ValidationContextTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/util/ValidationContextTest.java
@@ -51,8 +51,8 @@ public class ValidationContextTest {
     private static final String JSON_PATH = "json.path";
     private static final String FIELD_PATH = "mockString";
     private static final String NESTED_FIELD_PATH = "mockValidationModel.mockString";
-    private static final String MESSAGE_KEY = "invalid_character";
-    private static final String WEB_ERROR_MESSAGE = "validation.character.invalid";
+    private static final String MESSAGE_KEY = "value_outside_range";
+    private static final String WEB_ERROR_MESSAGE = "validation.range.outside";
     private static final String ERROR = "error";
     private static final Map<String, String> MESSAGE_ARGUMENTS = new HashMap<>();
 


### PR DESCRIPTION
Make the `invalid_character` error returned from the API map to a non-generic web error message key.

Fixes bug: SFA-1022