### PR TITLE
Add 10 year expiration to cookie so it "never" expires

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/CompanyAccountsDataStateInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/CompanyAccountsDataStateInterceptor.java
@@ -127,6 +127,9 @@ public class CompanyAccountsDataStateInterceptor extends HandlerInterceptorAdapt
                 stateCookie.setValue(token);
                 stateCookie.setPath("/");
 
+                //Set expiration of cookie to 10 years in the future
+                stateCookie.setMaxAge(60 * 60 * 24 * 365 * 10);
+
                 // Add the cookie to the response to save it
                 response.addCookie(stateCookie);
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/CompanyAccountsDataStateInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/interceptor/CompanyAccountsDataStateInterceptor.java
@@ -30,6 +30,9 @@ public class CompanyAccountsDataStateInterceptor extends HandlerInterceptorAdapt
 
     private static final Pattern APPROVAL_REGEX = Pattern.compile("/approval$");
 
+    //Used to expire the cookie 10 years in the future, therefore it's "never expiring"
+    private static final Integer COOKIE_EXPIRY = 60 * 60 * 24 * 365 * 10;
+
     @Autowired
     private TokenManager tokenManager;
 
@@ -126,9 +129,7 @@ public class CompanyAccountsDataStateInterceptor extends HandlerInterceptorAdapt
                 String token = tokenManager.createJWT(companyAccountsDataStates);
                 stateCookie.setValue(token);
                 stateCookie.setPath("/");
-
-                //Set expiration of cookie to 10 years in the future
-                stateCookie.setMaxAge(60 * 60 * 24 * 365 * 10);
+                stateCookie.setMaxAge(COOKIE_EXPIRY);
 
                 // Add the cookie to the response to save it
                 response.addCookie(stateCookie);


### PR DESCRIPTION
Cookies need to have some kind of expiry, and given the nature of the cookie it needs to last as long as possible. 10 years is *enough* time that a person will probably either change their computer or clear their cookies before then, so it's considered a "never-expiring" cookie.

Resolves: SFA-1051.