### PR TITLE
Approvals Save or Print Widget

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -27,7 +27,11 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 @RequestMapping("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/approval")
 public class ApprovalController extends BaseController {
 
-   private static final UriTemplate CONFIRMATION_REDIRECT = new UriTemplate("/transaction/{transactionId}/confirmation");
+    private static final UriTemplate CONFIRMATION_REDIRECT = new UriTemplate("/transaction/{transactionId}/confirmation");
+
+    private static final String APPROVAL = "approval";
+    private static final String TRANSACTION_ID = "transaction_id";
+    private static final String COMPANY_ACCOUNTS_ID = "company_accounts_id";
 
     @Autowired
     private TransactionService transactionService;
@@ -48,7 +52,9 @@ public class ApprovalController extends BaseController {
 
         addBackPageAttributeToModel(model, companyNumber, transactionId, companyAccountsId);
 
-        model.addAttribute("approval", new Approval());
+        model.addAttribute(APPROVAL, new Approval());
+        model.addAttribute(TRANSACTION_ID, transactionId);
+        model.addAttribute(COMPANY_ACCOUNTS_ID, companyAccountsId);
 
         return getTemplateName();
     }
@@ -57,7 +63,7 @@ public class ApprovalController extends BaseController {
     public String postApproval(@PathVariable String companyNumber,
                                @PathVariable String transactionId,
                                @PathVariable String companyAccountsId,
-                               @ModelAttribute("approval") @Valid Approval approval,
+                               @ModelAttribute(APPROVAL) @Valid Approval approval,
                                BindingResult bindingResult,
                                Model model,
                                HttpServletRequest request) {

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -111,6 +111,26 @@
               </div>
             </fieldset>
 
+            <div class="govuk-inset-text onlyJS">
+              <div id="widget">
+                <a class="render-accounts-document PDF print piwik-event" data-event-id="save or print" href="#"> Save or print a copy of your accounts
+                  <span class="govuk-visually-hidden">(Opens in new tab/window)</span>
+                </a>
+                <span class="govuk-hint"> (Opens in new tab/window) </span>
+                <div id="status-widget" class="widget-footer hidden">
+                  <div id="status">
+                    <div id="process-spinner" class="process-spinner"></div>
+                    <span id="process-status" class="process-status">Status: in-progress</span>
+                  </div>
+                  <input type="hidden" id="document-data"
+                         th:data-resource-url="'/transactions/' + ${transaction_id} + '/company-accounts/' + ${company_accounts_id}"
+                         data-content-type="text/html" data-document-type="text/html">
+                  </input>
+                </div>
+              </div>
+            </div>
+            <div id="download-button"></div>
+
           </div>
 
         </fieldset>
@@ -119,7 +139,7 @@
 
       </div>
     </div>
-
+    <script th:src="@{{cdnUrl}/javascripts/app/accounts-pdf.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
   </form>
 
 </div>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -71,6 +71,10 @@ public class ApprovalControllerTests {
 
     private static final String APPROVAL_MODEL_ATTR = "approval";
 
+    private static final String TRANSACTION_ID_MODEL_ATTR = "transaction_id";
+
+    private static final String COMPANY_ACCOUNTS_ID_MODEL_ATTR = "company_accounts_id";
+
     private static final String ERROR_VIEW = "error";
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
@@ -89,7 +93,9 @@ public class ApprovalControllerTests {
                 .andExpect(view().name(APPROVAL_VIEW))
                 .andExpect(model().attributeExists(BACK_PAGE_MODEL_ATTR))
                 .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
-                .andExpect(model().attributeExists(APPROVAL_MODEL_ATTR));
+                .andExpect(model().attributeExists(APPROVAL_MODEL_ATTR))
+                .andExpect(model().attributeExists(TRANSACTION_ID_MODEL_ATTR))
+                .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID_MODEL_ATTR));
     }
 
     @Test


### PR DESCRIPTION
Enable save or print functionality on the small full approvals screen, accompanied by a relevant Piwik event capture.

Resolves SFA-616, SFA-609