### PR TITLE
Update `getSmallFullAccounts` method signature to take an `ApiClient` 

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/SmallFullService.java
@@ -17,7 +17,7 @@ public interface SmallFullService {
     /**
      * Retrieve a small full resource
      *
-     * @param apiClient
+     * @param apiClient The api client with which to execute the get request
      * @param transactionId The id of the CHS transaction
      * @param companyAccountsId The company accounts identifier
      * @return the small full resource

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/SmallFullService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/SmallFullService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull;
 
+import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
@@ -15,10 +16,13 @@ public interface SmallFullService {
 
     /**
      * Retrieve a small full resource
+     *
+     * @param apiClient
      * @param transactionId The id of the CHS transaction
      * @param companyAccountsId The company accounts identifier
      * @return the small full resource
      * @throws ServiceException or retrieval failure
      */
-    SmallFullApi getSmallFullAccounts(String transactionId, String companyAccountsId) throws ServiceException;
+    SmallFullApi getSmallFullAccounts(ApiClient apiClient,
+            String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ApprovalServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ApprovalServiceImpl.java
@@ -70,7 +70,8 @@ public class ApprovalServiceImpl implements ApprovalService {
         ApprovalApi approvalApi = transformer.getApprovalApi(approval);
 
         try {
-            SmallFullApi smallFullApi = smallFullService.getSmallFullAccounts(transactionId, companyAccountsId);
+            SmallFullApi smallFullApi = smallFullService.getSmallFullAccounts(apiClient, transactionId,
+                    companyAccountsId);
 
             if (smallFullApi.getLinks().getApproval() != null) {
                 apiClient.smallFull().approval().update(uri, approvalApi).execute();

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/SmallFullServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/SmallFullServiceImpl.java
@@ -45,10 +45,8 @@ public class SmallFullServiceImpl implements SmallFullService {
      * {@inheritDoc}
      */
     @Override
-    public SmallFullApi getSmallFullAccounts(String transactionId, String companyAccountsId)
-            throws ServiceException {
-
-        ApiClient apiClient = apiClientService.getApiClient();
+    public SmallFullApi getSmallFullAccounts(ApiClient apiClient, String transactionId,
+            String companyAccountsId) throws ServiceException {
 
         String uri = SMALL_FULL_URI.expand(transactionId, companyAccountsId).toString();
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ApprovalServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ApprovalServiceImplTests.java
@@ -114,7 +114,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -150,7 +150,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -184,7 +184,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -228,7 +228,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -270,7 +270,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -303,7 +303,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -339,7 +339,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -373,7 +373,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -417,7 +417,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);
@@ -459,7 +459,7 @@ public class ApprovalServiceImplTests {
 
         when(smallFullResourceHandler.approval()).thenReturn(approvalResourceHandler);
 
-        when(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
                 .thenReturn(smallFullApi);
 
         when(smallFullApi.getLinks()).thenReturn(smallFullLinks);

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/SmallFullServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/SmallFullServiceImplTests.java
@@ -56,14 +56,14 @@ public class SmallFullServiceImplTests {
     @BeforeEach
     private void setUp() {
 
-        when(apiClientService.getApiClient()).thenReturn(apiClient);
-
         when(apiClient.smallFull()).thenReturn(smallFullResourceHandler);
     }
 
     @Test
     @DisplayName("Create Small Full Accounts - Success Path")
     void createSmallFullSuccess() throws ServiceException, ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         when(smallFullResourceHandler.create(anyString(), any(SmallFullApi.class)))
                 .thenReturn(smallFullCreate);
@@ -79,6 +79,8 @@ public class SmallFullServiceImplTests {
     @DisplayName("Create Small Full Accounts - Throws ApiErrorResponseException")
     void createSmallFullApiErrorResponseExceptionThrown() throws ApiErrorResponseException, URIValidationException {
 
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+
         when(smallFullResourceHandler.create(anyString(), any(SmallFullApi.class)))
                 .thenReturn(smallFullCreate);
 
@@ -91,6 +93,8 @@ public class SmallFullServiceImplTests {
     @Test
     @DisplayName("Create Small Full Accounts - Throws URIValidationException")
     void createSmallFullURIValidationExceptionThrown() throws ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         when(smallFullResourceHandler.create(anyString(), any(SmallFullApi.class)))
                 .thenReturn(smallFullCreate);
@@ -109,7 +113,7 @@ public class SmallFullServiceImplTests {
 
         when(smallFullGet.execute()).thenReturn(new SmallFullApi());
 
-        assertNotNull(smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+        assertNotNull(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
 
         verify(smallFullGet, times(1)).execute();
     }
@@ -123,7 +127,7 @@ public class SmallFullServiceImplTests {
         when(smallFullGet.execute()).thenThrow(ApiErrorResponseException.class);
 
         assertThrows(ServiceException.class, () ->
-                smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
     }
 
     @Test
@@ -135,6 +139,6 @@ public class SmallFullServiceImplTests {
         when(smallFullGet.execute()).thenThrow(URIValidationException.class);
 
         assertThrows(ServiceException.class, () ->
-                smallFullService.getSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+                smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
     }
 }


### PR DESCRIPTION
Update small full service `getSmallFullAccounts` method signature to take an `ApiClient` to prevent unnecessary overheads