### PR TITLE
Add creditors after note to review screen

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
         
-        <api-sdk-java.version>3.13.17</api-sdk-java.version>
+        <api-sdk-java.version>3.13.18</api-sdk-java.version>
 
         <sdk-manager-java.version>1.3.0-rc3</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/Review.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/Review.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.ValuationInformationPolicy;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorswithinoneyear.CreditorsWithinOneYear;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteroneyear.CreditorsAfterOneYear;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.Debtors;
 
 @Getter
@@ -32,6 +33,8 @@ public class Review {
     OtherAccountingPolicy otherAccountingPolicy;
     
     CreditorsWithinOneYear creditorsWithinOneYear;
+
+    CreditorsAfterOneYear creditorsAfterOneYear;
 
     Debtors debtors;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/CreditorsAfterOneYearService.java
@@ -37,8 +37,7 @@ public interface CreditorsAfterOneYearService {
      *
      * @param transactionId The id of the CHS transaction
      * @param companyAccountsId The company accounts identifier
-     * @return A list of validation errors, or an empty array list if none are present
      * @throws ServiceException if there's an error on deletion
      */
-    List<ValidationError> deleteCreditorsAfterOneYear(String transactionId, String companyAccountsId) throws ServiceException;
+    void deleteCreditorsAfterOneYear(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/CreditorsAfterOneYearService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/CreditorsAfterOneYearService.java
@@ -1,9 +1,10 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull;
 
-import java.util.List;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteroneyear.CreditorsAfterOneYear;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
+
+import java.util.List;
 
 public interface CreditorsAfterOneYearService {
 
@@ -31,4 +32,14 @@ public interface CreditorsAfterOneYearService {
      */
     List<ValidationError> submitCreditorsAfterOneYear(String transactionId, String companyAccountsId, CreditorsAfterOneYear creditorsAfterOneYear, String companyNumber)
             throws ServiceException;
+
+    /**
+     * Delete the creditors after one year note
+     *
+     * @param transactionId The id of the CHS transaction
+     * @param companyAccountsId The company accounts identifier
+     * @return A list of validation errors, or an empty array list if none are present
+     * @throws ServiceException if there's an error on deletion
+     */
+    List<ValidationError> deleteCreditorsAfterOneYear(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -314,22 +314,22 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
                                        BalanceSheet balanceSheet, SmallFullLinks smallFullLinks,
                                        String transactionId, String companyAccountsId) throws ServiceException {
 
-        if ((isDebtorsCurrentAmountNull(balanceSheet)
-            && isDebtorsPreviousAmountNull(balanceSheet))
+        if ((isDebtorsCurrentAmountNullOrZero(balanceSheet)
+            && isDebtorsPreviousAmountNullOrZero(balanceSheet))
             && smallFullLinks.getDebtorsNote() != null) {
 
             debtorsService.deleteDebtors(transactionId, companyAccountsId);
         }
 
-        if ((isCreditorsAfterOneYearCurrentAmountNull(balanceSheet)
-            && isCreditorsAfterOneYearPreviousAmountNull(balanceSheet))
+        if ((isCreditorsAfterOneYearCurrentAmountNullOrZero(balanceSheet)
+            && isCreditorsAfterOneYearPreviousAmountNullOrZero(balanceSheet))
             && smallFullLinks.getCreditorsAfterMoreThanOneYearNote() != null) {
 
             creditorsAfterOneYearService.deleteCreditorsAfterOneYear(transactionId, companyAccountsId);
         }
     }
 
-    private boolean isDebtorsCurrentAmountNull(BalanceSheet balanceSheet) {
+    private boolean isDebtorsCurrentAmountNullOrZero(BalanceSheet balanceSheet) {
         Long currentDebtors =
             Optional.of(balanceSheet)
                 .map(BalanceSheet::getCurrentAssets)
@@ -340,7 +340,7 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
         return currentDebtors.equals(0L);
     }
 
-    private boolean isDebtorsPreviousAmountNull(BalanceSheet balanceSheet) {
+    private boolean isDebtorsPreviousAmountNullOrZero(BalanceSheet balanceSheet) {
         Long previousDebtors =
             Optional.of(balanceSheet)
                 .map(BalanceSheet::getCurrentAssets)
@@ -351,7 +351,7 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
         return previousDebtors.equals(0L);
     }
 
-    private boolean isCreditorsAfterOneYearCurrentAmountNull(BalanceSheet balanceSheet) {
+    private boolean isCreditorsAfterOneYearCurrentAmountNullOrZero(BalanceSheet balanceSheet) {
         return Optional.of(balanceSheet)
             .map(BalanceSheet::getOtherLiabilitiesOrAssets)
             .map(OtherLiabilitiesOrAssets::getCreditorsAfterOneYear)
@@ -359,7 +359,7 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
             .orElse(0L).equals(0L);
     }
 
-    private boolean isCreditorsAfterOneYearPreviousAmountNull(BalanceSheet balanceSheet) {
+    private boolean isCreditorsAfterOneYearPreviousAmountNullOrZero(BalanceSheet balanceSheet) {
         return Optional.of(balanceSheet)
             .map(BalanceSheet::getOtherLiabilitiesOrAssets)
             .map(OtherLiabilitiesOrAssets::getCreditorsAfterOneYear)

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImpl.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -22,6 +20,9 @@ import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.CreditorsAfterOneYearTransformer;
 import uk.gov.companieshouse.web.accounts.util.ValidationContext;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class CreditorsAfterOneYearServiceImpl implements CreditorsAfterOneYearService {
@@ -100,6 +101,32 @@ public class CreditorsAfterOneYearServiceImpl implements CreditorsAfterOneYearSe
             }
             throw new ServiceException("Error creating creditors after one year resource", e);
         }
+
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<ValidationError> deleteCreditorsAfterOneYear(String transactionId, String companyAccountsId) throws ServiceException {
+        ApiClient apiClient = apiClientService.getApiClient();
+
+        String uri = CREDITORS_AFTER_ONE_YEAR_URI.expand(transactionId, companyAccountsId).toString();
+
+        try {
+            apiClient.smallFull().creditorsAfterOneYear().delete(uri).execute();
+        } catch (URIValidationException e) {
+
+            throw new ServiceException(INVALID_URI_MESSAGE, e);
+        } catch (ApiErrorResponseException e) {
+            if (e.getStatusCode() == HttpStatus.BAD_REQUEST.value()) {
+                List<ValidationError> validationErrors = validationContext.getValidationErrors(e);
+                if (validationErrors.isEmpty()) {
+                    throw new ServiceException("Bad request when deleting creditors after one year note resource", e);
+                }
+                return validationErrors;
+            }
+            throw new ServiceException("Error deleting creditors after one year note resource", e);
+        }
+
 
         return new ArrayList<>();
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImpl.java
@@ -106,7 +106,7 @@ public class CreditorsAfterOneYearServiceImpl implements CreditorsAfterOneYearSe
     }
 
     @Override
-    public List<ValidationError> deleteCreditorsAfterOneYear(String transactionId, String companyAccountsId) throws ServiceException {
+    public void deleteCreditorsAfterOneYear(String transactionId, String companyAccountsId) throws ServiceException {
         ApiClient apiClient = apiClientService.getApiClient();
 
         String uri = CREDITORS_AFTER_ONE_YEAR_URI.expand(transactionId, companyAccountsId).toString();
@@ -114,21 +114,10 @@ public class CreditorsAfterOneYearServiceImpl implements CreditorsAfterOneYearSe
         try {
             apiClient.smallFull().creditorsAfterOneYear().delete(uri).execute();
         } catch (URIValidationException e) {
-
             throw new ServiceException(INVALID_URI_MESSAGE, e);
         } catch (ApiErrorResponseException e) {
-            if (e.getStatusCode() == HttpStatus.BAD_REQUEST.value()) {
-                List<ValidationError> validationErrors = validationContext.getValidationErrors(e);
-                if (validationErrors.isEmpty()) {
-                    throw new ServiceException("Bad request when deleting creditors after one year note resource", e);
-                }
-                return validationErrors;
-            }
             throw new ServiceException("Error deleting creditors after one year note resource", e);
         }
-
-
-        return new ArrayList<>();
     }
 
     private CreditorsAfterOneYearApi getCreditorsAfterOneYearApi(String transactionId,

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ReviewServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ReviewServiceImpl.java
@@ -12,10 +12,12 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TangibleDepreciationPolicy;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.ValuationInformationPolicy;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteroneyear.CreditorsAfterOneYear;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorswithinoneyear.CreditorsWithinOneYear;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.Debtors;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BasisOfPreparationService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.CreditorsAfterOneYearService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.CreditorsWithinOneYearService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DebtorsService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.IntangibleAmortisationPolicyService;
@@ -57,6 +59,9 @@ public class ReviewServiceImpl implements ReviewService {
     private CreditorsWithinOneYearService creditorsWithinOneYearService;
 
     @Autowired
+    private CreditorsAfterOneYearService creditorsAfterOneYearService;
+
+    @Autowired
     private DebtorsService debtorsService;
 
     public Review getReview(String transactionId, String companyAccountsId, String companyNumber) throws ServiceException {
@@ -82,6 +87,8 @@ public class ReviewServiceImpl implements ReviewService {
         
         CreditorsWithinOneYear creditorsWithinOneYear = creditorsWithinOneYearService.getCreditorsWithinOneYear(transactionId, companyAccountsId, companyNumber);
 
+        CreditorsAfterOneYear creditorsAfterOneYear = creditorsAfterOneYearService.getCreditorsAfterOneYear(transactionId, companyAccountsId, companyNumber);
+
         Debtors debtors = debtorsService.getDebtors(transactionId,companyAccountsId, companyNumber);
 
         Review review = new Review();
@@ -94,6 +101,7 @@ public class ReviewServiceImpl implements ReviewService {
         review.setValuationInformationPolicy(valuationInformationPolicy);
         review.setOtherAccountingPolicy(otherAccountingPolicy);
         review.setCreditorsWithinOneYear(creditorsWithinOneYear);
+        review.setCreditorsAfterOneYear(creditorsAfterOneYear);
         review.setDebtors(debtors);
 
         return review;

--- a/src/main/resources/templates/smallfull/creditorsAfterOneYear.html
+++ b/src/main/resources/templates/smallfull/creditorsAfterOneYear.html
@@ -180,6 +180,7 @@
         <input id="next-button" class="govuk-button piwik-event" data-event-id="Creditors After More Than One Year - Save and continue" type="submit" role="button" value="Save and continue"/>
       </div>
     </div>
+    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/balancesheet-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
   </form>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/review.html
+++ b/src/main/resources/templates/smallfull/review.html
@@ -603,7 +603,7 @@
                         <div th:replace="fragments/review/sectionHeader :: sectionHeader (
                             description = 'Creditors - amounts falling due after one year note',
                             identifier= 'creditors-after-one-year-note',
-                            resource = 'creditors-after-one-year',
+                            resource = 'creditors-after-more-than-one-year',
 
                             marginTop = true
                             )">

--- a/src/main/resources/templates/smallfull/review.html
+++ b/src/main/resources/templates/smallfull/review.html
@@ -595,6 +595,85 @@
                     </div>
                 </div>
                 <!-- End Creditors Within One Year Note -->
+
+                <!-- Creditors After One Year Note -->
+                <div id="cya-small-full-creditors-after-one-year-note">
+
+                    <div th:if="*{creditorsAfterOneYear.total != null}">
+                        <div th:replace="fragments/review/sectionHeader :: sectionHeader (
+                            description = 'Creditors - amounts falling due after one year note',
+                            identifier= 'creditors-after-one-year-note',
+                            resource = 'creditors-after-one-year',
+
+                            marginTop = true
+                            )">
+                        </div>
+
+                        <dl class="app-check-your-answers app-check-your-answers--short">
+                            <div class="app-check-your-answers__contents cya-desktop-only">
+                                <dt class="app-check-your-answers__question"></dt>
+                                <dd class="app-check-your-answers__answer govuk-heading-s"
+                                    th:if="*{balanceSheet.balanceSheetHeadings.currentPeriodHeading != null}"
+                                    th:text='*{balanceSheet.balanceSheetHeadings.currentPeriodHeading}'></dd>
+                                <dd class="app-check-your-answers__answer govuk-heading-s"
+                                    th:if="*{balanceSheet.balanceSheetHeadings.previousPeriodHeading != null}"
+                                    th:text='*{balanceSheet.balanceSheetHeadings.previousPeriodHeading}'></dd>
+                                <dd class="app-check-your-answers__change"></dd>
+                            </div>
+
+                            <div th:replace="fragments/review/balanceSheetValueRow :: balanceSheetValueRow (
+                                description = 'Bank loans and overdrafts',
+                                identifier = 'bank-loans-and-overdrafts',
+                                currentAmount = *{creditorsAfterOneYear?.bankLoansAndOverdrafts.currentBankLoansAndOverdrafts},
+                                previousAmount = *{creditorsAfterOneYear?.bankLoansAndOverdrafts.previousBankLoansAndOverdrafts},
+                                isBoldLegend = true
+                            )">
+                            </div>
+
+                            <div th:replace="fragments/review/balanceSheetValueRow :: balanceSheetValueRow (
+                                description = 'Amounts due under finance leases and hire purchase contracts',
+                                identifier = 'finance-leases-and-hire-purchase-contracts',
+                                currentAmount = *{creditorsAfterOneYear?.financeLeasesAndHirePurchaseContracts.currentFinanceLeasesAndHirePurchaseContracts},
+                                previousAmount = *{creditorsAfterOneYear?.financeLeasesAndHirePurchaseContracts.previousFinanceLeasesAndHirePurchaseContracts},
+                                isBoldLegend = true
+                            )">
+                            </div>
+
+                            <div th:replace="fragments/review/balanceSheetValueRow :: balanceSheetValueRow (
+                                description = 'Other creditors',
+                                identifier = 'other-creditors',
+                                currentAmount = *{creditorsAfterOneYear?.otherCreditors.currentOtherCreditors},
+                                previousAmount = *{creditorsAfterOneYear?.otherCreditors.previousOtherCreditors},
+                                isBoldLegend = true
+                            )">
+                            </div>
+
+                            <div th:replace="fragments/review/balanceSheetValueRow :: balanceSheetValueRow (
+                                description = 'Total',
+                                identifier = 'total',
+                                currentAmount = *{creditorsAfterOneYear?.total.currentTotal},
+                                previousAmount = *{creditorsAfterOneYear?.total.previousTotal},
+                                isTotalRow = true
+                            )">
+                            </div>
+
+                        </dl>
+
+                        <div th:if="*{creditorsAfterOneYear.details != null}">
+                            <dl class="app-check-your-answers app-check-your-answers--short">
+                                <div class="app-check-your-answers__contents">
+                                    <dt class="app-check-your-answers__question">Additional information</dt>
+                                    <dd class="app-check-your-answers__answer">
+                                        <p id="review-creditors-after-one-year-details"
+                                           th:text="*{creditorsAfterOneYear?.details}">
+                                        </p>
+                                    <dd class="app-check-your-answers__change"></dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+                <!-- End Creditors After One Year Note -->
                 
                 <div class="govuk-form-group">
                     <input id="next-button" class="govuk-button" type="submit" role="button" value="Continue"/>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImplTests.java
@@ -395,23 +395,6 @@ public class CreditorsAfterOneYearServiceImplTests {
     }
 
     @Test
-    @DisplayName("DELETE - Creditors after more than one year throws ServiceExcepiton due to ApiErrorResponseException - 400 Bad Request")
-    void deleteCreditorsAfterOneYearApiErrorResponseExceptionBadRequest() throws Exception {
-
-        getMockCreditorsAfterOneYearResourceHandler();
-        when(mockCreditorsAfterOneYearResourceHandler.delete(CREDITORS_AFTER_ONE_YEAR_URI)).thenReturn(mockCreditorsAfterOneYearDelete);
-
-        HttpResponseException httpResponseException = new HttpResponseException.Builder(400,"Bad Request",new HttpHeaders()).build();
-        ApiErrorResponseException apiErrorResponseException = ApiErrorResponseException.fromHttpResponseException(httpResponseException);
-        when(mockCreditorsAfterOneYearDelete.execute()).thenThrow(apiErrorResponseException);
-
-        assertThrows(ApiErrorResponseException.class, () -> mockCreditorsAfterOneYearDelete.execute());
-        assertThrows(ServiceException.class, () -> creditorsAfterOneYearService.deleteCreditorsAfterOneYear(
-            TRANSACTION_ID,
-            COMPANY_ACCOUNTS_ID));
-    }
-
-    @Test
     @DisplayName("DELETE - Creditors after more than one year throws ServiceExcepiton due to ApiErrorResponseException - 404 Not Found")
     void deleteCreditorsAfterOneYearApiErrorResponseExceptionNotFound() throws Exception {
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImplTests.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.api.client.http.HttpHeaders;
@@ -373,10 +375,9 @@ public class CreditorsAfterOneYearServiceImplTests {
         when(mockCreditorsAfterOneYearResourceHandler.delete(CREDITORS_AFTER_ONE_YEAR_URI)).thenReturn(mockCreditorsAfterOneYearDelete);
         doNothing().when(mockCreditorsAfterOneYearDelete).execute();
 
-        List<ValidationError> validationErrors = creditorsAfterOneYearService.deleteCreditorsAfterOneYear(TRANSACTION_ID,
-            COMPANY_ACCOUNTS_ID);
+        creditorsAfterOneYearService.deleteCreditorsAfterOneYear(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
-        assertEquals(0, validationErrors.size());
+        verify(mockCreditorsAfterOneYearDelete, times(1)).execute();
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CreditorsAfterOneYearServiceImplTests.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.smallfull.SmallFullResourceHandler;
 import uk.gov.companieshouse.api.handler.smallfull.creditorsafteroneyear.CreditorsAfterOneYearResourceHandler;
 import uk.gov.companieshouse.api.handler.smallfull.creditorsafteroneyear.request.CreditorsAfterOneYearCreate;
+import uk.gov.companieshouse.api.handler.smallfull.creditorsafteroneyear.request.CreditorsAfterOneYearDelete;
 import uk.gov.companieshouse.api.handler.smallfull.creditorsafteroneyear.request.CreditorsAfterOneYearGet;
 import uk.gov.companieshouse.api.handler.smallfull.creditorsafteroneyear.request.CreditorsAfterOneYearUpdate;
 import uk.gov.companieshouse.api.handler.smallfull.request.SmallFullGet;
@@ -84,6 +85,9 @@ public class CreditorsAfterOneYearServiceImplTests {
 
     @Mock
     private CreditorsAfterOneYearUpdate mockCreditorsAfterOneYearUpdate;
+
+    @Mock
+    private CreditorsAfterOneYearDelete mockCreditorsAfterOneYearDelete;
 
     @Mock
     private ValidationContext mockValidationContext;
@@ -366,6 +370,68 @@ public class CreditorsAfterOneYearServiceImplTests {
                 COMPANY_ACCOUNTS_ID,
                 creditorsAfterOneYear,
                 COMPANY_NUMBER));
+    }
+
+    @Test
+    @DisplayName("DELETE - Creditors after more than one year successful delete path")
+    void deleteCreditorsAfterOneYear() throws Exception {
+
+        getMockCreditorsAfterOneYearResourceHandler();
+        when(mockCreditorsAfterOneYearResourceHandler.delete(CREDITORS_AFTER_ONE_YEAR_URI)).thenReturn(mockCreditorsAfterOneYearDelete);
+        doNothing().when(mockCreditorsAfterOneYearDelete).execute();
+
+        List<ValidationError> validationErrors = creditorsAfterOneYearService.deleteCreditorsAfterOneYear(TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID);
+
+        assertEquals(0, validationErrors.size());
+    }
+
+    @Test
+    @DisplayName("DELETE - Creditors after more than one year throws ServiceExcepiton due to URIValidationException")
+    void deleteCreditorsAfterOneYearUriValidationException() throws Exception {
+
+        getMockCreditorsAfterOneYearResourceHandler();
+        when(mockCreditorsAfterOneYearResourceHandler.delete(CREDITORS_AFTER_ONE_YEAR_URI)).thenReturn(mockCreditorsAfterOneYearDelete);
+        when(mockCreditorsAfterOneYearDelete.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(URIValidationException.class, () -> mockCreditorsAfterOneYearDelete.execute());
+        assertThrows(ServiceException.class, () -> creditorsAfterOneYearService.deleteCreditorsAfterOneYear(
+            TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID));
+    }
+
+    @Test
+    @DisplayName("DELETE - Creditors after more than one year throws ServiceExcepiton due to ApiErrorResponseException - 400 Bad Request")
+    void deleteCreditorsAfterOneYearApiErrorResponseExceptionBadRequest() throws Exception {
+
+        getMockCreditorsAfterOneYearResourceHandler();
+        when(mockCreditorsAfterOneYearResourceHandler.delete(CREDITORS_AFTER_ONE_YEAR_URI)).thenReturn(mockCreditorsAfterOneYearDelete);
+
+        HttpResponseException httpResponseException = new HttpResponseException.Builder(400,"Bad Request",new HttpHeaders()).build();
+        ApiErrorResponseException apiErrorResponseException = ApiErrorResponseException.fromHttpResponseException(httpResponseException);
+        when(mockCreditorsAfterOneYearDelete.execute()).thenThrow(apiErrorResponseException);
+
+        assertThrows(ApiErrorResponseException.class, () -> mockCreditorsAfterOneYearDelete.execute());
+        assertThrows(ServiceException.class, () -> creditorsAfterOneYearService.deleteCreditorsAfterOneYear(
+            TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID));
+    }
+
+    @Test
+    @DisplayName("DELETE - Creditors after more than one year throws ServiceExcepiton due to ApiErrorResponseException - 404 Not Found")
+    void deleteCreditorsAfterOneYearApiErrorResponseExceptionNotFound() throws Exception {
+
+        getMockCreditorsAfterOneYearResourceHandler();
+        when(mockCreditorsAfterOneYearResourceHandler.delete(CREDITORS_AFTER_ONE_YEAR_URI)).thenReturn(mockCreditorsAfterOneYearDelete);
+
+        HttpResponseException httpResponseException = new HttpResponseException.Builder(404,"Not Found",new HttpHeaders()).build();
+        ApiErrorResponseException apiErrorResponseException = ApiErrorResponseException.fromHttpResponseException(httpResponseException);
+        when(mockCreditorsAfterOneYearDelete.execute()).thenThrow(apiErrorResponseException);
+
+        assertThrows(ApiErrorResponseException.class, () -> mockCreditorsAfterOneYearDelete.execute());
+        assertThrows(ServiceException.class, () -> creditorsAfterOneYearService.deleteCreditorsAfterOneYear(
+            TRANSACTION_ID,
+            COMPANY_ACCOUNTS_ID));
     }
 
     private void creditorsAfterOneYearUpdate(CreditorsAfterOneYearApi creditorsAfterOneYearApi) throws Exception {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ReviewServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/ReviewServiceImplTests.java
@@ -22,10 +22,12 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolici
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TangibleDepreciationPolicy;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.TurnoverPolicy;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.accountingpolicies.ValuationInformationPolicy;
+import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteroneyear.CreditorsAfterOneYear;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorswithinoneyear.CreditorsWithinOneYear;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.Debtors;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.BasisOfPreparationService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.CreditorsAfterOneYearService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.CreditorsWithinOneYearService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DebtorsService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.IntangibleAmortisationPolicyService;
@@ -73,6 +75,9 @@ public class ReviewServiceImplTests {
     private CreditorsWithinOneYearService creditorsWithinOneYearService;
 
     @Mock
+    private CreditorsAfterOneYearService creditorsAfterOneYearService;
+
+    @Mock
     private DebtorsService debtorsService;
 
     @InjectMocks
@@ -115,6 +120,10 @@ public class ReviewServiceImplTests {
         when(creditorsWithinOneYearService.getCreditorsWithinOneYear(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER))
             .thenReturn(mockCreditorsWithinOneYear);
 
+        CreditorsAfterOneYear mockCreditorsAfterOneYear = new CreditorsAfterOneYear();
+        when(creditorsAfterOneYearService.getCreditorsAfterOneYear(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER))
+            .thenReturn(mockCreditorsAfterOneYear);
+
         Debtors mockDebtors = new Debtors();
         when(debtorsService.getDebtors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER)).thenReturn(mockDebtors);
 
@@ -130,5 +139,6 @@ public class ReviewServiceImplTests {
         assertEquals(valuationInformationPolicy, review.getValuationInformationPolicy());
         assertEquals(mockOtherAccounting, review.getOtherAccountingPolicy());
         assertEquals(mockCreditorsWithinOneYear, review.getCreditorsWithinOneYear());
+        assertEquals(mockCreditorsAfterOneYear, review.getCreditorsAfterOneYear());
     }
 }


### PR DESCRIPTION
Add "Creditors - amounts falling due after one year note" section to the review screen so that a user can see what values they have entered in the note and allow them to return to the note screen to change the values they have provided.

**Resolves**: SFA-1015
