### PR TITLE
Refactor note transformer to accommodate API validation changes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -20,10 +20,10 @@ public enum ValidationMessage {
     DATE_INVALID("date_is_invalid", "validation.date.invalid", false),
     MAX_LENGTH_EXCEEDED("max_length_exceeded", "validation.length.maxExceeded", false),
     SHAREHOLDER_FUND_MISMATCH("shareholder_funds_mismatch", "validation.shareholderFunds.mismatch", false),
-    INVALID_NOTE("invalid_note", "invalid.note", true),
     CURRENT_BALANCESHEET_NOT_EQUAL("value_not_equal_to_current_period_on_balance_sheet", "current.balancesheet.not.equal", false),
     PREVIOUS_BALANCESHEET_NOT_EQUAL("value_not_equal_to_previous_period_on_balance_sheet", "previous.balancesheet.not.equal", false),
-    VALUE_REQUIRED("value_required", "value.required", true);
+    VALUE_REQUIRED("value_required", "value.required", true),
+    UNEXPECTED_DATA("unexpected_data", "validation.unexpected.data", false);
 
     private String messageKey;
     private String apiError;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsAfterOneYearTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsAfterOneYearTransformerImpl.java
@@ -109,10 +109,7 @@ public class CreditorsAfterOneYearTransformerImpl implements CreditorsAfterOneYe
             CreditorsAfterOneYearApi creditorsAfterOneYearApi) {
         CurrentPeriod currentPeriod = new CurrentPeriod();
 
-        if (creditorsAfterOneYear.getDetails() != null
-                && StringUtils.isBlank(creditorsAfterOneYear.getDetails())) {
-            currentPeriod.setDetails(null);
-        } else {
+        if (StringUtils.isNotBlank(creditorsAfterOneYear.getDetails())) {
             currentPeriod.setDetails(creditorsAfterOneYear.getDetails());
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsAfterOneYearTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsAfterOneYearTransformerImpl.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 
-import java.util.Objects;
-import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorsafteroneyear.CreditorsAfterOneYearApi;
@@ -13,6 +11,9 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteron
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteroneyear.OtherCreditors;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.creditorsafteroneyear.Total;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.CreditorsAfterOneYearTransformer;
+
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Component
 public class CreditorsAfterOneYearTransformerImpl implements CreditorsAfterOneYearTransformer {
@@ -53,15 +54,9 @@ public class CreditorsAfterOneYearTransformerImpl implements CreditorsAfterOneYe
 
         CreditorsAfterOneYearApi creditorsAfterOneYearApi = new CreditorsAfterOneYearApi();
 
-        if (creditorsAfterOneYear.getTotal() != null) {
-            if (creditorsAfterOneYear.getTotal().getCurrentTotal() != null) {
-                setCurrentPeriodOnApiModel(creditorsAfterOneYear, creditorsAfterOneYearApi);
-            }
+        setCurrentPeriodOnApiModel(creditorsAfterOneYear, creditorsAfterOneYearApi);
 
-            if (creditorsAfterOneYear.getTotal().getPreviousTotal() != null) {
-                setPreviousPeriodOnApiModel(creditorsAfterOneYear, creditorsAfterOneYearApi);
-            }
-        }
+        setPreviousPeriodOnApiModel(creditorsAfterOneYear, creditorsAfterOneYearApi);
 
         return creditorsAfterOneYearApi;
     }
@@ -115,7 +110,7 @@ public class CreditorsAfterOneYearTransformerImpl implements CreditorsAfterOneYe
         CurrentPeriod currentPeriod = new CurrentPeriod();
 
         if (creditorsAfterOneYear.getDetails() != null
-                && StringUtils.isBlank(creditorsAfterOneYear.getDetails())){
+                && StringUtils.isBlank(creditorsAfterOneYear.getDetails())) {
             currentPeriod.setDetails(null);
         } else {
             currentPeriod.setDetails(creditorsAfterOneYear.getDetails());
@@ -146,7 +141,9 @@ public class CreditorsAfterOneYearTransformerImpl implements CreditorsAfterOneYe
             currentPeriod.setTotal(creditorsAfterOneYear.getTotal().getCurrentTotal());
         }
 
-        creditorsAfterOneYearApi.setCurrentPeriod(currentPeriod);
+        if (isCurrentPeriodPopulated(currentPeriod)) {
+            creditorsAfterOneYearApi.setCurrentPeriod(currentPeriod);
+        }
     }
 
     private void setPreviousPeriodOnApiModel(CreditorsAfterOneYear creditorsAfterOneYear,
@@ -183,12 +180,19 @@ public class CreditorsAfterOneYearTransformerImpl implements CreditorsAfterOneYe
         }
     }
 
-    private boolean isPreviousPeriodPopulated(PreviousPeriod period) {
-        return Stream.of(
-                period.getBankLoansAndOverdrafts(),
-                period.getFinanceLeasesAndHirePurchaseContracts(),
-                period.getOtherCreditors(),
-           period.getTotal()).anyMatch(Objects ::nonNull);
+    private boolean isCurrentPeriodPopulated(CurrentPeriod currentPeriod) {
+
+        return Stream.of(currentPeriod.getBankLoansAndOverdrafts(),
+                currentPeriod.getFinanceLeasesAndHirePurchaseContracts(),
+                currentPeriod.getOtherCreditors(),
+                currentPeriod.getTotal()).anyMatch(Objects::nonNull);
     }
 
+    private boolean isPreviousPeriodPopulated(PreviousPeriod previousPeriod) {
+
+        return Stream.of(previousPeriod.getBankLoansAndOverdrafts(),
+                previousPeriod.getFinanceLeasesAndHirePurchaseContracts(),
+                previousPeriod.getOtherCreditors(),
+                previousPeriod.getTotal()).anyMatch(Objects::nonNull);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsWithinOneYearTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsWithinOneYearTransformerImpl.java
@@ -2,6 +2,8 @@ package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.CreditorsWithinOneYearApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.creditorswithinoneyear.CurrentPeriod;
@@ -132,10 +134,7 @@ public class CreditorsWithinOneYearTransformerImpl implements CreditorsWithinOne
       CreditorsWithinOneYearApi creditorsWithinOneYearApi) {
     CurrentPeriod currentPeriod = new CurrentPeriod();
 
-    if (creditorsWithinOneYear.getDetails() != null
-        && creditorsWithinOneYear.getDetails().equals("")) {
-      currentPeriod.setDetails(null);
-    } else {
+    if (StringUtils.isNotBlank(creditorsWithinOneYear.getDetails())) {
       currentPeriod.setDetails(creditorsWithinOneYear.getDetails());
     }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsWithinOneYearTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CreditorsWithinOneYearTransformerImpl.java
@@ -121,16 +121,10 @@ public class CreditorsWithinOneYearTransformerImpl implements CreditorsWithinOne
 
     CreditorsWithinOneYearApi creditorsWithinOneYearApi = new CreditorsWithinOneYearApi();
 
-    if (creditorsWithinOneYear.getTotal() != null) {
-        if (creditorsWithinOneYear.getTotal().getCurrentTotal() != null) {
-            setCurrentPeriodOnApiModel(creditorsWithinOneYear, creditorsWithinOneYearApi);
-        }
-    
-        if (creditorsWithinOneYear.getTotal().getPreviousTotal() != null) {
-            setPreviousPeriodOnApiModel(creditorsWithinOneYear, creditorsWithinOneYearApi);
-        }
-    }
-    
+    setCurrentPeriodOnApiModel(creditorsWithinOneYear, creditorsWithinOneYearApi);
+
+    setPreviousPeriodOnApiModel(creditorsWithinOneYear, creditorsWithinOneYearApi);
+
     return creditorsWithinOneYearApi;
   }
 
@@ -190,7 +184,9 @@ public class CreditorsWithinOneYearTransformerImpl implements CreditorsWithinOne
           .getCurrentTradeCreditors());
     }
 
-    creditorsWithinOneYearApi.setCreditorsWithinOneYearCurrentPeriod(currentPeriod);
+      if (isCurrentPeriodPopulated(currentPeriod)) {
+          creditorsWithinOneYearApi.setCreditorsWithinOneYearCurrentPeriod(currentPeriod);
+      }
   }
 
   private void setPreviousPeriodOnApiModel(CreditorsWithinOneYear creditorsWithinOneYear,
@@ -246,14 +242,26 @@ public class CreditorsWithinOneYearTransformerImpl implements CreditorsWithinOne
       creditorsWithinOneYearApi.setCreditorsWithinOneYearPreviousPeriod(previousPeriod);
     }
   }
