### PR TITLE
Fix Current Assets Investments note error messages

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CurrentAssetsInvestmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CurrentAssetsInvestmentsController.java
@@ -73,6 +73,10 @@ public class CurrentAssetsInvestmentsController extends BaseController implement
 
         addBackPageAttributeToModel(model, companyNumber, transactionId, companyAccountsId);
 
+        if (bindingResult.hasErrors()) {
+            return getTemplateName();
+        }
+
         try {
             List<ValidationError> validationErrors =
                 currentAssetsInvestmentsService.submitCurrentAssetsInvestments(transactionId,

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/currentassetsinvestments/CurrentAssetsInvestments.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/notes/currentassetsinvestments/CurrentAssetsInvestments.java
@@ -14,5 +14,5 @@ public class CurrentAssetsInvestments {
 
     @NotBlank(message = "{currentAssetsInvestments.details.missing}")
     @ValidationMapping("$.current_assets_investments.details")
-    private String details;
+    private String currentAssetsInvestmentsDetails;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CurrentAssetsInvestmentsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/CurrentAssetsInvestmentsTransformerImpl.java
@@ -18,7 +18,7 @@ public class CurrentAssetsInvestmentsTransformerImpl implements CurrentAssetsInv
             return  currentAssetsInvestments;
         }
 
-        currentAssetsInvestments.setDetails(currentAssetsInvestmentsApi.getDetails());
+        currentAssetsInvestments.setCurrentAssetsInvestmentsDetails(currentAssetsInvestmentsApi.getDetails());
 
         return currentAssetsInvestments;
     }
@@ -29,7 +29,7 @@ public class CurrentAssetsInvestmentsTransformerImpl implements CurrentAssetsInv
 
         CurrentAssetsInvestmentsApi currentAssetsInvestmentsApi = new CurrentAssetsInvestmentsApi();
 
-        currentAssetsInvestmentsApi.setDetails(currentAssetsInvestments.getDetails());
+        currentAssetsInvestmentsApi.setDetails(currentAssetsInvestments.getCurrentAssetsInvestmentsDetails());
 
         return currentAssetsInvestmentsApi;
     }

--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -8,4 +8,4 @@ valuationInformationPolicy.selectionNotMade=Tell us if your prepared accounts in
 employeesQuestion.selectionNotMade=Tell us if your prepared accounts include an ''employees'' note
 corporationTax.selectionNotMade=Tell us if you also want to file your corporation tax with HMRC now
 typeOfAccounts.selectionNotMade=Tell us which type of accounts you have prepared
-currentAssetsInvestments.details.missing = Provide details of your ''current assets investments''
+currentAssetsInvestments.details.missing = Give details of your ''current assets investments''

--- a/src/main/resources/templates/smallfull/currentAssetsInvestments.html
+++ b/src/main/resources/templates/smallfull/currentAssetsInvestments.html
@@ -20,18 +20,18 @@
 
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
-                    <label class="govuk-label govuk-label govuk-label--l" th:for="details">Enter your 'current assets investments' note</label>
+                    <label class="govuk-label govuk-label govuk-label--l" th:for="currentAssetsInvestmentsDetails">Enter your 'current assets investments' note</label>
 
                     <span class="govuk-error-message"
                           id="details-errorId"
-                          th:if="${#fields.hasErrors('__details__')}"
-                          th:each="e : ${#fields.errors('__details__')}" th:text="${e}">
+                          th:if="${#fields.hasErrors('__currentAssetsInvestmentsDetails__')}"
+                          th:each="e : ${#fields.errors('__currentAssetsInvestmentsDetails__')}" th:text="${e}">
                     </span>
 
-                    <textarea class="govuk-textarea" th:id="details" th:name="details" th:field="*{__details__}"
+                    <textarea class="govuk-textarea" th:id="details" th:name="details" th:field="*{__currentAssetsInvestmentsDetails__}"
                               th:value="details"
                               rows="5"
