### PR TITLE
Add delete functionality for debtors to remove note when balancesheet value removed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/DebtorsService.java
@@ -38,7 +38,8 @@ public interface DebtorsService {
      *
      * @param transactionId The id of the CHS transaction
      * @param companyAccountsId The company accounts identifier
+     * @return A list of validation errors, or an empty array list if none are present
      * @throws ServiceException if there's an error on deletion
      */
-    void deleteDebtors(String transactionId, String companyAccountsId) throws ServiceException;
+    List<ValidationError> deleteDebtors(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/DebtorsService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/DebtorsService.java
@@ -32,4 +32,13 @@ public interface DebtorsService {
         */
     List<ValidationError> submitDebtors(String transactionId, String companyAccountsId, Debtors debtors, String companyNumber)
         throws ServiceException;
+
+    /**
+     * Delete the debtors note
+     *
+     * @param transactionId The id of the CHS transaction
+     * @param companyAccountsId The company accounts identifier
+     * @throws ServiceException if there's an error on deletion
+     */
+    void deleteDebtors(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -20,6 +20,8 @@ import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheetHeadings;
+import uk.gov.companieshouse.web.accounts.model.smallfull.CurrentAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.Debtors;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DebtorsService;
@@ -322,7 +324,10 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
 
     private boolean isDebtorsCurrentAmountNull(BalanceSheet balanceSheet) {
         Long currentDebtors =
-            Optional.ofNullable(balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount())
+            Optional.of(balanceSheet)
+                .map(BalanceSheet::getCurrentAssets)
+                .map(CurrentAssets::getDebtors)
+                .map(Debtors::getCurrentAmount)
                 .orElse(0L);
 
         return currentDebtors.equals(0L);
@@ -330,8 +335,11 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
 
     private boolean isDebtorsPreviousAmountNull(BalanceSheet balanceSheet) {
         Long previousDebtors =
-            Optional.ofNullable(balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount())
-            .orElse(0L);
+            Optional.of(balanceSheet)
+                .map(BalanceSheet::getCurrentAssets)
+                .map(CurrentAssets::getDebtors)
+                .map(Debtors::getPreviousAmount)
+                .orElse(0L);
 
         return previousDebtors.equals(0L);
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -154,6 +154,9 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
         createCurrentPeriod(apiClient, smallFullApi, currentPeriodUri, currentPeriod,
                 validationErrors);
 
+        checkConditionalNotes(companyProfileApi, balanceSheet, smallFullApi.getLinks(),
+            transactionId, companyAccountsId);
+
         return validationErrors;
 
     }
@@ -287,4 +290,43 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
     private boolean hasPreviousPeriod(SmallFullLinks smallFullLinks) {
         return smallFullLinks.getPreviousPeriod() != null;
     }
+
+    /**
+     * Checks whether a conditional note exists when there is no balancesheet value for it
+     * If there is, the note is then deleted
+     *
+     * @param balanceSheet the populated balancesheet
+     * @param smallFullLinks the links used to determine if notes are present
+     * @param transactionId The id of the CHS transaction
+     * @param companyAccountsId The company accounts identifier
+     * @throws ServiceException if there's an error on submission
+     */
+    private void checkConditionalNotes(CompanyProfileApi companyProfileApi,
+                                       BalanceSheet balanceSheet, SmallFullLinks smallFullLinks,
+                                       String transactionId, String companyAccountsId) throws ServiceException {
+
+        if (isMultipleYearFiler(companyProfileApi)) {
+
+            if ((isDebtorsCurrentAmountNull(balanceSheet) || isDebtorsPreviousAmountNull(balanceSheet))
+                && smallFullLinks.getDebtorsNote() != null) {
+
+                debtorsService.deleteDebtors(transactionId, companyAccountsId);
+            }
+        } else {
+            if ((isDebtorsCurrentAmountNull(balanceSheet) && smallFullLinks.getDebtorsNote() != null)) {
+                debtorsService.deleteDebtors(transactionId, companyAccountsId);
+            }
+        }
+    }
+
+    private boolean isDebtorsCurrentAmountNull(BalanceSheet balanceSheet) {
+        return balanceSheet.getCurrentAssets() != null && balanceSheet.getCurrentAssets().getDebtors() != null
+            && (balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount() == null || balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount() == (0));
+    }
+
+    private boolean isDebtorsPreviousAmountNull(BalanceSheet balanceSheet) {
+        return balanceSheet.getCurrentAssets() != null && balanceSheet.getCurrentAssets().getDebtors() != null
+            && (balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount() == null || balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount() == (0));
+    }
+
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -30,6 +30,7 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class BalanceSheetServiceImpl implements BalanceSheetService {
@@ -320,13 +321,18 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
     }
 
     private boolean isDebtorsCurrentAmountNull(BalanceSheet balanceSheet) {
-        return balanceSheet.getCurrentAssets() != null && balanceSheet.getCurrentAssets().getDebtors() != null
-            && (balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount() == null || balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount() == (0));
+        Long currentDebtors =
+            Optional.ofNullable(balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount())
+                .orElse(0L);
+
+        return currentDebtors.equals(0L);
     }
 
     private boolean isDebtorsPreviousAmountNull(BalanceSheet balanceSheet) {
-        return balanceSheet.getCurrentAssets() != null && balanceSheet.getCurrentAssets().getDebtors() != null
-            && (balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount() == null || balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount() == (0));
-    }
+        Long previousDebtors =
+            Optional.ofNullable(balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount())
+            .orElse(0L);
 
+        return previousDebtors.equals(0L);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImpl.java
@@ -94,6 +94,23 @@ public class DebtorsServiceImpl implements DebtorsService {
         return new ArrayList<>();
     }
 
+    @Override
+    public void deleteDebtors(String transactionId, String companyAccountsId) throws ServiceException {
+        ApiClient apiClient = apiClientService.getApiClient();
+
+        String uri = DEBTORS_URI.expand(transactionId, companyAccountsId).toString();
+
+        try {
+            apiClient.smallFull().debtors().delete(uri).execute();
+        } catch (URIValidationException e) {
+
+            throw new ServiceException(INVALID_URI_MESSAGE, e);
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException("Error creating debtors resource", e);
+        }
+    }
+
     private DebtorsApi getDebtorsApi(String transactionId, String companyAccountsId) throws ServiceException {
         ApiClient apiClient = apiClientService.getApiClient();
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImplTests.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.smallfull.SmallFullResourceHandler;
 import uk.gov.companieshouse.api.handler.smallfull.debtors.DebtorsResourceHandler;
 import uk.gov.companieshouse.api.handler.smallfull.debtors.request.DebtorsCreate;
+import uk.gov.companieshouse.api.handler.smallfull.debtors.request.DebtorsDelete;
 import uk.gov.companieshouse.api.handler.smallfull.debtors.request.DebtorsGet;
 import uk.gov.companieshouse.api.handler.smallfull.debtors.request.DebtorsUpdate;
 import uk.gov.companieshouse.api.handler.smallfull.request.SmallFullGet;
@@ -70,6 +71,9 @@ public class DebtorsServiceImplTests {
 
     @Mock
     private DebtorsUpdate mockDebtorsUpdate;
+
+    @Mock
+    private DebtorsDelete mockDebtorsDelete;
 
     @Mock
     private SmallFullGet mockSmallFullGet;
@@ -322,6 +326,68 @@ public class DebtorsServiceImplTests {
             COMPANY_ACCOUNTS_ID,
             debtors,
             COMPANY_NUMBER));
+    }
+
+    @Test
+    @DisplayName("DELETE - Debtors successful delete path")
+    void deleteDebtors() throws Exception {
+
+        getMockDebtorsResourceHandler();
+        when(mockDebtorsResourceHandler.delete(DEBTORS_URI)).thenReturn(mockDebtorsDelete);
+        doNothing().when(mockDebtorsDelete).execute();
+
+        List<ValidationError> validationErrors = debtorsService.deleteDebtors(TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID);
+
+        assertEquals(0, validationErrors.size());
+    }
+
+    @Test
+    @DisplayName("DELETE - Debtors throws ServiceExcepiton due to URIValidationException")
+    void deleteDebtorsUriValidationException() throws Exception {
+
+        getMockDebtorsResourceHandler();
+        when(mockDebtorsResourceHandler.delete(DEBTORS_URI)).thenReturn(mockDebtorsDelete);
+        when(mockDebtorsDelete.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(URIValidationException.class, () -> mockDebtorsDelete.execute());
+        assertThrows(ServiceException.class, () -> debtorsService.deleteDebtors(
+            TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID));
+    }
+
+    @Test
+    @DisplayName("DELETE - Debtors throws ServiceExcepiton due to ApiErrorResponseException - 400 Bad Request")
+    void deleteDebtorsApiErrorResponseExceptionBadRequest() throws Exception {
+
+        getMockDebtorsResourceHandler();
+        when(mockDebtorsResourceHandler.delete(DEBTORS_URI)).thenReturn(mockDebtorsDelete);
+
+        HttpResponseException httpResponseException = new HttpResponseException.Builder(400,"Bad Request",new HttpHeaders()).build();
+        ApiErrorResponseException apiErrorResponseException = ApiErrorResponseException.fromHttpResponseException(httpResponseException);
+        when(mockDebtorsDelete.execute()).thenThrow(apiErrorResponseException);
+
+        assertThrows(ApiErrorResponseException.class, () -> mockDebtorsDelete.execute());
+        assertThrows(ServiceException.class, () -> debtorsService.deleteDebtors(
+            TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID));
+    }
+
+    @Test
+    @DisplayName("DELETE - Debtors throws ServiceExcepiton due to ApiErrorResponseException - 404 Not Found")
+    void deleteDebtorsApiErrorResponseExceptionNotFound() throws Exception {
+
+        getMockDebtorsResourceHandler();
+        when(mockDebtorsResourceHandler.delete(DEBTORS_URI)).thenReturn(mockDebtorsDelete);
+
+        HttpResponseException httpResponseException = new HttpResponseException.Builder(404,"Not Found",new HttpHeaders()).build();
+        ApiErrorResponseException apiErrorResponseException = ApiErrorResponseException.fromHttpResponseException(httpResponseException);
+        when(mockDebtorsDelete.execute()).thenThrow(apiErrorResponseException);
+
+        assertThrows(ApiErrorResponseException.class, () -> mockDebtorsDelete.execute());
+        assertThrows(ServiceException.class, () -> debtorsService.deleteDebtors(
+            TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID));
     }
 
     private void getMockSmallFullResourceHandler() {


### PR DESCRIPTION
Fix for issue where once a user completes a conditional note and then removes the corresponding values on the balancesheet, the note still exists though the balancesheet value doesn't. Therefore the note will appear on the review screen and be generated in the iXBRL. This PR adds a delete when the note is present and the value in the balancesheet is not.

**Resolves**: SFA-1062