### PR TITLE
Change body of company accounts POST request to be empty in line with API changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>3.13.28</api-sdk-java.version>
+        <api-sdk-java.version>3.13.29</api-sdk-java.version>
 
         <sdk-manager-java.version>1.3.0-rc3</sdk-manager-java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>3.13.21</api-sdk-java.version>
+        <api-sdk-java.version>3.13.28</api-sdk-java.version>
 
         <sdk-manager-java.version>1.3.0-rc3</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
-import java.time.LocalDate;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -9,12 +8,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
-import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccountsService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.StatementsService;
@@ -28,9 +25,6 @@ public class StepsToCompleteController extends BaseController {
 
     @Autowired
     private TransactionService transactionService;
-
-    @Autowired
-    private CompanyService companyService;
 
     @Autowired
     private SmallFullService smallFullService;
@@ -62,10 +56,7 @@ public class StepsToCompleteController extends BaseController {
         try {
             String transactionId = transactionService.createTransaction(companyNumber);
 
-            CompanyProfileApi companyProfile = companyService.getCompanyProfile(companyNumber);
-            LocalDate periodEndOn = companyProfile.getAccounts().getNextAccounts().getPeriodEndOn();
-
-            String companyAccountsId = companyAccountsService.createCompanyAccounts(transactionId, periodEndOn);
+            String companyAccountsId = companyAccountsService.createCompanyAccounts(transactionId);
 
             smallFullService.createSmallFullAccounts(transactionId, companyAccountsId);
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
@@ -1,9 +1,8 @@
 package uk.gov.companieshouse.web.accounts.service.companyaccounts;
 
-import java.time.LocalDate;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
 public interface CompanyAccountsService {
 
-    String createCompanyAccounts(String transactionId, LocalDate periodEndOn) throws ServiceException;
+    String createCompanyAccounts(String transactionId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.web.accounts.service.companyaccounts.impl;
 
-import java.time.LocalDate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,12 +25,11 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
             new UriTemplate("/transactions/{transactionId}/company-accounts");
 
     @Override
-    public String createCompanyAccounts(String transactionId, LocalDate periodEndOn) throws ServiceException {
+    public String createCompanyAccounts(String transactionId) throws ServiceException {
 
         ApiClient apiClient = apiClientService.getApiClient();
 
         CompanyAccountsApi companyAccounts = new CompanyAccountsApi();
-        companyAccounts.setPeriodEndOn(periodEndOn);
 
         String uri = CREATE_COMPANY_ACCOUNTS_URI.expand(transactionId).toString();
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CurrentAssetsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CurrentAssetsTransformerImpl.java
@@ -23,7 +23,7 @@ public class CurrentAssetsTransformerImpl implements Transformer {
             CurrentAssetsApi currentAssetsApi = new CurrentAssetsApi();
             currentAssetsApi.setStocks(balanceSheet.getCurrentAssets().getStocks().getCurrentAmount());
             currentAssetsApi.setDebtors(balanceSheet.getCurrentAssets().getDebtors().getCurrentAmount());
-            currentAssetsApi.setCashInBankAndInHand(balanceSheet.getCurrentAssets().getCashAtBankAndInHand().getCurrentAmount());
+            currentAssetsApi.setCashAtBankAndInHand(balanceSheet.getCurrentAssets().getCashAtBankAndInHand().getCurrentAmount());
             currentAssetsApi.setTotal(balanceSheet.getCurrentAssets().getCurrentTotal());
 
             balanceSheetApi.setCurrentAssets(currentAssetsApi);
@@ -37,7 +37,7 @@ public class CurrentAssetsTransformerImpl implements Transformer {
             CurrentAssetsApi currentAssetsApi = new CurrentAssetsApi();
             currentAssetsApi.setStocks(balanceSheet.getCurrentAssets().getStocks().getPreviousAmount());
             currentAssetsApi.setDebtors(balanceSheet.getCurrentAssets().getDebtors().getPreviousAmount());
-            currentAssetsApi.setCashInBankAndInHand(balanceSheet.getCurrentAssets().getCashAtBankAndInHand().getPreviousAmount());
+            currentAssetsApi.setCashAtBankAndInHand(balanceSheet.getCurrentAssets().getCashAtBankAndInHand().getPreviousAmount());
             currentAssetsApi.setTotal(balanceSheet.getCurrentAssets().getPreviousTotal());
 
             balanceSheetApi.setCurrentAssets(currentAssetsApi);

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
@@ -13,8 +13,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,11 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
-import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
-import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
-import uk.gov.companieshouse.api.model.company.account.NextAccountsApi;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
-import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.companyaccounts.CompanyAccountsService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.StatementsService;
@@ -48,9 +42,6 @@ public class StepsToCompleteControllerTests {
     private TransactionService transactionService;
 
     @Mock
-    private CompanyService companyService;
-
-    @Mock
     private CompanyAccountsService companyAccountsService;
 
     @Mock
@@ -60,7 +51,7 @@ public class StepsToCompleteControllerTests {
     private StatementsService statementsService;
 
     @Mock
-    NavigatorService navigatorService;
+    private NavigatorService navigatorService;
 
     @InjectMocks
     private StepsToCompleteController controller;
@@ -109,20 +100,7 @@ public class StepsToCompleteControllerTests {
 
         when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
 
-        LocalDate periodEndOn = LocalDate.now();
-
-        NextAccountsApi nextAccounts = new NextAccountsApi();
-        nextAccounts.setPeriodEndOn(periodEndOn);
-
-        CompanyAccountApi companyAccount = new CompanyAccountApi();
-        companyAccount.setNextAccounts(nextAccounts);
-
-        CompanyProfileApi companyProfile = new CompanyProfileApi();
-        companyProfile.setAccounts(companyAccount);
-
-        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
-
-        when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn)).thenReturn(COMPANY_ACCOUNTS_ID);
+        when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
         when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
@@ -136,9 +114,7 @@ public class StepsToCompleteControllerTests {
 
         verify(transactionService, times(1)).createTransaction(COMPANY_NUMBER);
 
-        verify(companyService, times(1)).getCompanyProfile(COMPANY_NUMBER);
-
-        verify(companyAccountsService, times(1)).createCompanyAccounts(TRANSACTION_ID, periodEndOn);
+        verify(companyAccountsService, times(1)).createCompanyAccounts(TRANSACTION_ID);
 
         verify(smallFullService, times(1)).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
@@ -158,40 +134,13 @@ public class StepsToCompleteControllerTests {
     }
 
     @Test
-    @DisplayName("Post steps to complete failure path for company service")
-    void postRequestCompanyServiceFailure() throws Exception {
-
-        when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
-
-        doThrow(ServiceException.class)
-                .when(companyService).getCompanyProfile(anyString());
-
-        this.mockMvc.perform(post(STEPS_TO_COMPLETE_PATH))
-                .andExpect(status().isOk())
-                .andExpect(view().name(ERROR_VIEW));
-    }
-
-    @Test
     @DisplayName("Post steps to complete failure path for create company accounts resource")
     void postRequestCompanyAccountsServiceCreateCompanyAccountsFailure() throws Exception {
 
         when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
 
-        LocalDate periodEndOn = LocalDate.now();
-
-        NextAccountsApi nextAccounts = new NextAccountsApi();
-        nextAccounts.setPeriodEndOn(periodEndOn);
-
-        CompanyAccountApi companyAccount = new CompanyAccountApi();
-        companyAccount.setNextAccounts(nextAccounts);
-
-        CompanyProfileApi companyProfile = new CompanyProfileApi();
-        companyProfile.setAccounts(companyAccount);
-
-        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
-
         doThrow(ServiceException.class)
-                .when(companyAccountsService).createCompanyAccounts(anyString(), any(LocalDate.class));
+                .when(companyAccountsService).createCompanyAccounts(TRANSACTION_ID);
 
         this.mockMvc.perform(post(STEPS_TO_COMPLETE_PATH))
                 .andExpect(status().isOk())
@@ -204,23 +153,10 @@ public class StepsToCompleteControllerTests {
 
         when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
 
-        LocalDate periodEndOn = LocalDate.now();
-
-        NextAccountsApi nextAccounts = new NextAccountsApi();
-        nextAccounts.setPeriodEndOn(periodEndOn);
-
-        CompanyAccountApi companyAccount = new CompanyAccountApi();
-        companyAccount.setNextAccounts(nextAccounts);
-
-        CompanyProfileApi companyProfile = new CompanyProfileApi();
-        companyProfile.setAccounts(companyAccount);
-
-        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
-
-        when(companyAccountsService.createCompanyAccounts(anyString(), any(LocalDate.class))).thenReturn("company_accounts_id");
+        when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
         doThrow(ServiceException.class)
-                .when(smallFullService).createSmallFullAccounts(anyString(), anyString());
+                .when(smallFullService).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         this.mockMvc.perform(post(STEPS_TO_COMPLETE_PATH))
                 .andExpect(status().isOk())
@@ -233,23 +169,12 @@ public class StepsToCompleteControllerTests {
 
         when(transactionService.createTransaction(COMPANY_NUMBER)).thenReturn(TRANSACTION_ID);
 
-        NextAccountsApi nextAccounts = new NextAccountsApi();
-        nextAccounts.setPeriodEndOn(LocalDate.now());
+        when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
-        CompanyAccountApi companyAccount = new CompanyAccountApi();
-        companyAccount.setNextAccounts(nextAccounts);
-
-        CompanyProfileApi companyProfile = new CompanyProfileApi();
-        companyProfile.setAccounts(companyAccount);
-
-        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
-
-        when(companyAccountsService.createCompanyAccounts(anyString(), any(LocalDate.class))).thenReturn("company_accounts_id");
-
-        doNothing().when(smallFullService).createSmallFullAccounts(anyString(), anyString());
+        doNothing().when(smallFullService).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         doThrow(ServiceException.class)
-                .when(statementsService).createBalanceSheetStatementsResource(anyString(), anyString());
+                .when(statementsService).createBalanceSheetStatementsResource(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         this.mockMvc.perform(post(STEPS_TO_COMPLETE_PATH))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImplTests.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,8 +60,6 @@ public class CompanyAccountsServiceImplTests {
 
         when(apiClient.companyAccounts()).thenReturn(companyAccountsResourceHandler);
 
-        LocalDate periodEndOn = LocalDate.now();
-
         CompanyAccountsLinks companyAccountsLinks = new CompanyAccountsLinks();
         companyAccountsLinks.setSelf("/company-accounts/" + COMPANY_ACCOUNTS_ID);
 
@@ -74,7 +71,7 @@ public class CompanyAccountsServiceImplTests {
 
         when(companyAccountsCreate.execute()).thenReturn(companyAccounts);
 
-        String companyAccountsId = companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn);
+        String companyAccountsId = companyAccountsService.createCompanyAccounts(TRANSACTION_ID);
 
         assertEquals(COMPANY_ACCOUNTS_ID, companyAccountsId);
     }
@@ -85,8 +82,6 @@ public class CompanyAccountsServiceImplTests {
 
         when(apiClient.companyAccounts()).thenReturn(companyAccountsResourceHandler);
 
-        LocalDate periodEndOn = LocalDate.now();
-
         when(companyAccountsResourceHandler.create(anyString(), any(CompanyAccountsApi.class)))
                 .thenReturn(companyAccountsCreate);
 
@@ -94,7 +89,7 @@ public class CompanyAccountsServiceImplTests {
                 .thenThrow(ApiErrorResponseException.class);
 
         assertThrows(ServiceException.class, () ->
-                companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn));
+                companyAccountsService.createCompanyAccounts(TRANSACTION_ID));
     }
 
     @Test
@@ -103,8 +98,6 @@ public class CompanyAccountsServiceImplTests {
 
         when(apiClient.companyAccounts()).thenReturn(companyAccountsResourceHandler);
 
-        LocalDate periodEndOn = LocalDate.now();
-
         when(companyAccountsResourceHandler.create(anyString(), any(CompanyAccountsApi.class)))
                 .thenReturn(companyAccountsCreate);
 
@@ -112,6 +105,6 @@ public class CompanyAccountsServiceImplTests {
                 .thenThrow(URIValidationException.class);
 
         assertThrows(ServiceException.class, () ->
-                companyAccountsService.createCompanyAccounts(TRANSACTION_ID, periodEndOn));
+                companyAccountsService.createCompanyAccounts(TRANSACTION_ID));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/CurrentAssetsTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/CurrentAssetsTransformerImplTests.java
@@ -237,7 +237,7 @@ public class CurrentAssetsTransformerImplTests {
     private BalanceSheetApi mockBalanceSheetApiForCurrentPeriod() {
 
         CurrentAssetsApi currentAssetsApi = new CurrentAssetsApi();
-        currentAssetsApi.setCashInBankAndInHand(CURRENT_CASH_IN_BANK_AND_IN_HAND);
+        currentAssetsApi.setCashAtBankAndInHand(CURRENT_CASH_IN_BANK_AND_IN_HAND);
         currentAssetsApi.setDebtors(CURRENT_DEBTORS);
         currentAssetsApi.setStocks(CURRENT_STOCKS);
         currentAssetsApi.setTotal(CURRENT_TOTAL);
@@ -251,7 +251,7 @@ public class CurrentAssetsTransformerImplTests {
     private BalanceSheetApi mockBalanceSheetApiForPreviousPeriod() {
 
         CurrentAssetsApi currentAssetsApi = new CurrentAssetsApi();
-        currentAssetsApi.setCashInBankAndInHand(PREVIOUS_CASH_IN_BANK_AND_IN_HAND);
+        currentAssetsApi.setCashAtBankAndInHand(PREVIOUS_CASH_IN_BANK_AND_IN_HAND);
         currentAssetsApi.setDebtors(PREVIOUS_DEBTORS);
         currentAssetsApi.setStocks(PREVIOUS_STOCKS);
         currentAssetsApi.setTotal(PREVIOUS_TOTAL);


### PR DESCRIPTION
Change body of company accounts POST request to be empty in line with API changes; accounting period dates are now derived from the company profile associated with the transaction used to create the company accounts.

Resolves: SFA-1360