-                              th:classappend="${#fields.hasErrors('__details__')} ? 'govuk-textarea--error' : ''"></textarea>
+                              th:classappend="${#fields.hasErrors('__currentAssetsInvestmentsDetails__')} ? 'govuk-textarea--error' : ''"></textarea>
                 </div>
             </div>
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CurrentAssetsInvestmentsControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CurrentAssetsInvestmentsControllerTests.java
@@ -71,7 +71,7 @@ public class CurrentAssetsInvestmentsControllerTests {
 
     private static final String ERROR_VIEW = "error";
 
-    private static final String TEST_PATH = "details";
+    private static final String TEST_PATH = "currentAssetsInvestmentsDetails";
 
 
     @BeforeEach

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CurrentAssetsInvestmentsControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/CurrentAssetsInvestmentsControllerTests.java
@@ -13,14 +13,22 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheetHeadings;
+import uk.gov.companieshouse.web.accounts.model.smallfull.CurrentAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.FixedAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.TangibleAssets;
 import uk.gov.companieshouse.web.accounts.model.smallfull.notes.currentassetsinvestments.CurrentAssetsInvestments;
 import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.BalanceSheetService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.CurrentAssetsInvestmentsService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -45,6 +53,9 @@ public class CurrentAssetsInvestmentsControllerTests {
     @Mock
     private CurrentAssetsInvestmentsService mockCurrentAssetsInvestmentsService;
 
+    @Mock
+    private BalanceSheetService mockBalanceSheetService;
+
     @InjectMocks
     private CurrentAssetsInvestmentsController controller;
 
@@ -54,7 +65,7 @@ public class CurrentAssetsInvestmentsControllerTests {
 
     private static final String COMPANY_NUMBER = "companyNumber";
 
-    private static final String SMALL_FULL_FIXED_ASSETS_INVESTMENTS_PATH = "/company/" + COMPANY_NUMBER +
+    private static final String SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH = "/company/" + COMPANY_NUMBER +
         "/transaction/" + TRANSACTION_ID +
         "/company-accounts/" + COMPANY_ACCOUNTS_ID +
         "/small-full/current-assets-investments";
@@ -89,7 +100,7 @@ public class CurrentAssetsInvestmentsControllerTests {
             TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER))
             .thenReturn(new CurrentAssetsInvestments());
 
-        this.mockMvc.perform(get(SMALL_FULL_FIXED_ASSETS_INVESTMENTS_PATH))
+        this.mockMvc.perform(get(SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH))
             .andExpect(status().isOk())
             .andExpect(view().name(CURRENT_ASSETS_INVESTMENTS_VIEW))
             .andExpect(model().attributeExists(CURRENT_ASSETS_INVESTMENTS_MODEL_ATTR))
@@ -108,7 +119,7 @@ public class CurrentAssetsInvestmentsControllerTests {
             TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER))
             .thenThrow(ServiceException.class);
 
-        this.mockMvc.perform(get(SMALL_FULL_FIXED_ASSETS_INVESTMENTS_PATH))
+        this.mockMvc.perform(get(SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH))
             .andExpect(status().isOk())
             .andExpect(view().name(ERROR_VIEW))
             .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
@@ -124,7 +135,8 @@ public class CurrentAssetsInvestmentsControllerTests {
             anyString(), anyString(), any(CurrentAssetsInvestments.class), anyString()))
             .thenReturn(new ArrayList<>());
 
-        this.mockMvc.perform(post(SMALL_FULL_FIXED_ASSETS_INVESTMENTS_PATH))
+        this.mockMvc.perform(post(SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH)
+            .param(TEST_PATH, "Test"))
             .andExpect(status().is3xxRedirection())
             .andExpect(view().name(MOCK_CONTROLLER_PATH));
     }
@@ -137,7 +149,8 @@ public class CurrentAssetsInvestmentsControllerTests {
             .when(mockCurrentAssetsInvestmentsService).submitCurrentAssetsInvestments(
                 anyString(), anyString(), any(CurrentAssetsInvestments.class), anyString());
 
-        this.mockMvc.perform(post(SMALL_FULL_FIXED_ASSETS_INVESTMENTS_PATH))
+        this.mockMvc.perform(post(SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH)
+            .param(TEST_PATH, "Test"))
             .andExpect(status().isOk())
             .andExpect(view().name(ERROR_VIEW))
             .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
@@ -158,8 +171,106 @@ public class CurrentAssetsInvestmentsControllerTests {
             anyString(), anyString(), any(CurrentAssetsInvestments.class), anyString()))
             .thenReturn(errors);
 
