### PR TITLE
Move navigation to service layer and add support for error handling

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
@@ -9,7 +9,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.web.accounts.CompanyAccountsWebApplication;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ import java.util.Map;
 public abstract class BaseController {
 
     @Autowired
-    protected Navigator navigator;
+    protected NavigatorService navigatorService;
 
     protected static final Logger LOGGER = LoggerFactory
             .getLogger(CompanyAccountsWebApplication.APPLICATION_NAME_SPACE);
@@ -64,7 +64,7 @@ public abstract class BaseController {
 
     protected void addBackPageAttributeToModel(Model model, String... pathVars) {
 
-        model.addAttribute("backButton", navigator.getPreviousControllerPath(this.getClass(), pathVars));
+        model.addAttribute("backButton", navigatorService.getPreviousControllerPath(this.getClass(), pathVars));
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/ConditionalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/ConditionalController.java
@@ -15,11 +15,18 @@ public interface ConditionalController {
 
     /**
      * Returns a boolean value indicating whether the template associated
-     * with a controller will be rendered or not.
+     * with a controller will be rendered or not. Any {@code ServiceException}
+     * generated when determining whether the controller should render or
+     * not should be thrown from this method and will be handled by the
+     * navigation service and result in an error page being returned to the
+     * user agent.
      *
      * @param companyNumber     the company number
      * @param transactionId     the transaction identifier
      * @param companyAccountsId the company accounts identifier
+     *
+     * @see uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService
+     * @see uk.gov.companieshouse.web.accounts.exception.NavigationException
      *
      * @return true if the template for a controller will be rendered
      */

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/ConditionalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/ConditionalController.java
@@ -15,7 +15,7 @@ public interface ConditionalController {
 
     /**
      * Returns a boolean value indicating whether the template associated
-     * with a controller will be rendered or not. Any {@code ServiceException}
+     * with a controller will be rendered or not. Any {@link ServiceException}
      * generated when determining whether the controller should render or
      * not should be thrown from this method and will be handled by the
      * navigation service and result in an error page being returned to the

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/ConditionalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/ConditionalController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.web.accounts.controller;
 
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+
 /**
  * The {@code ConditionalController} interface defines a single method that
  * should be implemented in controller classes whose template is rendered
@@ -21,5 +23,5 @@ public interface ConditionalController {
      *
      * @return true if the template for a controller will be rendered
      */
-    boolean willRender(String companyNumber, String transactionId, String companyAccountsId);
+    boolean willRender(String companyNumber, String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetController.java
@@ -83,6 +83,6 @@ public class BalanceSheetController extends BaseController {
             return ERROR_VIEW;
         }
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationController.java
@@ -79,7 +79,7 @@ public class BasisOfPreparationController extends BaseController {
             return ERROR_VIEW;
         }
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaController.java
@@ -45,6 +45,6 @@ public class CriteriaController extends BaseController {
             return getTemplateName();
         }
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/IntangibleAmortisationPolicyController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/IntangibleAmortisationPolicyController.java
@@ -90,7 +90,7 @@ public class IntangibleAmortisationPolicyController extends BaseController {
 
         cacheIsPolicyIncluded(request, intangibleAmortisationPolicy);
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/OtherAccountingPolicyController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/OtherAccountingPolicyController.java
@@ -87,7 +87,7 @@ public class OtherAccountingPolicyController extends BaseController {
 
         cacheIsPolicyIncluded(request, otherAccountingPolicy);
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId,
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId,
             companyAccountsId);
     }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ReviewController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ReviewController.java
@@ -56,7 +56,7 @@ public class ReviewController extends BaseController {
                                  @PathVariable String transactionId,
                                  @PathVariable String companyAccountsId) {
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StatementsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StatementsController.java
@@ -57,7 +57,7 @@ public class StatementsController extends BaseController {
             return ERROR_VIEW;
         }
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -73,7 +73,7 @@ public class StepsToCompleteController extends BaseController {
 
             transactionService.createResumeLink(companyNumber, transactionId, companyAccountsId);
 
-            return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+            return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
 
         } catch (ServiceException e) {
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TangibleDepreciationPolicyController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TangibleDepreciationPolicyController.java
@@ -92,7 +92,7 @@ public class TangibleDepreciationPolicyController extends BaseController {
 
         cacheIsPolicyIncluded(request, tangiblePolicy);
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId,
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId,
             companyAccountsId);
     }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyController.java
@@ -88,7 +88,7 @@ public class TurnoverPolicyController extends BaseController {
 
         cacheIsPolicyIncluded(request, turnoverPolicy);
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId,
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId,
             companyAccountsId);
     }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ValuationInformationPolicyController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ValuationInformationPolicyController.java
@@ -92,7 +92,7 @@ public class ValuationInformationPolicyController extends BaseController {
 
         cacheIsPolicyIncluded(request, valuationInformationPolicy);
 
-        return navigator.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber, transactionId, companyAccountsId);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/NavigationException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/NavigationException.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.web.accounts.exception;
+
+/**
+ * The class {@code NavigationException} is a form of {@link RuntimeException}
+ * that is thrown if errors occur when attempting to determine if
+ * a conditional controller should render or not during navigation.
+ *
+ * @see uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService
+ * @see uk.gov.companieshouse.web.accounts.controller.ConditionalController
+ **/
+public class NavigationException extends RuntimeException {
+
+    /**
+     * Constructs a new {@code NavigationException} with a custom message and the specified
+     * cause.
+     *
+     * @param message a custom message
+     * @param cause the cause
+     */
+    public NavigationException(String message, Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/NavigationException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/NavigationException.java
@@ -18,6 +18,6 @@ public class NavigationException extends RuntimeException {
      * @param cause the cause
      */
     public NavigationException(String message, Throwable cause) {
-        super(cause);
+        super(message, cause);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -17,7 +17,7 @@ import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.Approval;
 import uk.gov.companieshouse.web.accounts.service.smallfull.ApprovalService;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -44,7 +44,7 @@ public class ApprovalControllerTests {
     private TransactionService transactionService;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private ApprovalController approvalController;
@@ -77,7 +77,7 @@ public class ApprovalControllerTests {
 
     @BeforeEach
     private void setup() {
-        when(navigator.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
         this.mockMvc = MockMvcBuilders.standaloneSetup(approvalController).build();
     }
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BalanceSheetControllerTests.java
@@ -29,7 +29,7 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ public class BalanceSheetControllerTests {
     private BalanceSheetService balanceSheetService;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private BalanceSheetController controller;
@@ -75,7 +75,7 @@ public class BalanceSheetControllerTests {
 
     @BeforeEach
     private void setup() {
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -112,7 +112,7 @@ public class BalanceSheetControllerTests {
     @DisplayName("Post balance sheet success path")
     void postRequestSuccess() throws Exception {
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
         when(balanceSheetService.postBalanceSheet(anyString(), anyString(), any(BalanceSheet.class), anyString())).thenReturn(new ArrayList<>());
 
         this.mockMvc.perform(post(BALANCE_SHEET_PATH))

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/BasisOfPreparationControllerTests.java
@@ -26,7 +26,7 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.BasisOfPreparation;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BasisOfPreparationService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,7 +42,7 @@ public class BasisOfPreparationControllerTests {
     private BasisOfPreparationService basisOfPreparationService;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private BasisOfPreparationController controller;
@@ -74,7 +74,7 @@ public class BasisOfPreparationControllerTests {
 
     @BeforeEach
     private void setup() {
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -112,7 +112,7 @@ public class BasisOfPreparationControllerTests {
         when(basisOfPreparationService.submitBasisOfPreparation(eq(TRANSACTION_ID), eq(COMPANY_ACCOUNTS_ID), any(BasisOfPreparation.class)))
                 .thenReturn(validationErrors);
         when(validationErrors.isEmpty()).thenReturn(true);
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(postRequestWithValidData())
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CriteriaControllerTests.java
@@ -20,7 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -29,7 +29,7 @@ public class CriteriaControllerTests {
     private MockMvc mockMvc;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private CriteriaController controller;
@@ -71,7 +71,7 @@ public class CriteriaControllerTests {
         String beanElement = "isCriteriaMet";
         String criteriaMet = "yes";
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(post(CRITERIA_PATH)
                 .param(beanElement, criteriaMet))

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/IntangibleAmortisationPolicyControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/IntangibleAmortisationPolicyControllerTests.java
@@ -32,7 +32,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.state.AccountingPolicies;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.smallfull.IntangibleAmortisationPolicyService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +54,7 @@ public class IntangibleAmortisationPolicyControllerTests {
     private AccountingPolicies accountingPolicies;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private IntangibleAmortisationPolicyController controller;
@@ -102,7 +102,7 @@ public class IntangibleAmortisationPolicyControllerTests {
         intangibleAmortisationPolicy.setIncludeIntangibleAmortisationPolicy(true);
         when(intangibleAmortisationPolicyService.getIntangibleAmortisationPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(intangibleAmortisationPolicy);
-        when(navigator.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(INTANGIBLE_AMORTISATION_POLICY_PATH))
                 .andExpect(status().isOk())
@@ -124,7 +124,7 @@ public class IntangibleAmortisationPolicyControllerTests {
 
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
         when(accountingPolicies.getHasProvidedIntangiblePolicy()).thenReturn(false);
-        when(navigator.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(INTANGIBLE_AMORTISATION_POLICY_PATH).session(session))
                 .andExpect(status().isOk())
@@ -163,7 +163,7 @@ public class IntangibleAmortisationPolicyControllerTests {
         session.setAttribute(COMPANY_ACCOUNTS_STATE, companyAccountsDataState);
 
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(postRequestWithValidData().session(session))
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/OtherAccountingPolicyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/OtherAccountingPolicyControllerTest.java
@@ -33,7 +33,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.state.AccountingPolicies;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.smallfull.OtherAccountingPolicyService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +55,7 @@ public class OtherAccountingPolicyControllerTest {
     private AccountingPolicies accountingPolicies;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private OtherAccountingPolicyController controller;
@@ -93,7 +93,7 @@ public class OtherAccountingPolicyControllerTest {
         when(otherAccountingPolicyService
             .getOtherAccountingPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
             .thenReturn(otherAccountingPolicy);
-        when(navigator.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(OTHER_ACCOUNTING_POLICY_PATH))
             .andExpect(status().isOk())
@@ -117,7 +117,7 @@ public class OtherAccountingPolicyControllerTest {
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
         when(accountingPolicies.getHasProvidedOtherAccountingPolicy()).thenReturn(false);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(OTHER_ACCOUNTING_POLICY_PATH).session(session))
                 .andExpect(status().isOk())
@@ -156,7 +156,7 @@ public class OtherAccountingPolicyControllerTest {
         session.setAttribute(COMPANY_ACCOUNTS_STATE, companyAccountsDataState);
 
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
-        when(navigator.getNextControllerRedirect(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(postRequestWithValidData().session(session))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ResumeControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ResumeControllerTests.java
@@ -12,7 +12,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.service.smallfull.ResumeService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -43,7 +43,7 @@ public class ResumeControllerTests {
     ResumeService resumeService;
 
     @Mock
-    Navigator navigator;
+    NavigatorService navigatorService;
 
     @InjectMocks
     private ResumeController controller;

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ReviewControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ReviewControllerTests.java
@@ -19,7 +19,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.Review;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.ReviewService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -65,7 +65,7 @@ public class ReviewControllerTests {
     ReviewService reviewService;
 
     @Mock
-    Navigator navigator;
+    NavigatorService navigatorService;
 
     private MockMvc mockMvc;
 
@@ -113,7 +113,7 @@ public class ReviewControllerTests {
     @DisplayName("Post review page success path")
     void postRequestSuccess() throws Exception {
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(post(REVIEW_PATH))
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StatementsControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StatementsControllerTests.java
@@ -25,7 +25,7 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.Statements;
 import uk.gov.companieshouse.web.accounts.service.smallfull.StatementsService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -37,7 +37,7 @@ public class StatementsControllerTests {
     private StatementsService statementsService;
 
     @Mock
-    Navigator navigator;
+    NavigatorService navigatorService;
 
     @InjectMocks
     private StatementsController controller;
@@ -78,7 +78,7 @@ public class StatementsControllerTests {
         when(statementsService.getBalanceSheetStatements(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(new Statements());
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(STATEMENTS_PATH))
                 .andExpect(status().isOk())
@@ -106,7 +106,7 @@ public class StatementsControllerTests {
 
         doNothing().when(statementsService).acceptBalanceSheetStatements(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(post(STATEMENTS_PATH))
                 .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
@@ -36,7 +36,7 @@ import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccount
 import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.StatementsService;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -60,7 +60,7 @@ public class StepsToCompleteControllerTests {
     private StatementsService statementsService;
 
     @Mock
-    Navigator navigator;
+    NavigatorService navigatorService;
 
     @InjectMocks
     private StepsToCompleteController controller;
@@ -94,7 +94,7 @@ public class StepsToCompleteControllerTests {
     @DisplayName("Get steps to complete view success path")
     void getRequestSuccess() throws Exception {
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(STEPS_TO_COMPLETE_PATH))
                 .andExpect(status().isOk())
@@ -124,7 +124,7 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn)).thenReturn(COMPANY_ACCOUNTS_ID);
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         doNothing().when(smallFullService).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TangibleDepreciationPolicyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TangibleDepreciationPolicyControllerTest.java
@@ -33,7 +33,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.state.AccountingPolicies;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.smallfull.impl.TangibleDepreciationPolicyServiceImpl;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +55,7 @@ public class TangibleDepreciationPolicyControllerTest {
     private AccountingPolicies accountingPolicies;
 
     @Mock
-    Navigator navigator;
+    NavigatorService navigatorService;
 
     @InjectMocks
     private TangibleDepreciationPolicyController controller;
@@ -92,7 +92,7 @@ public class TangibleDepreciationPolicyControllerTest {
             .getTangibleDepreciationPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
             .thenReturn(tangibleDepreciationPolicy);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(TANGIBLE_DEPRECIATION_POLICY_PATH))
             .andExpect(status().isOk())
@@ -116,7 +116,7 @@ public class TangibleDepreciationPolicyControllerTest {
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
         when(accountingPolicies.getHasProvidedTangiblePolicy()).thenReturn(false);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(TANGIBLE_DEPRECIATION_POLICY_PATH).session(session))
                 .andExpect(status().isOk())
@@ -156,7 +156,7 @@ public class TangibleDepreciationPolicyControllerTest {
 
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(postRequestWithValidData().session(session))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/TurnoverPolicyControllerTest.java
@@ -35,7 +35,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.state.AccountingPolicies;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.smallfull.TurnoverPolicyService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,14 +80,14 @@ public class TurnoverPolicyControllerTest {
     private AccountingPolicies accountingPolicies;
 
     @Mock
-    Navigator navigator;
+    NavigatorService navigatorService;
 
     @InjectMocks
     private TurnoverPolicyController turnoverPolicyController;
 
     @BeforeEach
     private void setupBeforeEach() {
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
         this.mockMvc = MockMvcBuilders.standaloneSetup(turnoverPolicyController).build();
     }
 
@@ -100,7 +100,7 @@ public class TurnoverPolicyControllerTest {
         when(turnoverPolicyServiceMock.getTurnOverPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
             .thenReturn(turnoverPolicy);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc
             .perform(get(TURNOVER_POLICY_PATH))
@@ -166,7 +166,7 @@ public class TurnoverPolicyControllerTest {
 
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(createPostRequestWithParam(false).session(session))
             .andExpect(status().is3xxRedirection())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ValuationInformationPolicyControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ValuationInformationPolicyControllerTest.java
@@ -33,7 +33,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.state.AccountingPolicies;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.smallfull.ValuationInformationPolicyService;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @ExtendWith(MockitoExtension.class)
@@ -78,7 +78,7 @@ public class ValuationInformationPolicyControllerTest {
     private AccountingPolicies accountingPolicies;
 
     @Mock
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private ValuationInformationPolicyController controller;
@@ -97,7 +97,7 @@ public class ValuationInformationPolicyControllerTest {
         when(valuationInformationPolicyService.getValuationInformationPolicy(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
             .thenReturn(valuationInformationPolicy);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc
             .perform(get(VALUATION_INFORMATION_POLICY_PATH))
@@ -121,7 +121,7 @@ public class ValuationInformationPolicyControllerTest {
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
         when(accountingPolicies.getHasProvidedValuationInformationPolicy()).thenReturn(false);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc
                 .perform(get(VALUATION_INFORMATION_POLICY_PATH).session(session))
@@ -164,7 +164,7 @@ public class ValuationInformationPolicyControllerTest {
 
         when(companyAccountsDataState.getAccountingPolicies()).thenReturn(accountingPolicies);
 
-        when(navigator.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(createPostRequestWithParam(true).session(session))
             .andExpect(status().is3xxRedirection())
@@ -177,7 +177,7 @@ public class ValuationInformationPolicyControllerTest {
     @DisplayName("Submit valuation information policy - binding result errors")
     void postRequestBindingResultErrors() throws Exception {
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc
             .perform(createPostRequestWithParam(false))
@@ -199,7 +199,7 @@ public class ValuationInformationPolicyControllerTest {
 
         when(validationErrors.isEmpty()).thenReturn(false);
 
-        when(navigator.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+        when(navigatorService.getPreviousControllerPath(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc
             .perform(createPostRequestWithParam(true))

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/NavigatorServiceTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/NavigatorServiceTests.java
@@ -10,6 +10,8 @@ import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.MissingAnnotationException;
+import uk.gov.companieshouse.web.accounts.exception.NavigationException;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerEight;
 import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerFive;
 import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerFour;
 import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerOne;
@@ -141,5 +143,14 @@ public class NavigatorServiceTests {
         String redirect = navigatorService.getPreviousControllerPath(MockSuccessJourneyControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         assertEquals("/mock-success-journey-controller-one", redirect);
+    }
+
+    @Test
+    public void navigationExceptionThrownWhenWillRenderThrowsServiceException() {
+        when(applicationContext.getBean(MockControllerSeven.class)).thenReturn(new MockControllerSeven());
+        when(applicationContext.getBean(MockControllerEight.class)).thenReturn(new MockControllerEight());
+
+        assertThrows(NavigationException.class, () -> navigatorService.getNextControllerRedirect(MockControllerSeven.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/NavigatorServiceTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/NavigatorServiceTests.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.web.accounts.util.navigator;
+package uk.gov.companieshouse.web.accounts.service.navigation;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +10,15 @@ import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.MissingAnnotationException;
-import uk.gov.companieshouse.web.accounts.util.Navigator;
-import uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerFive;
-import uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerFour;
-import uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerOne;
-import uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerSeven;
-import uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerThree;
-import uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerTwo;
-import uk.gov.companieshouse.web.accounts.util.navigator.success.MockSuccessJourneyControllerOne;
-import uk.gov.companieshouse.web.accounts.util.navigator.success.MockSuccessJourneyControllerThree;
-import uk.gov.companieshouse.web.accounts.util.navigator.success.MockSuccessJourneyControllerTwo;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerFive;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerFour;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerOne;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerSeven;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerThree;
+import uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerTwo;
+import uk.gov.companieshouse.web.accounts.service.navigation.success.MockSuccessJourneyControllerOne;
+import uk.gov.companieshouse.web.accounts.service.navigation.success.MockSuccessJourneyControllerThree;
+import uk.gov.companieshouse.web.accounts.service.navigation.success.MockSuccessJourneyControllerTwo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -28,13 +27,13 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class NavigatorTests {
+public class NavigatorServiceTests {
 
     @Mock
     private ApplicationContext applicationContext;
 
     @InjectMocks
-    private Navigator navigator;
+    private NavigatorService navigatorService;
 
     private static final String COMPANY_NUMBER = "companyNumber";
     private static final String TRANSACTION_ID = "transactionId";
@@ -43,55 +42,55 @@ public class NavigatorTests {
     @Test
     public void missingNextControllerAnnotation() {
         Throwable exception = assertThrows(MissingAnnotationException.class, () ->
-                navigator.getNextControllerRedirect(MockControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                navigatorService.getNextControllerRedirect(MockControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
-        assertEquals("Missing @NextController annotation on class uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerThree", exception.getMessage());
+        assertEquals("Missing @NextController annotation on class uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerThree", exception.getMessage());
     }
 
     @Test
     public void missingPreviousControllerAnnotation() {
         Throwable exception = assertThrows(MissingAnnotationException.class, () ->
-                navigator.getPreviousControllerPath(MockControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                navigatorService.getPreviousControllerPath(MockControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
-        assertEquals("Missing @PreviousController annotation on class uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerThree", exception.getMessage());
+        assertEquals("Missing @PreviousController annotation on class uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerThree", exception.getMessage());
     }
 
     @Test
     public void missingRequestMappingAnnotationOnNextController() {
         Throwable exception = assertThrows(MissingAnnotationException.class, () ->
-                navigator.getNextControllerRedirect(MockControllerOne.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                navigatorService.getNextControllerRedirect(MockControllerOne.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
-        assertEquals("Missing @RequestMapping annotation on class uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerTwo", exception.getMessage());
+        assertEquals("Missing @RequestMapping annotation on class uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerTwo", exception.getMessage());
     }
 
     @Test
     public void missingRequestMappingAnnotationOnPreviousController() {
         Throwable exception = assertThrows(MissingAnnotationException.class, () ->
-                navigator.getPreviousControllerPath(MockControllerTwo.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                navigatorService.getPreviousControllerPath(MockControllerTwo.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
-        assertEquals("Missing @RequestMapping annotation on class uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerOne", exception.getMessage());
+        assertEquals("Missing @RequestMapping annotation on class uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerOne", exception.getMessage());
     }
 
     @Test
     public void missingRequestMappingValueOnNextController() {
         Throwable exception = assertThrows(MissingAnnotationException.class, () ->
-                navigator.getNextControllerRedirect(MockControllerFive.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                navigatorService.getNextControllerRedirect(MockControllerFive.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
-        assertEquals("Missing @RequestMapping value on class uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerSix", exception.getMessage());
+        assertEquals("Missing @RequestMapping value on class uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerSix", exception.getMessage());
     }
 
     @Test
     public void missingRequestMappingValueOnPreviousController() {
         Throwable exception = assertThrows(MissingAnnotationException.class, () ->
-                navigator.getPreviousControllerPath(MockControllerSeven.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                navigatorService.getPreviousControllerPath(MockControllerSeven.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
-        assertEquals("Missing @RequestMapping value on class uk.gov.companieshouse.web.accounts.util.navigator.failure.MockControllerSix", exception.getMessage());
+        assertEquals("Missing @RequestMapping value on class uk.gov.companieshouse.web.accounts.service.navigation.failure.MockControllerSix", exception.getMessage());
     }
 
     @Test
     public void missingExpectedNumberOfPathVariablesForMandatoryController() {
 
-        String redirect = navigator.getNextControllerRedirect(MockControllerFour.class, COMPANY_NUMBER);
+        String redirect = navigatorService.getNextControllerRedirect(MockControllerFour.class, COMPANY_NUMBER);
 
         assertEquals(UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/mock-controller-five", redirect);
     }
@@ -101,7 +100,7 @@ public class NavigatorTests {
         when(applicationContext.getBean(MockSuccessJourneyControllerTwo.class)).thenReturn(new MockSuccessJourneyControllerTwo());
         when(applicationContext.getBean(MockSuccessJourneyControllerThree.class)).thenReturn(new MockSuccessJourneyControllerThree());
 
-        String redirect = navigator.getNextControllerRedirect(MockSuccessJourneyControllerOne.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+        String redirect = navigatorService.getNextControllerRedirect(MockSuccessJourneyControllerOne.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         assertEquals(UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/mock-success-journey-controller-three", redirect);
     }
@@ -111,7 +110,7 @@ public class NavigatorTests {
         when(applicationContext.getBean(MockSuccessJourneyControllerTwo.class)).thenReturn(new MockSuccessJourneyControllerTwo());
         when(applicationContext.getBean(MockSuccessJourneyControllerThree.class)).thenReturn(new MockSuccessJourneyControllerThree());
 
-        String redirect = navigator.getNextControllerRedirect(MockSuccessJourneyControllerOne.class, COMPANY_NUMBER);
+        String redirect = navigatorService.getNextControllerRedirect(MockSuccessJourneyControllerOne.class, COMPANY_NUMBER);
 
         assertEquals(UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/mock-success-journey-controller-two", redirect);
     }
@@ -120,7 +119,7 @@ public class NavigatorTests {
     public void successfulRedirectStartingFromConditionalControllerWithExpectedNumberOfPathVariables() {
         when(applicationContext.getBean(MockSuccessJourneyControllerThree.class)).thenReturn(new MockSuccessJourneyControllerThree());
 
-        String redirect = navigator.getNextControllerRedirect(MockSuccessJourneyControllerTwo.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+        String redirect = navigatorService.getNextControllerRedirect(MockSuccessJourneyControllerTwo.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         assertEquals(UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/mock-success-journey-controller-three", redirect);
     }
@@ -129,7 +128,7 @@ public class NavigatorTests {
     public void successfulRedirectStartingFromConditionalControllerWithMissingPathVariables() {
         when(applicationContext.getBean(MockSuccessJourneyControllerThree.class)).thenReturn(new MockSuccessJourneyControllerThree());
 
-        String redirect = navigator.getNextControllerRedirect(MockSuccessJourneyControllerTwo.class, COMPANY_NUMBER);
+        String redirect = navigatorService.getNextControllerRedirect(MockSuccessJourneyControllerTwo.class, COMPANY_NUMBER);
 
         assertEquals(UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/mock-success-journey-controller-three", redirect);
     }
@@ -139,7 +138,7 @@ public class NavigatorTests {
         when(applicationContext.getBean(MockSuccessJourneyControllerTwo.class)).thenReturn(new MockSuccessJourneyControllerTwo());
         when(applicationContext.getBean(MockSuccessJourneyControllerThree.class)).thenReturn(new MockSuccessJourneyControllerThree());
 
-        String redirect = navigator.getPreviousControllerPath(MockSuccessJourneyControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+        String redirect = navigatorService.getPreviousControllerPath(MockSuccessJourneyControllerThree.class, COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         assertEquals("/mock-success-journey-controller-one", redirect);
     }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerEight.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerEight.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
+import uk.gov.companieshouse.web.accounts.controller.BaseController;
+import uk.gov.companieshouse.web.accounts.controller.ConditionalController;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
+
+/**
+ * Mock conditional controller class for testing exception handling.
+ *
+ * @see NavigatorServiceTests
+ * @see uk.gov.companieshouse.web.accounts.exception.NavigationException
+ */
+@RequestMapping("/mock-controller-eight")
+@PreviousController(MockControllerSeven.class)
+public class MockControllerEight extends BaseController implements ConditionalController {
+
+    @Override
+    protected String getTemplateName() {
+        return null;
+    }
+
+    @Override
+    public boolean willRender(String companyNumber, String transactionId, String companyAccountsId) throws ServiceException {
+        throw new ServiceException("Test exception", null);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerFive.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerFive.java
@@ -1,15 +1,15 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
  * Mock controller class.
  *
- * @see NavigatorTests
+ * @see NavigatorServiceTests
  */
 @NextController(MockControllerSix.class)
 @PreviousController(MockControllerFour.class)

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerFour.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerFour.java
@@ -1,18 +1,20 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.success;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
-import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.controller.ConditionalController;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
- * Mock controller class for success scenario testing of navigation.
+ * Mock conditional controller class for testing missing expected number of
+ * path variables.
+ *
+ * @see NavigatorServiceTests
  */
-@NextController(MockSuccessJourneyControllerThree.class)
-@PreviousController(MockSuccessJourneyControllerOne.class)
-@RequestMapping("/mock-success-journey-controller-two")
-public class MockSuccessJourneyControllerTwo extends BaseController implements ConditionalController {
+@NextController(MockControllerFive.class)
+@PreviousController(MockControllerThree.class)
+public class MockControllerFour extends BaseController implements ConditionalController {
 
     @Override
     protected String getTemplateName() {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerOne.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerOne.java
@@ -1,14 +1,14 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
  * Mock controller class for testing missing navigation annotation {@code RequestMapping}
  * when attempting to obtain the previous controller in the journey.
  *
- * @see NavigatorTests
+ * @see NavigatorServiceTests
  */
 @NextController(MockControllerTwo.class)
 public class MockControllerOne extends BaseController {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerSeven.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerSeven.java
@@ -1,14 +1,14 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
  * Mock controller class for testing missing {@code RequestMapping} value
  * when searching backwards in the controller chain.
  *
- * @see NavigatorTests
+ * @see NavigatorServiceTests
  */
 @PreviousController(MockControllerSix.class)
 public class MockControllerSeven extends BaseController {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerSeven.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerSeven.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
+import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
@@ -10,6 +11,7 @@ import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTes
  *
  * @see NavigatorServiceTests
  */
+@NextController(MockControllerEight.class)
 @PreviousController(MockControllerSix.class)
 public class MockControllerSeven extends BaseController {
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerSix.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerSix.java
@@ -1,15 +1,15 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
  * Mock controller class for testing missing {@code RequestMapping} value
  * when searching forwards or backwards in the controller chain.
  *
- * @see NavigatorTests
+ * @see NavigatorServiceTests
  */
 @PreviousController(MockControllerFive.class)
 @RequestMapping()

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerThree.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerThree.java
@@ -1,13 +1,13 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
  * Mock controller class for testing missing navigation annotations {@code NextController}
  * and {@code PreviousController}.
  *
- * @see NavigatorTests
+ * @see NavigatorServiceTests
  */
 public class MockControllerThree extends BaseController {
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerTwo.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/failure/MockControllerTwo.java
@@ -1,15 +1,15 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.failure;
 
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorServiceTests;
 
 /**
  * Mock controller class for testing missing navigation annotation {@code RequestMapping}
  * when attempting to obtain the next controller in the journey.
  *
- * @see NavigatorTests
+ * @see NavigatorServiceTests
  */
 @NextController(MockControllerThree.class)
 @PreviousController(MockControllerOne.class)

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/success/MockSuccessJourneyControllerOne.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/success/MockSuccessJourneyControllerOne.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.success;
+package uk.gov.companieshouse.web.accounts.service.navigation.success;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/success/MockSuccessJourneyControllerThree.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/success/MockSuccessJourneyControllerThree.java
@@ -1,4 +1,4 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.success;
+package uk.gov.companieshouse.web.accounts.service.navigation.success;
 
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/success/MockSuccessJourneyControllerTwo.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/navigation/success/MockSuccessJourneyControllerTwo.java
@@ -1,20 +1,18 @@
-package uk.gov.companieshouse.web.accounts.util.navigator.failure;
+package uk.gov.companieshouse.web.accounts.service.navigation.success;
 
+import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.controller.ConditionalController;
-import uk.gov.companieshouse.web.accounts.util.navigator.NavigatorTests;
 
 /**
- * Mock conditional controller class for testing missing expected number of
- * path variables.
- *
- * @see NavigatorTests
+ * Mock controller class for success scenario testing of navigation.
  */
-@NextController(MockControllerFive.class)
-@PreviousController(MockControllerThree.class)
-public class MockControllerFour extends BaseController implements ConditionalController {
+@NextController(MockSuccessJourneyControllerThree.class)
+@PreviousController(MockSuccessJourneyControllerOne.class)
+@RequestMapping("/mock-success-journey-controller-two")
+public class MockSuccessJourneyControllerTwo extends BaseController implements ConditionalController {
 
     @Override
     protected String getTemplateName() {


### PR DESCRIPTION
The changes in this pull-request were introduced to avoid an edge case scenario with navigation explained below:

With several adjacent conditional controllers in the controller chain, if the first call to a controller's `willRender()` method results in a request being made to the API and this request **fails**, the method returns `false` meaning the controller will be skipped in the journey. If any subsequent call to `willRender()` succeeds, the associated template is rendered (or alternatively the next mandatory controller in the chain will be rendered). This could lead to pages being skipped during the web journey if requests to the API fail or if the API itself is unavailable.

With these changes, the `willRender()` method is now expected to throw a `ServiceException` for any failed requests, which `NavigatorService` will catch and handle by throwing a custom `RuntimeException` leading to the default error page being returned to the user agent.

