### PR TITLE
Mobile devices - IOS/Android balance sheet sections incorrectly named

### DIFF
--- a/src/main/resources/templates/smallfull/balanceSheet.html
+++ b/src/main/resources/templates/smallfull/balanceSheet.html
@@ -121,7 +121,7 @@
                         <div class="govuk-grid-column-one-quarter">
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'fixedAssets.currentTotal',
-                                text = 'Total current fixed assets',
+                                text = 'Total fixed assets current',
                                 class= 'govuk-input current-fixed-assets-total current-assets-less-current-liabilities-add'
                                 )">
                             </div>
@@ -129,7 +129,7 @@
                         <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter">
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'fixedAssets.previousTotal',
-                                text = 'Total previous fixed assets',
+                                text = 'Total fixed assets previous',
                                 class= 'govuk-input previous-fixed-assets-total previous-assets-less-current-liabilities-add',
                                 )">
                             </div>
@@ -246,7 +246,7 @@
                         <div class="govuk-grid-column-one-quarter">
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'currentAssets.currentTotal',
-                                text = 'Total current current assets',
+                                text = 'Total current assets current',
                                 class= 'govuk-input current-current-assets-total current-net-assets-add'
                                 )">
                             </div>
@@ -254,7 +254,7 @@
                         <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter">
                             <div th:replace="fragments/numberInput :: numberInput (
                                  id = 'currentAssets.previousTotal',
-                                 text = 'Total previous current assets',
+                                 text = 'Total current assets previous',
                                  class= 'govuk-input previous-current-assets-total previous-net-assets-add'
                                  )">
                             </div>
@@ -287,7 +287,7 @@
                         <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter">
                             <div th:replace="fragments/numberInput :: numberInput (
                                    id = 'otherLiabilitiesOrAssets.prepaymentsAndAccruedIncome.previousAmount',
-                                   text = 'Tangible assets previous',
+                                   text = 'Prepayments and accrued income previous',
                                    class= 'govuk-input previous previous-net-assets-add'
                                    )">
                             </div>


### PR DESCRIPTION
Corrected naming of sections within the balancesheet.html

- fixed assets total fields for current and previous years
- current assets total fields for current and previous years
- prepayments and accrued income previous headed as Tangible assets previous corrected

Resolves sfa 1265