### PR TITLE
Fixed errors in Employees Note

### DIFF
--- a/src/main/resources/templates/fragments/numberInput.html
+++ b/src/main/resources/templates/fragments/numberInput.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <div th:fragment="numberInput" class="govuk-form-group">
-            <span class="currency-type">£</span>
+            <span th:if="${isEmployees != true}" class="currency-type">£</span>
             <label th:for="${id}">
                 <span th:id="${id} + '-mobile-label'" th:text="${text}" class="mobile-only-label"></span>
                 <input th:field="*{__${id}__}"

--- a/src/main/resources/templates/smallfull/employees.html
+++ b/src/main/resources/templates/smallfull/employees.html
@@ -55,7 +55,7 @@
         <div class="govuk-grid-column-one-half">
 
           <details class="govuk-details" role="group">
-            <summary class="govuk-details__summary" role="button" aria-controls="details-content"
+            <summary class="govuk-details__summary" role="button" aria-controls="employees-details-content"
                      aria-expanded="false">
               <span id="average-employees-title-text" class="govuk-details__summary-text">Average number of employees</span>
             </summary>

--- a/src/main/resources/templates/smallfull/employees.html
+++ b/src/main/resources/templates/smallfull/employees.html
@@ -12,7 +12,7 @@
 <div id="employees-main-content" layout:fragment="content" class="two-column-accounts">
 
   <form id="balanceSheet-form" th:action="@{''}" th:object="${employees}"
-        class="form currency-included-within-inputs govuk-body" method="post">
+        class="form" method="post">
 
     <div th:replace="fragments/globalErrors :: globalErrors"></div>
 
@@ -57,13 +57,13 @@
           <details class="govuk-details" role="group">
             <summary class="govuk-details__summary" role="button" aria-controls="details-content"
                      aria-expanded="false">
-              <span id="additional-information-title-text" class="govuk-details__summary-text">Average number of employees</span>
+              <span id="average-employees-title-text" class="govuk-details__summary-text">Average number of employees</span>
             </summary>
-            <div class="govuk-govuk-form-group" id="details-content" aria-hidden="true">
+            <div class="govuk-govuk-form-group" id="employees-details-content" aria-hidden="true">
               <label class="govuk-visually-hidden"
                      th:for="averageNumberOfEmployees.currentAverageNumberOfEmployees">Average
                 number of employees</label>
-              <span id="more-detail-hint" class="govuk-hint">Enter the average number of people employed by the company in the period you're filing for.</span>
+              <span id="employees-more-detail-hint" class="govuk-hint">Enter the average number of people employed by the company in the period you're filing for.</span>
             </div>
           </details>
         </div>
@@ -72,6 +72,7 @@
                                 id = 'averageNumberOfEmployees.currentAverageNumberOfEmployees',
                                 text = 'Average number of employees current',
                                 class= 'govuk-input range-to-99999 current',
+                                isEmployees = true,
                                 )">
           </div>
         </div>

--- a/src/main/resources/templates/smallfull/employeesQuestion.html
+++ b/src/main/resources/templates/smallfull/employeesQuestion.html
@@ -20,7 +20,7 @@
              th:classappend="${#fields.hasErrors('hasSelectedEmployeesNote')} ? 'govuk-form-group--error' : ''">
 
           <div th:replace="fragments/inlineYesNoRadioButtons :: inlineYesNoRadioButtons (
-              legendText = 'Do your prepared accounts include an employees note?',
+              legendText = 'Do your prepared accounts include an \'employees\' note?',
               radioButtonsFieldName = 'hasSelectedEmployeesNote'
               )">
           </div>


### PR DESCRIPTION
Corrected employees note

- Removed duplicate ids by including employees in the id name.
- Updated Form class to remove currency-included tag as not a currency
- Added th:if"${isEmployees !=true} to numberInput to remove £ when employees note
- Updated employees question html to include 'employees'

Resolves SFA 1108 & 1087