-        this.mockMvc.perform(post(SMALL_FULL_FIXED_ASSETS_INVESTMENTS_PATH))
+        this.mockMvc.perform(post(SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH)
+            .param(TEST_PATH, "#¢¢#¢"))
             .andExpect(status().isOk())
             .andExpect(view().name(CURRENT_ASSETS_INVESTMENTS_VIEW));
+    }
+
+    @Test
+    @DisplayName("Post currentAssetsInvestments with binding result error")
+    void postRequestBindingResultErrors() throws Exception {
+
+        this.mockMvc.perform(post(SMALL_FULL_CURRENT_ASSETS_INVESTMENTS_PATH)
+            .param(TEST_PATH, ""))
+            .andExpect(status().isOk())
+            .andExpect(view().name(CURRENT_ASSETS_INVESTMENTS_VIEW))
+            .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
+    }
+
+    @Test
+    @DisplayName("Test will render with Investments present on balancesheet")
+    void willRenderInvestmentsPresent() throws Exception {
+        when(mockBalanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER)).thenReturn(getMockBalanceSheet());
+
+        boolean renderPage = controller.willRender(COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        assertTrue(renderPage);
+    }
+
+    @Test
+    @DisplayName("Test will render with Investments not present on balancesheet")
+    void willRenderInvestmentsNotPresent() throws Exception {
+        when(mockBalanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER)).thenReturn(getMockBalanceSheetNoCurrentInvestments());
+
+        boolean renderPage = controller.willRender(COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        assertFalse(renderPage);
+    }
+
+    @Test
+    @DisplayName("Test will not render with 0 values in Investments on balance sheet")
+    void willNotRenderDebtorsZeroValues() throws Exception {
+        when(mockBalanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER)).thenReturn(getMockBalanceSheetZeroValues());
+
+        boolean renderPage = controller.willRender(COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        assertFalse(renderPage);
+    }
+
+    private BalanceSheet getMockBalanceSheet() {
+        BalanceSheet balanceSheet = new BalanceSheet();
+        BalanceSheetHeadings balanceSheetHeadings = new BalanceSheetHeadings();
+        CurrentAssets currentAssets = new CurrentAssets();
+        uk.gov.companieshouse.web.accounts.model.smallfull.CurrentAssetsInvestments currentAssetsInvestments
+            = new uk.gov.companieshouse.web.accounts.model.smallfull.CurrentAssetsInvestments();
+
+        currentAssetsInvestments.setCurrentAmount(1L);
+        currentAssetsInvestments.setPreviousAmount(2L);
+
+        currentAssets.setInvestments(currentAssetsInvestments);
+
+        balanceSheetHeadings.setCurrentPeriodHeading("currentBalanceSheetHeading");
+        balanceSheetHeadings.setPreviousPeriodHeading("previousBalanceSheetHeading");
+
+        balanceSheet.setCurrentAssets(currentAssets);
+
+        balanceSheet.setBalanceSheetHeadings(balanceSheetHeadings);
+        return balanceSheet;
+    }
+
+    private BalanceSheet getMockBalanceSheetNoCurrentInvestments() {
+        BalanceSheet balanceSheet = new BalanceSheet();
+        FixedAssets fixedAssets = new FixedAssets();
+
+        TangibleAssets tangibleAssets = new TangibleAssets();
+
+        tangibleAssets.setCurrentAmount(1L);
+        tangibleAssets.setPreviousAmount(1L);
+
+        fixedAssets.setTangibleAssets(tangibleAssets);
+        balanceSheet.setFixedAssets(fixedAssets);
+        return balanceSheet;
+    }
+
+    private BalanceSheet getMockBalanceSheetZeroValues() {
+        BalanceSheet balanceSheet = new BalanceSheet();
+        BalanceSheetHeadings balanceSheetHeadings = new BalanceSheetHeadings();
+        CurrentAssets currentAssets = new CurrentAssets();
+        uk.gov.companieshouse.web.accounts.model.smallfull.CurrentAssetsInvestments currentAssetsInvestments
+            = new uk.gov.companieshouse.web.accounts.model.smallfull.CurrentAssetsInvestments();
+
+        currentAssetsInvestments.setCurrentAmount(0L);
+        currentAssetsInvestments.setPreviousAmount(0L);
+
+        currentAssets.setInvestments(currentAssetsInvestments);
+
+        balanceSheetHeadings.setCurrentPeriodHeading("currentBalanceSheetHeading");
+        balanceSheetHeadings.setPreviousPeriodHeading("previousBalanceSheetHeading");
+
+        balanceSheet.setCurrentAssets(currentAssets);
+
+        balanceSheet.setBalanceSheetHeadings(balanceSheetHeadings);
+        return balanceSheet;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CurrentAssetsInvestmentsServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CurrentAssetsInvestmentsServiceImplTests.java
@@ -95,7 +95,7 @@ public class CurrentAssetsInvestmentsServiceImplTests {
             service.getCurrentAssetsInvestments(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER);
 
         assertNotNull(currentAssetsInvestments);
-        assertEquals(TEST_DETAILS, currentAssetsInvestments.getDetails());
+        assertEquals(TEST_DETAILS, currentAssetsInvestments.getCurrentAssetsInvestmentsDetails());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class CurrentAssetsInvestmentsServiceImplTests {
             service.getCurrentAssetsInvestments(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER);
 
         assertNotNull(currentAssetsInvestments);
-        assertEquals(TEST_DETAILS, currentAssetsInvestments.getDetails());
+        assertEquals(TEST_DETAILS, currentAssetsInvestments.getCurrentAssetsInvestmentsDetails());
     }
 
     @Test
@@ -301,7 +301,7 @@ public class CurrentAssetsInvestmentsServiceImplTests {
 
     private CurrentAssetsInvestments createCurrentAssetsInvestments() {
         CurrentAssetsInvestments currentAssetsInvestments = new CurrentAssetsInvestments();
-        currentAssetsInvestments.setDetails(TEST_DETAILS);
+        currentAssetsInvestments.setCurrentAssetsInvestmentsDetails(TEST_DETAILS);
         return currentAssetsInvestments;
     }
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/CurrentAssetsInvestmentsTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/CurrentAssetsInvestmentsTransformerImplTests.java
@@ -31,8 +31,8 @@ public class CurrentAssetsInvestmentsTransformerImplTests {
             transformer.getCurrentAssetsInvestments(currentAssetsInvestmentsApi);
 
         assertNotNull(currentAssetsInvestments);
-        assertNotNull(currentAssetsInvestments.getDetails());
-        assertEquals(TEST_DETAILS, currentAssetsInvestments.getDetails());
+        assertNotNull(currentAssetsInvestments.getCurrentAssetsInvestmentsDetails());
+        assertEquals(TEST_DETAILS, currentAssetsInvestments.getCurrentAssetsInvestmentsDetails());
     }
 
     @Test
@@ -42,14 +42,14 @@ public class CurrentAssetsInvestmentsTransformerImplTests {
             transformer.getCurrentAssetsInvestments(null);
 
         assertNotNull(currentAssetsInvestments);
-        assertNull(currentAssetsInvestments.getDetails());
+        assertNull(currentAssetsInvestments.getCurrentAssetsInvestmentsDetails());
     }
 
     @Test
     @DisplayName("Transform web model to api model")
     void transformCurrentAssetsInvestmentsWebToApi() {
         CurrentAssetsInvestments currentAssetsInvestments = new CurrentAssetsInvestments();
-        currentAssetsInvestments.setDetails(TEST_DETAILS);
+        currentAssetsInvestments.setCurrentAssetsInvestmentsDetails(TEST_DETAILS);
 
         CurrentAssetsInvestmentsApi currentAssetsInvestmentsApi =
             transformer.getCurrentAssetsInvestmentsApi(currentAssetsInvestments);


### PR DESCRIPTION
- Fix "Additional information" appearing before error message as these are not additional information fields
- Update message text to be consistent with other note error text i.e current assets investments
- Add check for BindingResult errors
- Fix broken tests and increase test coverage

**Resolves**: SFA-1147