### PR TITLE
Add support for request-scoped balance sheet caching

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImpl.java
@@ -5,8 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 import uk.gov.companieshouse.accountsdates.impl.AccountsDatesHelperImpl;
@@ -20,6 +23,8 @@ import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullLinks;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
 import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
@@ -44,6 +49,7 @@ import uk.gov.companieshouse.web.accounts.util.ValidationContext;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 @Service
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class BalanceSheetServiceImpl implements BalanceSheetService {
 
     @Autowired
@@ -73,6 +79,8 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
     @Autowired
     private TangibleAssetsNoteService tangibleAssetsNoteService;
 
+    private BalanceSheet cachedBalanceSheet;
+
     private AccountsDatesHelper accountsDatesHelper = new AccountsDatesHelperImpl();
 
     private static final UriTemplate SMALL_FULL_URI =
@@ -88,6 +96,10 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
     public BalanceSheet getBalanceSheet(String transactionId, String companyAccountsId,
         String companyNumber)
         throws ServiceException {
+
+        if (cachedBalanceSheet != null) {
+            return cachedBalanceSheet;
+        }
 
         ApiClient apiClient = apiClientService.getApiClient();
 
@@ -108,6 +120,8 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
             previousPeriodApi);
 
         balanceSheet.setBalanceSheetHeadings(balanceSheetHeadings);
+
+        cachedBalanceSheet = balanceSheet;
 
         return balanceSheet;
     }
@@ -156,6 +170,9 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
     public List<ValidationError> postBalanceSheet(String transactionId, String companyAccountsId,
         BalanceSheet balanceSheet, String companyNumber)
         throws ServiceException {
+
+        invalidateRequestScopedCache();
+
         ApiClient apiClient = apiClientService.getApiClient();
 
         List<ValidationError> validationErrors = new ArrayList<>();
@@ -447,5 +464,9 @@ public class BalanceSheetServiceImpl implements BalanceSheetService {
                 .map(CurrentAssets::getStocks)
                 .map(Stocks::getPreviousAmount)
                 .orElse(0L).equals(0L);
+    }
+
+    private void invalidateRequestScopedCache() {
+        cachedBalanceSheet = null;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/BalanceSheetServiceImplTests.java
@@ -133,6 +133,8 @@ public class BalanceSheetServiceImplTests {
     @Mock
     private TangibleAssetsNoteService tangibleAssetsNoteService;
 
+    @Mock
+    private BalanceSheet mockCachedBalanceSheet;
 
     @InjectMocks
     private BalanceSheetService balanceSheetService = new BalanceSheetServiceImpl();
@@ -907,6 +909,16 @@ public class BalanceSheetServiceImplTests {
         assertNotNull(balanceSheet.getBalanceSheetHeadings());
         assertEquals(currentPeriodHeading, balanceSheet.getBalanceSheetHeadings().getCurrentPeriodHeading());
         assertEquals(previousPeriodHeading, balanceSheet.getBalanceSheetHeadings().getPreviousPeriodHeading());
+    }
+
+    @Test
+    @DisplayName("Cached balance sheet returned if previously set")
+    void cachedBalanceSheetReturnedIfPreviouslySet() throws ServiceException {
+
+        BalanceSheet balanceSheet = balanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER);
+
+        assertNotNull(balanceSheet);
+        assertEquals(mockCachedBalanceSheet, balanceSheet);
     }
 
     private void createFirstYearFilerCompanyProfile() throws ServiceException {


### PR DESCRIPTION
The recent introduction of conditional controller navigation has introduced a scenario where multiple consecutive controllers may request the balance sheet resource during the lifetime of a single request. To optimise this inefficiency, a basic request-scoped caching mechanism is being implemented here.

Resolves: SFA-1215