### PR TITLE
Move id's to nested div's for automation tests

### DIFF
--- a/src/main/resources/templates/fragments/review/tangibleAssetsValueRow.html
+++ b/src/main/resources/templates/fragments/review/tangibleAssetsValueRow.html
@@ -7,53 +7,47 @@
 <div th:fragment="tangibleAssetsValueRow" class="app-check-your-answers__contents">
   <dt class="app-check-your-answers__question" th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : 'govuk-!-font-weight-regular'" th:text="${description}"></dt>
 
-  <dd th:attr="id='review-' + ${identifier} + '-land-and-buildings'"
-      class="app-check-your-answers__answer"
+  <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Land &amp; buildings:</span>
-    <th:block
+    <div th:id="'review-' + ${identifier} + '-land-and-buildings'"
         th:text="${row?.landAndBuildings != null ? '£' + #numbers.formatInteger(row.landAndBuildings, 0, 'COMMA') : ''}">
-    </th:block>
+    </div>
   </dd>
-  <dd th:attr="id='review-' + ${identifier} + '-plant-and-machinery'"
-      class="app-check-your-answers__answer"
+  <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Plant &amp; machinery:</span>
-    <th:block
+    <div th:id="'review-' + ${identifier} + '-plant-and-machinery'"
         th:text="${row?.plantAndMachinery != null ? '£' + #numbers.formatInteger(row.plantAndMachinery, 0, 'COMMA') : ''}">
-    </th:block>
+    </div>
   </dd>
-  <dd th:attr="id='review-' + ${identifier} + '-fixtures-and-fittings'"
-      class="app-check-your-answers__answer"
+  <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Fixtures &amp; fittings:</span>
-    <th:block
+    <div th:id="'review-' + ${identifier} + '-fixtures-and-fittings'"
         th:text="${row?.fixturesAndFittings != null ? '£' + #numbers.formatInteger(row.fixturesAndFittings, 0, 'COMMA') : ''}">
-    </th:block>
+    </div>
   </dd>
-  <dd th:attr="id='review-' + ${identifier} + '-office-equipment'"
-      class="app-check-your-answers__answer"
+  <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Office equipment:</span>
-    <th:block
+    <div th:id="'review-' + ${identifier} + '-office-equipment'"
         th:text="${row?.officeEquipment != null ? '£' + #numbers.formatInteger(row.officeEquipment, 0, 'COMMA') : ''}">
-    </th:block>
+    </div>
   </dd>
-  <dd th:attr="id='review-' + ${identifier} + '-motor-vehicles'"
-      class="app-check-your-answers__answer"
+  <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Motor vehicles:</span>
-    <th:block
+    <div th:id="'review-' + ${identifier} + '-motor-vehicles'"
         th:text="${row?.motorVehicles != null ? '£' + #numbers.formatInteger(row.motorVehicles, 0, 'COMMA') : ''}">
-    </th:block>
+    </div>
   </dd>
-  <dd th:attr="id='review-' + ${identifier} + '-total'"
-      class="app-check-your-answers__answer"
+  <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Total:</span>
-    <th:block
+    <div th:id="'review-' + ${identifier} + '-total'"
         th:text="${row?.total != null ? '£' + #numbers.formatInteger(row.total, 0, 'COMMA') : ''}">
-    </th:block>
+    </div>
   </dd>
 
   <dd class="app-check-your-answers__change"></dd>

--- a/src/main/resources/templates/fragments/review/tangibleAssetsValueRow.html
+++ b/src/main/resources/templates/fragments/review/tangibleAssetsValueRow.html
@@ -10,44 +10,44 @@
   <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Land &amp; buildings:</span>
-    <div th:id="'review-' + ${identifier} + '-land-and-buildings'"
+    <span th:id="'review-' + ${identifier} + '-land-and-buildings'"
         th:text="${row?.landAndBuildings != null ? '£' + #numbers.formatInteger(row.landAndBuildings, 0, 'COMMA') : ''}">
-    </div>
+    </span>
   </dd>
   <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Plant &amp; machinery:</span>
-    <div th:id="'review-' + ${identifier} + '-plant-and-machinery'"
+    <span th:id="'review-' + ${identifier} + '-plant-and-machinery'"
         th:text="${row?.plantAndMachinery != null ? '£' + #numbers.formatInteger(row.plantAndMachinery, 0, 'COMMA') : ''}">
-    </div>
+    </span>
   </dd>
   <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Fixtures &amp; fittings:</span>
-    <div th:id="'review-' + ${identifier} + '-fixtures-and-fittings'"
+    <span th:id="'review-' + ${identifier} + '-fixtures-and-fittings'"
         th:text="${row?.fixturesAndFittings != null ? '£' + #numbers.formatInteger(row.fixturesAndFittings, 0, 'COMMA') : ''}">
-    </div>
+    </span>
   </dd>
   <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Office equipment:</span>
-    <div th:id="'review-' + ${identifier} + '-office-equipment'"
+    <span th:id="'review-' + ${identifier} + '-office-equipment'"
         th:text="${row?.officeEquipment != null ? '£' + #numbers.formatInteger(row.officeEquipment, 0, 'COMMA') : ''}">
-    </div>
+    </span>
   </dd>
   <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Motor vehicles:</span>
-    <div th:id="'review-' + ${identifier} + '-motor-vehicles'"
+    <span th:id="'review-' + ${identifier} + '-motor-vehicles'"
         th:text="${row?.motorVehicles != null ? '£' + #numbers.formatInteger(row.motorVehicles, 0, 'COMMA') : ''}">
-    </div>
+    </span>
   </dd>
   <dd class="app-check-your-answers__answer"
       th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
     <span class="mobile-only-label">Total:</span>
-    <div th:id="'review-' + ${identifier} + '-total'"
+    <span th:id="'review-' + ${identifier} + '-total'"
         th:text="${row?.total != null ? '£' + #numbers.formatInteger(row.total, 0, 'COMMA') : ''}">
-    </div>
+    </span>
   </dd>
 
   <dd class="app-check-your-answers__change"></dd>


### PR DESCRIPTION
Move id's to nested div tags for tangible assets on the review page so that automation tests don't read mobile-only spans