-  
-  private boolean isPreviousPeriodPopulated(PreviousPeriod period) {
-    return Stream.of(period.getAccrualsAndDeferredIncome(),
-        period.getBankLoansAndOverdrafts(),
-        period.getFinanceLeasesAndHirePurchaseContracts(),
-        period.getOtherCreditors(),
-        period.getTaxationAndSocialSecurity(),
-        period.getTotal(),
-        period.getTradeCreditors()).anyMatch(Objects::nonNull);
-  }
+
+    private boolean isCurrentPeriodPopulated(CurrentPeriod currentPeriod) {
+
+        return Stream.of(currentPeriod.getAccrualsAndDeferredIncome(),
+                currentPeriod.getBankLoansAndOverdrafts(),
+                currentPeriod.getFinanceLeasesAndHirePurchaseContracts(),
+                currentPeriod.getOtherCreditors(),
+                currentPeriod.getTaxationAndSocialSecurity(),
+                currentPeriod.getTotal(),
+                currentPeriod.getTradeCreditors()).anyMatch(Objects::nonNull);
+    }
+
+    private boolean isPreviousPeriodPopulated(PreviousPeriod previousPeriod) {
+
+        return Stream.of(previousPeriod.getAccrualsAndDeferredIncome(),
+                previousPeriod.getBankLoansAndOverdrafts(),
+                previousPeriod.getFinanceLeasesAndHirePurchaseContracts(),
+                previousPeriod.getOtherCreditors(),
+                previousPeriod.getTaxationAndSocialSecurity(),
+                previousPeriod.getTotal(),
+                previousPeriod.getTradeCreditors()).anyMatch(Objects::nonNull);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/DebtorsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/DebtorsTransformerImpl.java
@@ -1,11 +1,11 @@
 package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.CurrentPeriod;
 import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.DebtorsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.Debtors.PreviousPeriod;
-import uk.gov.companieshouse.api.model.transaction.Transaction;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.Debtors;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.GreaterThanOneYear;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.OtherDebtors;
@@ -123,9 +123,7 @@ public class DebtorsTransformerImpl implements DebtorsTransformer {
     private void setCurrentPeriodDebtorsOnApiModel(Debtors debtors, DebtorsApi debtorsApi) {
         CurrentPeriod currentPeriod = new CurrentPeriod();
 
-        if (debtors.getDetails() != null && debtors.getDetails().equals("")) {
-            currentPeriod.setDetails(null);
-        } else {
+        if (StringUtils.isNotBlank(debtors.getDetails())) {
             currentPeriod.setDetails(debtors.getDetails());
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/DebtorsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/DebtorsTransformerImpl.java
@@ -15,6 +15,9 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.debtors.TradeDeb
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.DebtorsTransformer;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+
 @Component
 public class DebtorsTransformerImpl implements DebtorsTransformer {
 
@@ -81,17 +84,12 @@ public class DebtorsTransformerImpl implements DebtorsTransformer {
     public DebtorsApi getDebtorsApi(Debtors debtors) {
 
         DebtorsApi debtorsApi = new DebtorsApi();
-        if (debtors.getTotal().getCurrentTotal() != null) {
 
-            setCurrentPeriodDebtorsOnApiModel(debtors, debtorsApi);
-        }
+        setCurrentPeriodDebtorsOnApiModel(debtors, debtorsApi);
 
-        if (debtors.getTotal().getPreviousTotal() != null) {
+        setPreviousPeriodDebtorsOnApiModel(debtors, debtorsApi);
 
-            setPreviousPeriodDebtorsOnApiModel(debtors, debtorsApi);
-        }
         return debtorsApi;
-
     }
 
     private void setPreviousPeriodDebtorsOnApiModel(Debtors debtors, DebtorsApi debtorsApi) {
@@ -116,7 +114,10 @@ public class DebtorsTransformerImpl implements DebtorsTransformer {
         if (debtors.getGreaterThanOneYear() != null && debtors.getGreaterThanOneYear().getPreviousGreaterThanOneYear() != null) {
             previousPeriod.setGreaterThanOneYear(debtors.getGreaterThanOneYear().getPreviousGreaterThanOneYear());
         }
-        debtorsApi.setDebtorsPreviousPeriod(previousPeriod);
+
+        if (isPreviousPeriodPopulated(previousPeriod)) {
+            debtorsApi.setDebtorsPreviousPeriod(previousPeriod);
+        }
     }
 
     private void setCurrentPeriodDebtorsOnApiModel(Debtors debtors, DebtorsApi debtorsApi) {
@@ -148,6 +149,27 @@ public class DebtorsTransformerImpl implements DebtorsTransformer {
             currentPeriod.setGreaterThanOneYear(debtors.getGreaterThanOneYear().getCurrentGreaterThanOneYear());
         }
 
-        debtorsApi.setDebtorsCurrentPeriod(currentPeriod);
+        if (isCurrentPeriodPopulated(currentPeriod)) {
+            debtorsApi.setDebtorsCurrentPeriod(currentPeriod);
+        }
+    }
+
+    private boolean isCurrentPeriodPopulated(CurrentPeriod currentPeriod) {
+
+        return Stream.of(currentPeriod.getDetails(),
+                currentPeriod.getGreaterThanOneYear(),
+                currentPeriod.getOtherDebtors(),
+                currentPeriod.getPrepaymentsAndAccruedIncome(),
+                currentPeriod.getTotal(),
+                currentPeriod.getTradeDebtors()).anyMatch(Objects::nonNull);
+    }
+
+    private boolean isPreviousPeriodPopulated(PreviousPeriod previousPeriod) {
+
+        return Stream.of(previousPeriod.getGreaterThanOneYear(),
+                previousPeriod.getOtherDebtors(),
+                previousPeriod.getPrepaymentsAndAccruedIncome(),
+                previousPeriod.getTotal(),
+                previousPeriod.getTradeDebtors()).anyMatch(Objects::nonNull);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/StocksTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/StocksTransformerImpl.java
@@ -10,6 +10,9 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.notes.stocks.StocksNot
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.stocks.Total;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.StocksTransformer;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+
 @Component
 public class StocksTransformerImpl implements StocksTransformer {
 
@@ -40,15 +43,11 @@ public class StocksTransformerImpl implements StocksTransformer {
     public StocksApi getStocksApi(StocksNote stocksNote) {
 
         StocksApi stocksApi = new StocksApi();
-        if (stocksNote.getTotal().getCurrentTotal() != null) {
 
-            setCurrentPeriodDebtorsOnApiModel(stocksNote, stocksApi);
-        }
+        setCurrentPeriodDebtorsOnApiModel(stocksNote, stocksApi);
 
-        if (stocksNote.getTotal().getPreviousTotal() != null) {
+        setPreviousPeriodDebtorsOnApiModel(stocksNote, stocksApi);
 
-            setPreviousPeriodDebtorsOnApiModel(stocksNote, stocksApi);
-        }
         return stocksApi;
     }
 
@@ -70,7 +69,9 @@ public class StocksTransformerImpl implements StocksTransformer {
             previousPeriod.setTotal(stocksNote.getTotal().getPreviousTotal());
         }
 
-        stocksApi.setPreviousPeriod(previousPeriod);
+        if (isPreviousPeriodPopulated(previousPeriod)) {
+            stocksApi.setPreviousPeriod(previousPeriod);
+        }
     }
 
     private void setCurrentPeriodDebtorsOnApiModel(StocksNote stocksNote, StocksApi stocksApi) {
@@ -91,7 +92,9 @@ public class StocksTransformerImpl implements StocksTransformer {
             currentPeriod.setTotal(stocksNote.getTotal().getCurrentTotal());
         }
 
-        stocksApi.setCurrentPeriod(currentPeriod);
+        if (isCurrentPeriodPopulated(currentPeriod)) {
+            stocksApi.setCurrentPeriod(currentPeriod);
+        }
     }
 
     private void getStocksPreviousPeriodForWeb(StocksApi stocksApi,
@@ -116,5 +119,19 @@ public class StocksTransformerImpl implements StocksTransformer {
             stocks.setCurrentStocks(stocksApi.getCurrentPeriod().getStocks());
             total.setCurrentTotal(stocksApi.getCurrentPeriod().getTotal());
         }
+    }
+
+    private boolean isCurrentPeriodPopulated(CurrentPeriod currentPeriod) {
+
+        return Stream.of(currentPeriod.getPaymentsOnAccount(),
+                currentPeriod.getStocks(),
+                currentPeriod.getTotal()).anyMatch(Objects::nonNull);
+    }
+
+    private boolean isPreviousPeriodPopulated(PreviousPeriod previousPeriod) {
+
+        return Stream.of(previousPeriod.getPaymentsOnAccount(),
+                previousPeriod.getStocks(),
+                previousPeriod.getTotal()).anyMatch(Objects::nonNull);
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -69,7 +69,6 @@ prepaymentsAndAccruedIncome.previousPrepaymentsAndAccruedIncome = Prepayments an
 tradeDebtors.currentTradeDebtors = Trade Debtors current period:
 tradeDebtors.previousTradeDebtors = Trade Debtors previous period:
 validation.characters.invalid.debtors.current_period.details = Invalid characters entered
-validation.length.maxExceeded.debtors.current_period.details = Field must not exceed {0} characters
 current.balancesheet.not.equal.debtors.current_period.total = The total figure here must match the 'debtors' figure on the balance sheet
 previous.balancesheet.not.equal.debtors.previous_period.total = The total figure here must match the 'debtors' figure on the balance sheet
 validation.element.missing.debtors.current_period = The total figure here must match the 'debtors' figure on the balance sheet
@@ -78,6 +77,7 @@ validation.element.missing.debtors.current_period.total = Enter total figure
 validation.element.missing.debtors.previous_period.total = Enter total figure
 validation.unexpected.data.debtors.current_period = The total figure here must match the 'debtors' figure on the balance sheet
 validation.unexpected.data.debtors.previous_period = The total figure here must match the 'debtors' figure on the balance sheet
+validation.length.invalidInputLength.debtors.current_period.details = You must not exceed {1} characters
 
 #Stocks
 paymentsOnAccount.currentPaymentsOnAccount = Payments on account current period:
@@ -92,7 +92,7 @@ validation.element.missing.stocks.current_period.total = Enter total figure
 validation.element.missing.stocks.previous_period.total = Enter total figure
 validation.unexpected.data.stocks.current_period = The total figure here must match the 'stocks' figure on the balance sheet
 validation.unexpected.data.stocks.previous_period = The total figure here must match the 'stocks' figure on the balance sheet
-
+validation.length.invalidInputLength.stocks.current_period.details = You must not exceed {1} characters
 
 #Creditors within one year note
 bankLoansAndOverdrafts.currentBankLoansAndOverdrafts = Bank loans and overdrafts current period:
@@ -110,7 +110,7 @@ otherCreditors.previousOtherCreditors = Other creditors previous period:
 current.balancesheet.not.equal.creditors_within_one_year.current_period.total = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
 previous.balancesheet.not.equal.creditors_within_one_year.previous_period.total = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
 validation.characters.invalid.creditors_within_one_year.current_period.details = Invalid characters entered
-validation.length.maxExceeded.creditors_within_one_year.current_period.details = Field must not exceed {0} characters
+validation.length.invalidInputLength.creditors_within_one_year.current_period.details = You must not exceed {1} characters
 validation.element.missing.creditors_within_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
 validation.element.missing.creditors_within_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
 validation.element.missing.creditors_within_one_year.current_period.total = Enter total figure
@@ -122,13 +122,14 @@ validation.unexpected.data.creditors_within_one_year.previous_period = The total
 current.balancesheet.not.equal.creditors_after_one_year.current_period.total = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 previous.balancesheet.not.equal.creditors_after_one_year.previous_period.total = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 validation.characters.invalid.creditors_after_one_year.current_period.details = Invalid characters entered
-validation.length.maxExceeded.creditors_after_one_year.current_period.details = Field must not exceed {0} characters
+validation.length.invalidInputLength.creditors_after_one_year.current_period.details = You must not exceed {1} characters
 validation.element.missing.creditors_after_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 validation.element.missing.creditors_after_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 validation.element.missing.creditors_after_one_year.current_period.total = Enter total figure
 validation.element.missing.creditors_after_one_year.previous_period.total = Enter total figure
 validation.unexpected.data.creditors_after_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 validation.unexpected.data.creditors_after_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
+
 
 # Validation
 details  = Additional information:
@@ -173,7 +174,6 @@ validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_prepa
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
 validation.length.minInvalid.accounting_policies.turnover_policy = Give details of your 'turnover policy'
-validation.length.invalidInputLength.accounting_policies.turnover_policy = You must not exceed {1} characters
 
 validation.characters.invalid.accounting_policies.intangible_fixed_assets_amortisation_policy = Enter valid characters
 validation.length.minInvalid.accounting_policies.intangible_fixed_assets_amortisation_policy = Give details of your 'intangible fixed assets amortisation' policy

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -74,6 +74,10 @@ current.balancesheet.not.equal.debtors.current_period.total = The total figure h
 previous.balancesheet.not.equal.debtors.previous_period.total = The total figure here must match the 'debtors' figure on the balance sheet
 validation.element.missing.debtors.current_period = The total figure here must match the 'debtors' figure on the balance sheet
 validation.element.missing.debtors.previous_period = The total figure here must match the 'debtors' figure on the balance sheet
+validation.element.missing.debtors.current_period.total = Enter total figure
+validation.element.missing.debtors.previous_period.total = Enter total figure
+validation.unexpected.data.debtors.current_period = The total figure here must match the 'debtors' figure on the balance sheet
+validation.unexpected.data.debtors.previous_period = The total figure here must match the 'debtors' figure on the balance sheet
 
 #Stocks
 paymentsOnAccount.currentPaymentsOnAccount = Payments on account current period:
@@ -82,6 +86,13 @@ stocks.currentStocks = Stocks current period:
 stocks.previousStocks = Stocks previous period:
 current.balancesheet.not.equal.stocks.current_period.total = The total figure here must match the 'stocks' figure on the balance sheet
 previous.balancesheet.not.equal.stocks.previous_period.total = The total figure here must match the 'stocks' figure on the balance sheet
+validation.element.missing.stocks.current_period = The total figure here must match the 'stocks' figure on the balance sheet
+validation.element.missing.stocks.previous_period = The total figure here must match the 'stocks' figure on the balance sheet
+validation.element.missing.stocks.current_period.total = Enter total figure
+validation.element.missing.stocks.previous_period.total = Enter total figure
+validation.unexpected.data.stocks.current_period = The total figure here must match the 'stocks' figure on the balance sheet
+validation.unexpected.data.stocks.previous_period = The total figure here must match the 'stocks' figure on the balance sheet
+
 
 #Creditors within one year note
 bankLoansAndOverdrafts.currentBankLoansAndOverdrafts = Bank loans and overdrafts current period:
@@ -102,6 +113,10 @@ validation.characters.invalid.creditors_within_one_year.current_period.details =
 validation.length.maxExceeded.creditors_within_one_year.current_period.details = Field must not exceed {0} characters
 validation.element.missing.creditors_within_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
 validation.element.missing.creditors_within_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
+validation.element.missing.creditors_within_one_year.current_period.total = Enter total figure
+validation.element.missing.creditors_within_one_year.previous_period.total = Enter total figure
+validation.unexpected.data.creditors_within_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
+validation.unexpected.data.creditors_within_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due within one year' figure on the balance sheet
 
 #Creditors after one year
 current.balancesheet.not.equal.creditors_after_one_year.current_period.total = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
@@ -110,12 +125,15 @@ validation.characters.invalid.creditors_after_one_year.current_period.details = 
 validation.length.maxExceeded.creditors_after_one_year.current_period.details = Field must not exceed {0} characters
 validation.element.missing.creditors_after_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 validation.element.missing.creditors_after_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
+validation.element.missing.creditors_after_one_year.current_period.total = Enter total figure
+validation.element.missing.creditors_after_one_year.previous_period.total = Enter total figure
+validation.unexpected.data.creditors_after_one_year.current_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
+validation.unexpected.data.creditors_after_one_year.previous_period = The total figure here must match the 'Creditors - amounts falling due after one year' figure on the balance sheet
 
 # Validation
 details  = Additional information:
 total.currentTotal = Total current period:
 total.previousTotal = Total previous period:
-invalid.note = Enter total figure
 validation.range.outside = Enter a value between {0} and {1}
 validation.total.invalid = Total provided is incorrect
 validation.date.cannotBeFuture = The date cannot be in the future
@@ -172,9 +190,6 @@ validation.length.invalidInputLength.accounting_policies.valuation_information_a
 validation.characters.invalid.accounting_policies.other_accounting_policy=Enter valid characters
 validation.length.minInvalid.accounting_policies.other_accounting_policy=Give details of any other accounting policies
 validation.length.invalidInputLength.accounting_policies.other_accounting_policy=You must not exceed {1} characters
-
-validation.element.missing.stocks.current_period = The total figure here must match the 'stocks' figure on the balance sheet
-validation.element.missing.stocks.previous_period = The total figure here must match the 'stocks' figure on the balance sheet
 
 current.balancesheet.not.equal.tangible_assets.total.net_book_value_at_end_of_current_period=The 'total' figure here must match the 'Tangible assets' figure on the balance sheet
 previous.balancesheet.not.equal.tangible_assets.total.net_book_value_at_end_of_previous_period=The 'total' figure here must match the 'Tangible assets' figure on the balance sheet

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -174,6 +174,7 @@ validation.length.maxExceeded.accounting_policies.basis_of_measurement_and_prepa
 
 validation.characters.invalid.accounting_policies.turnover_policy = Enter valid characters
 validation.length.minInvalid.accounting_policies.turnover_policy = Give details of your 'turnover policy'
+validation.length.invalidInputLength.accounting_policies.turnover_policy = You must not exceed {1} characters
 
 validation.characters.invalid.accounting_policies.intangible_fixed_assets_amortisation_policy = Enter valid characters
 validation.length.minInvalid.accounting_policies.intangible_fixed_assets_amortisation_policy = Give details of your 'intangible fixed assets amortisation' policy


### PR DESCRIPTION
- transform all web model field data API model, rather than conditionally based on the presence of a total, to ensure API field fields are returned and handled
- update note transformers to stop empty periods being included in API requests and avoid unexpected_data errors being returned and blocking the web journey beyond a specific note page
- remove invalid_note in favour of more specific error introduced to API for this purpose (mandatory_element_missing)