### PR TITLE
Add Missed Piwik Event Tags

### DIFF
--- a/src/main/resources/templates/accountselector/selectAccountType.html
+++ b/src/main/resources/templates/accountselector/selectAccountType.html
@@ -39,7 +39,7 @@
                        name="chooseAccountsRadio"
                        type="radio"
                        value="micros"
-                       data-event-id="Micro-entity accounts"
+                       data-event-id="Micro"
                        th:field="*{selectedAccountTypeName}"
                        th:errorclass="govuk-error-message"/>
                 <label class="govuk-label govuk-radios__label" id="microEntityAccountsButton-label" for="microEntityAccountsButton" >
@@ -52,7 +52,7 @@
                      name="chooseAccountsRadio"
                      type="radio"
                      value="abridged"
-                     data-event-id="Abridged accounts"
+                     data-event-id="Abridged"
                      th:field="*{selectedAccountTypeName}"
                      th:errorclass="govuk-error-message"/>
                 <label class="govuk-label govuk-radios__label" id="abridgedAccountsButton-label" for="abridgedAccountsButton">
@@ -65,7 +65,7 @@
                        name="chooseAccountsRadio"
                        type="radio"
                        value="full"
-                       data-event-id="Full accounts"
+                       data-event-id="Full"
                        th:field="*{selectedAccountTypeName}"
                        th:errorclass="govuk-error-message"/>
                 <label class="govuk-label govuk-radios__label" id="fullAccountsButton-label" for="fullAccountsButton">
@@ -79,7 +79,7 @@
                        value="dormant"
                        th:field="*{selectedAccountTypeName}"
                        th:errorclass="govuk-error-message"
-                       data-event-id="Micro-entity selected"/>
+                       data-event-id="Dormant"/>
                 <label class="govuk-label govuk-radios__label" id="dormantCompanyAccountsButton-label" for="dormantCompanyAccountsButton">
                   Dormant company accounts
                 </label>

--- a/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
+++ b/src/main/resources/templates/fragments/inlineYesNoRadioButtons.html
@@ -23,14 +23,15 @@
   <div class="govuk-radios govuk-radios--inline" data-module="radios">
 
     <div class="govuk-radios__item">
-      <input class="govuk-radios__input show-text"
+      <input class="govuk-radios__input show-text piwik-event"
              id="yesButton"
              type="radio"
              value="1"
              name="${radioButtonsFieldName}"
              th:field="*{__${radioButtonsFieldName}__}"
              th:errorclass="govuk-error-message"
-             th:data-target-text-field="${dataTargetTextFieldName}"/>
+             th:data-target-text-field="${dataTargetTextFieldName}"
+             data-event-id="Yes"/>
 
       <label class="govuk-label govuk-radios__label" for="yesButton" id="yesButton-label">
         Yes
@@ -38,14 +39,15 @@
     </div>
 
     <div class="govuk-radios__item">
-      <input class="govuk-radios__input"
+      <input class="govuk-radios__input piwik-event"
              id="noButton"
              type="radio"
              value="0"
              name="${radioButtonsFieldName}"
              th:field="*{__${radioButtonsFieldName}__}"
              th:errorclass="govuk-error-message"
-             th:data-target-text-field="${dataTargetTextFieldName}"/>
+             th:data-target-text-field="${dataTargetTextFieldName}"
+             data-event-id="No"/>
 
       <label class="govuk-label govuk-radios__label" for="noButton" id="noButton-label">
         No

--- a/src/main/resources/templates/fragments/inlineYesNoRadioButtonsNoTextBox.html
+++ b/src/main/resources/templates/fragments/inlineYesNoRadioButtonsNoTextBox.html
@@ -23,13 +23,14 @@
     <div class="govuk-radios govuk-radios--inline" data-module="radios">
 
         <div class="govuk-radios__item">
-            <input class="govuk-radios__input show-text"
+            <input class="govuk-radios__input show-text piwik-event"
                    id="yesButton"
                    type="radio"
                    value="1"
                    name="${radioButtonsFieldName}"
                    th:field="*{__${radioButtonsFieldName}__}"
-                   th:errorclass="govuk-error-message"/>
+                   th:errorclass="govuk-error-message"
+                   data-event-id="Yes"/>
 
             <label class="govuk-label govuk-radios__label" for="yesButton" id="yesButton-label">
                 Yes
@@ -37,13 +38,14 @@
         </div>
 
         <div class="govuk-radios__item">
-            <input class="govuk-radios__input"
+            <input class="govuk-radios__input piwik-event"
                    id="noButton"
                    type="radio"
                    value="0"
                    name="${radioButtonsFieldName}"
                    th:field="*{__${radioButtonsFieldName}__}"
-                   th:errorclass="govuk-error-message"/>
+                   th:errorclass="govuk-error-message"
+                   data-event-id="No"/>
 
             <label class="govuk-label govuk-radios__label" for="noButton" id="noButton-label">
                 No

--- a/src/main/resources/templates/smallfull/basisOfPreparation.html
+++ b/src/main/resources/templates/smallfull/basisOfPreparation.html
@@ -44,14 +44,14 @@
                             </span>
 
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="basisOfPreparation-prepared-statement" data-target-text-field="basisOfPreparation-custom-statement-field" th:field="*{isPreparedInAccordanceWithStandards}" type="radio" value="1">
+                <input class="govuk-radios__input piwik-event" id="basisOfPreparation-prepared-statement" data-target-text-field="basisOfPreparation-custom-statement-field" th:field="*{isPreparedInAccordanceWithStandards}" type="radio" value="1" data-event-id="FRS102">
                 <label class="govuk-label govuk-radios__label" id="basisOfPreparation-prepared-statement-label" for="basisOfPreparation-prepared-statement">
                   These financial statements have been prepared in accordance with the provisions of Section 1A (Small Entities) of Financial Reporting Standard 102
                 </label>
               </div>
 
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input show-text" id="basisOfPreparation-custom-statement" data-target-text-field="basisOfPreparation-custom-statement-field" th:field="*{isPreparedInAccordanceWithStandards}" type="radio" value="0">
+                <input class="govuk-radios__input show-text piwik-event" id="basisOfPreparation-custom-statement" data-target-text-field="basisOfPreparation-custom-statement-field" th:field="*{isPreparedInAccordanceWithStandards}" type="radio" value="0" data-event-id="Another Standard">
                 <label class="govuk-label govuk-radios__label" id="basisOfPreparation-custom-statement-label" for="basisOfPreparation-custom-statement">
                   These accounts have been prepared in accordance with another standard
                 </label>


### PR DESCRIPTION
Add Piwik event tags to radio button fragments, basis of preparation, and correct the accounts chooser event names.

Resolves SFA-651, SFA-652, SFA-1310, SFA-1311, SFA-1312, SFA-1313, SFA-1314, SFA-1315