### PR TITLE
Exclude LocalDate from ValidationMapping annotation scan

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/util/ValidationContext.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/util/ValidationContext.java
@@ -15,6 +15,7 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -187,8 +188,8 @@ public class ValidationContext {
 
     /**
      * Returns {@code true} if the {@code Class} object is not a primitive,
-     * boxed primitive, collection or {@code String} and therefore likely
-     * to be a model class.
+     * boxed primitive, collection or {@code String} or {@code LocalDate}, 
+     * and therefore likely to be a model class.
      *
      * @param  clazz the {@code Class} object to test
      * @return       {@code true} if the class is not a primitive, boxed
@@ -219,6 +220,7 @@ public class ValidationContext {
         types.add(Boolean.class);
         types.add(Character.class);
         types.add(String.class);
+        types.add(LocalDate.class);
         return types;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/util/ValidationContextTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/util/ValidationContextTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
-
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +44,7 @@ public class ValidationContextTest {
     private static final String MAP_BEAN_NAME = MockMapValidationModel.class.getName();
     private static final String COLLECTION_BEAN_NAME = MockCollectionValidationModel.class.getName();
     private static final String RECURSIVE_BEAN_NAME = MockRecursiveValidationModel.class.getName();
+    private static final String LOCALDATE_BEAN_NAME = MockValidationModelWithLocalDate.class.getName();
     private static final String PRIMITIVES_ONLY_BEAN_NAME = MockPrimitivesOnlyValidationModel.class.getName();
     private static final String INVALID_BEAN_CLASS_NAME = MockValidationModel.class.getName() + "invalid";
     
@@ -83,6 +84,14 @@ public class ValidationContextTest {
     @Test
     public void testSuccessfulScanWithCollectionFieldPresent() {
         mockComponentScanning(COLLECTION_BEAN_NAME);
+
+        Assertions.assertAll(() ->
+                new ValidationContext(mockProvider, BASE_PATH));
+    }
+    
+    @Test
+    public void testSuccessfulScanWithLocalDateFieldPresent() {
+        mockComponentScanning(LOCALDATE_BEAN_NAME);
 
         Assertions.assertAll(() ->
                 new ValidationContext(mockProvider, BASE_PATH));
@@ -292,6 +301,19 @@ public class ValidationContextTest {
     private class MockRecursiveValidationModel {
         @SuppressWarnings("unused")
         public MockRecursiveValidationModel mockString;
+    }
+    
+    /**
+     * Mocked class containing a single field of the type LocalDate
+     */
+    @ValidationModel
+    private class MockValidationModelWithLocalDate {
+        @SuppressWarnings("unused")
+        @ValidationMapping(JSON_PATH)
+        public String mockString;
+        
+        @SuppressWarnings("unused")
+        public LocalDate localDate;
     }
     
     /**


### PR DESCRIPTION
To avoid error with recursion of LocalDate field on a model during app startup