### PR TITLE
Updated the version of the polyfill to cope with isInteger.

### DIFF
--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -18,7 +18,7 @@
     
 </head>
 <body>
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js" defer async ></script>
+    <script src="https://cdn.polyfill.io/v3/polyfill.min.js" defer async ></script>
     <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/details-polyfill.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>


### PR DESCRIPTION
Updated the version of the polyfill to cope with `isInteger` in the javascript in ie11.

Balancesheet bug fix for ie11