### PR TITLE
Added Govuk company details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <lombok.version>1.18.0</lombok.version>
 
         <thymeleaf-layout-dialect.version>2.3.0</thymeleaf-layout-dialect.version>
+        <thymeleaf-extras-java8time.version>3.0.1.RELEASE</thymeleaf-extras-java8time.version>
 
         <hamcrest.version>1.3</hamcrest.version>
         <hamcrest-library-version>1.3</hamcrest-library-version>
@@ -87,6 +88,12 @@
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
             <version>${thymeleaf-layout-dialect.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-java8time</artifactId>
+            <version>${thymeleaf-extras-java8time.version}</version>
         </dependency>
 
         <dependency>

--- a/routes.yaml
+++ b/routes.yaml
@@ -14,6 +14,7 @@ routes:
    10: ^/accounts/corporation-tax
    11: ^/accounts/select-account-type
    12: ^/accounts/full-accounts-criteria
-   13: ^/company/(.*)/cic/ 
-   14: ^/company/(.*)/transaction/(.*)/company-accounts/(.*)/resume
-   15: ^/company/(.*)/transaction/(.*)/company-accounts/(.*)/cic/
+   13: ^/accounts/company/(.*)/details
+   14: ^/company/(.*)/cic/
+   15: ^/company/(.*)/transaction/(.*)/company-accounts/(.*)/resume
+   16: ^/company/(.*)/transaction/(.*)/company-accounts/(.*)/cic/

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCompanyDetailController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCompanyDetailController.java
@@ -1,0 +1,52 @@
+package uk.gov.companieshouse.web.accounts.controller.govuk;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import uk.gov.companieshouse.web.accounts.annotation.NextController;
+import uk.gov.companieshouse.web.accounts.controller.BaseController;
+import uk.gov.companieshouse.web.accounts.controller.smallfull.StepsToCompleteController;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Controller
+@NextController(StepsToCompleteController.class)
+@RequestMapping("/accounts/company/{companyNumber}/details")
+public class GovukCompanyDetailController extends BaseController {
+
+    @Autowired
+    private CompanyService companyService;
+
+    private static final String TEMPLATE_HEADING = "Confirm company details";
+
+    @Override
+    protected String getTemplateName() {
+        return "company/companyDetail";
+    }
+
+    @GetMapping
+    public String getCompanyDetail(@PathVariable String companyNumber, Model model, HttpServletRequest request) {
+
+        try {
+            model.addAttribute("companyDetail", companyService.getCompanyDetail(companyNumber));
+            model.addAttribute("templateHeading", TEMPLATE_HEADING);
+        } catch (ServiceException e) {
+            LOGGER.errorRequest(request, e.getMessage(), e);
+            return ERROR_VIEW;
+        }
+
+        return getTemplateName();
+    }
+
+    @PostMapping
+    public String postCompanyDetail(@PathVariable String companyNumber) {
+
+        return navigatorService.getNextControllerRedirect(this.getClass(), companyNumber);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCompanyDetailController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCompanyDetailController.java
@@ -35,11 +35,12 @@ public class GovukCompanyDetailController extends BaseController {
 
         try {
             model.addAttribute("companyDetail", companyService.getCompanyDetail(companyNumber));
-            model.addAttribute("templateHeading", TEMPLATE_HEADING);
         } catch (ServiceException e) {
             LOGGER.errorRequest(request, e.getMessage(), e);
             return ERROR_VIEW;
         }
+
+        model.addAttribute("templateHeading", TEMPLATE_HEADING);
 
         return getTemplateName();
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCriteriaController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCriteriaController.java
@@ -58,7 +58,7 @@ public class GovukCriteriaController extends BaseController {
 
             return UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/accounts/select-account-type";
         }
-        attributes.addAttribute("forward", "/company/{companyNumber}/small-full/steps-to-complete");
+        attributes.addAttribute("forward", "/accounts/company/{companyNumber}/details");
         return UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/company-lookup/search";
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/company/CompanyDetail.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/company/CompanyDetail.java
@@ -1,0 +1,21 @@
+package uk.gov.companieshouse.web.accounts.model.company;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class CompanyDetail {
+
+    private String companyName;
+
+    private String companyNumber;
+
+    private String registeredOfficeAddress;
+
+    private LocalDate accountsNextMadeUpTo;
+
+    private LocalDate lastAccountsNextMadeUpTo;
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/security/WebSecurityConfigurer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/security/WebSecurityConfigurer.java
@@ -21,7 +21,7 @@ public class WebSecurityConfigurer {
         protected void configure(HttpSecurity http)
                 throws Exception {
 
-            http.antMatcher("/accounts/*")
+            http.antMatcher("/accounts/**")
                     .addFilterBefore(new SessionHandler(), BasicAuthenticationFilter.class)
                     .addFilterBefore(new HijackFilter(), BasicAuthenticationFilter.class);
         }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/CompanyService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/CompanyService.java
@@ -2,8 +2,11 @@ package uk.gov.companieshouse.web.accounts.service.company;
 
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
 
 public interface CompanyService {
 
     CompanyProfileApi getCompanyProfile(String companyNumber) throws ServiceException;
+
+    CompanyDetail getCompanyDetail(String companyNumber) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
@@ -9,13 +9,18 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
+import uk.gov.companieshouse.web.accounts.transformer.company.CompanyDetailTransformer;
 
 @Service
 public class CompanyServiceImpl implements CompanyService {
 
     @Autowired
     private ApiClientService apiClientService;
+
+    @Autowired
+    private CompanyDetailTransformer companyDetailTransformer;
 
     private static final UriTemplate GET_COMPANY_URI =
             new UriTemplate("/company/{companyNumber}");
@@ -33,12 +38,18 @@ public class CompanyServiceImpl implements CompanyService {
             companyProfileApi = apiClient.company().get(uri).execute().getData();
         } catch (ApiErrorResponseException e) {
 
-            throw new ServiceException("Error retieving company profile", e);
+            throw new ServiceException("Error retrieving company profile", e);
         } catch (URIValidationException e) {
 
             throw new ServiceException("Invalid URI for company resource", e);
         }
 
         return companyProfileApi;
+    }
+
+    @Override
+    public CompanyDetail getCompanyDetail(String companyNumber) throws ServiceException {
+
+        return companyDetailTransformer.getCompanyDetail(getCompanyProfile(companyNumber));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/company/CompanyDetailTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/company/CompanyDetailTransformer.java
@@ -1,0 +1,9 @@
+package uk.gov.companieshouse.web.accounts.transformer.company;
+
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
+
+public interface CompanyDetailTransformer {
+
+    CompanyDetail getCompanyDetail(CompanyProfileApi companyProfile);
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/company/impl/CompanyDetailTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/company/impl/CompanyDetailTransformerImpl.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.web.accounts.transformer.company.impl;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.RegisteredOfficeAddressApi;
+import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
+import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
+import uk.gov.companieshouse.web.accounts.transformer.company.CompanyDetailTransformer;
+
+import java.util.Optional;
+
+@Component
+public class CompanyDetailTransformerImpl implements CompanyDetailTransformer {
+
+    @Override
+    public CompanyDetail getCompanyDetail(CompanyProfileApi companyProfile) {
+
+        CompanyDetail companyDetail = new CompanyDetail();
+
+        companyDetail.setCompanyName(companyProfile.getCompanyName());
+        companyDetail.setCompanyNumber(companyProfile.getCompanyNumber());
+
+        RegisteredOfficeAddressApi registeredOfficeAddress = companyProfile
+                .getRegisteredOfficeAddress();
+
+        if (registeredOfficeAddress != null) {
+
+            companyDetail.setRegisteredOfficeAddress(
+                    ((registeredOfficeAddress.getAddressLine1() == null) ? "": registeredOfficeAddress
+                            .getAddressLine1()) +
+                            ((registeredOfficeAddress.getAddressLine2() == null) ? "" :", "
+                                    + registeredOfficeAddress.getAddressLine2() ) +
+                            ((registeredOfficeAddress.getPostalCode() == null) ? "" : ", "
+                                    + registeredOfficeAddress.getPostalCode()));
+        }
+
+        companyDetail
+                .setAccountsNextMadeUpTo(Optional.of(companyProfile)
+                        .map(CompanyProfileApi::getAccounts)
+                        .map(CompanyAccountApi::getNextMadeUpTo)
+                        .orElse(null));
+
+        companyDetail.setLastAccountsNextMadeUpTo(Optional.of(companyProfile)
+                .map(CompanyProfileApi::getAccounts)
+                .map(CompanyAccountApi::getLastAccounts)
+                .map(LastAccountsApi::getMadeUpTo)
+                .orElse(null));
+
+        return companyDetail;
+
+    }
+}

--- a/src/main/resources/templates/company/companyDetail.html
+++ b/src/main/resources/templates/company/companyDetail.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/baseLayout}">
+
+<head>
+  <title th:utext="${templateHeading}"></title>
+</head>
+<body>
+<div id="lookup-main-content" layout:fragment="content">
+
+  <form id="lookup-form" th:action="@{''}" th:object="${companyDetail}" class="form" method="post">
+
+    <div class="govuk-grid-row">
+
+      <div class="govuk-grid-column-two-thirds">
+
+        <fieldset class="govuk-fieldset">
+
+          <label class="govuk-label govuk-label--l" id="company-details-heading" th:utext="${templateHeading}">
+          </label>
+
+          <dl class="app-check-your-answers app-check-your-answers--short">
+            <div class="app-check-your-answers__contents">
+              <dt class="app-check-your-answers__question">
+                Company name
+              </dt>
+              <dd class="app-check-your-answers__answer"  id="companyDetail-companyName"
+                   th:utext="*{#strings.replace(companyName,'&#10;','&lt;br&gt;')}">
+              </dd>
+            </div>
+
+            <div class="app-check-your-answers__contents">
+              <dt class="app-check-your-answers__question">
+                Company number
+              </dt>
+              <dd class="app-check-your-answers__answer" id="companyDetail-companyNumber"
+                   th:utext="*{#strings.replace(companyNumber,'&#10;','&lt;br&gt;')}">
+              </dd>
+            </div>
+
+            <div class="app-check-your-answers__contents">
+              <dt class="app-check-your-answers__question">
+                Registered office address
+              </dt>
+              <dd class="app-check-your-answers__answer" id="companyDetail-registeredOfficeAddress"
+                   th:utext="*{#strings.replace(registeredOfficeAddress,'&#10;','&lt;br&gt;')}">
+              </dd>
+            </div>
+
+            <div class="app-check-your-answers__contents">
+              <dt class="app-check-your-answers__question">
+                Next accounts made up to
+              </dt>
+              <dd class="app-check-your-answers__answer" id="companyDetail-accountsNextMadeUpTo"
+                   th:utext="*{#temporals.format(accountsNextMadeUpTo, 'dd MMMM yyyy')}">
+              </dd>
+            </div>
+            <div class="app-check-your-answers__contents">
+              <dt class="app-check-your-answers__question">
+                Last accounts made up to
+              </dt>
+              <dd class="app-check-your-answers__answer" id="companyDetail-lastAccountsNextMadeUpTo"
+                   th:utext="*{#temporals.format(lastAccountsNextMadeUpTo, 'dd MMMM yyyy')}">
+              </dd>
+            </div>
+          </dl>
+        </fieldset>
+        <input id="next-button" class="govuk-button" type="submit" role="button" value="Continue"/>
+
+      </div>
+    </div>
+  </form>
+
+</div>
+</body>
+</html>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCompanyDetailControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCompanyDetailControllerTest.java
@@ -1,0 +1,93 @@
+package uk.gov.companieshouse.web.accounts.controller.govuk;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.view.UrlBasedViewResolver;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
+import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
+import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GovukCompanyDetailControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private CompanyService companyService;
+
+    @Mock
+    private NavigatorService navigatorService;
+
+    @InjectMocks
+    private GovukCompanyDetailController controller;
+
+    @Mock
+    private CompanyDetail companyDetail;
+
+    private static final String COMPANY_NUMBER = "number";
+    private static final String COMPANY_DETAIL_PATH = "/accounts/company/" + COMPANY_NUMBER + "/details";
+    private static final String COMPANY_DETAIL_VIEW = "company/companyDetail";
+    private static final String ERROR_VIEW = "error";
+    private static final String COMPANY_DETAIL_MODEL_ATTR = "companyDetail";
+    private static final String TEMPLATE_NAME_MODEL_ATTR = "templateName";
+    private static final String TEMPLATE_HEADING_MODEL_ATTR = "templateHeading";
+    private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
+
+    @BeforeEach
+    private void setup() {
+
+        this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    @DisplayName("Get Gov uk Company Details - Success")
+    void getRequestSuccess() throws Exception {
+
+        when(companyService.getCompanyDetail(COMPANY_NUMBER)).thenReturn(companyDetail);
+
+        mockMvc.perform(get(COMPANY_DETAIL_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(COMPANY_DETAIL_VIEW))
+                .andExpect(model().attributeExists(COMPANY_DETAIL_MODEL_ATTR))
+                .andExpect(model().attributeExists(TEMPLATE_HEADING_MODEL_ATTR))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
+    }
+
+    @Test
+    @DisplayName("Get Gov uk Company Details - Throws Exception")
+    void getRequestThrowsException() throws Exception {
+
+        when(companyService.getCompanyDetail(COMPANY_NUMBER)).thenThrow(ServiceException.class);
+
+        mockMvc.perform(get(COMPANY_DETAIL_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
+    }
+
+    @Test
+    @DisplayName("Post Gov uk Company Details")
+    void postRequest() throws Exception {
+
+        when(navigatorService.getNextControllerRedirect(controller.getClass(), COMPANY_NUMBER))
+                .thenReturn(MOCK_CONTROLLER_PATH);
+
+        mockMvc.perform(post(COMPANY_DETAIL_PATH))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name(MOCK_CONTROLLER_PATH));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCriteriaControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCriteriaControllerTest.java
@@ -39,6 +39,7 @@ public class GovukCriteriaControllerTest {
     private static final String ALTERNATIVE_FILING_PATH = "redirect:/accounts/alternative-filing-options";
     private static final String OTHER_FILING_PATH = "redirect:/accounts/select-account-type";
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/company-lookup/search";
+    private static final String FORWARD_PATH = "/accounts/company/{companyNumber}/details";
 
     @BeforeEach
     private void setup() {
@@ -67,7 +68,7 @@ public class GovukCriteriaControllerTest {
         this.mockMvc.perform(post(CRITERIA_PATH)
                 .param(beanElement, criteriaMet))
                 .andExpect(MockMvcResultMatchers.model()
-                    .attribute("forward", "/company/{companyNumber}/small-full/steps-to-complete"))
+                    .attribute("forward", FORWARD_PATH))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name(MOCK_CONTROLLER_PATH));
     }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
@@ -21,7 +21,9 @@ import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
 import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
+import uk.gov.companieshouse.web.accounts.transformer.company.CompanyDetailTransformer;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -44,6 +46,12 @@ public class CompanyServiceImplTests {
 
     @Mock
     private CompanyProfileApi companyProfile;
+
+    @Mock
+    private CompanyDetail companyDetail;
+
+    @Mock
+    private CompanyDetailTransformer companyDetailTransformer;
 
     @InjectMocks
     private CompanyService companyService = new CompanyServiceImpl();
@@ -93,5 +101,20 @@ public class CompanyServiceImplTests {
 
         assertThrows(ServiceException.class, () ->
                 companyService.getCompanyProfile(COMPANY_NUMBER));
+    }
+
+    @Test
+    @DisplayName("Get Company Details - Success Path")
+    void getCompanyDetailSuccess() throws ServiceException, ApiErrorResponseException, URIValidationException {
+
+        when(companyGet.execute()).thenReturn(responseWithData);
+
+        when(responseWithData.getData()).thenReturn(companyProfile);
+
+        when(companyDetailTransformer.getCompanyDetail(companyProfile)).thenReturn(companyDetail);
+
+        CompanyDetail returnedCompanyDetail = companyService.getCompanyDetail(COMPANY_NUMBER);
+
+        assertEquals(companyDetail, returnedCompanyDetail);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/company/impl/CompanyTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/company/impl/CompanyTransformerImplTests.java
@@ -1,0 +1,117 @@
+package uk.gov.companieshouse.web.accounts.transformer.company.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.handler.company.request.CompanyGet;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
+import uk.gov.companieshouse.api.model.company.RegisteredOfficeAddressApi;
+import uk.gov.companieshouse.api.model.company.account.CompanyAccountApi;
+import uk.gov.companieshouse.api.model.company.account.LastAccountsApi;
+import uk.gov.companieshouse.web.accounts.model.company.CompanyDetail;
+import uk.gov.companieshouse.web.accounts.transformer.company.CompanyDetailTransformer;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class CompanyTransformerImplTests {
+
+
+    @Mock
+    private CompanyGet companyGet;
+
+    @Mock
+    private ApiResponse<CompanyProfileApi> responseWithData;
+
+    @Mock
+    private CompanyDetail companyDetail;
+
+    private CompanyDetailTransformer companyDetailTransformer = new CompanyDetailTransformerImpl();
+
+    private static final String COMPANY_NAME = "company";
+    private static final String COMPANY_NUMBER = "number";
+
+    private static final String ADDRESS_LINE_1 = "address line 1";
+    private static final String ADDRESS_LINE_2 = "address line 2";
+    private static final String POSTAL_CODE = "postal code";
+    private static final String ADDRESS_FORMATTED = ADDRESS_LINE_1 + ", " + ADDRESS_LINE_2 + ", " + POSTAL_CODE;
+
+    private static final LocalDate NEXT_ACCOUNT_DATE = LocalDate.of(2016, 5, 3);
+    private static final LocalDate LAST_ACCOUNT_DATE = LocalDate.of(2015, 5, 3);
+
+    private CompanyProfileApi createMockCompanyProfileApi(boolean hasRegisteredOfficeAddress, boolean hasAccounts) {
+
+        CompanyProfileApi companyProfile = new CompanyProfileApi();
+
+        companyProfile.setCompanyName(COMPANY_NAME);
+        companyProfile.setCompanyNumber(COMPANY_NUMBER);
+
+        if (hasAccounts) {
+            CompanyAccountApi companyAccounts = new CompanyAccountApi();
+            companyAccounts.setNextMadeUpTo(NEXT_ACCOUNT_DATE);
+
+            LastAccountsApi lastAccounts = new LastAccountsApi();
+            lastAccounts.setMadeUpTo(LAST_ACCOUNT_DATE);
+            companyAccounts.setLastAccounts(lastAccounts);
+
+            companyProfile.setAccounts(companyAccounts);
+        }
+
+        if (hasRegisteredOfficeAddress) {
+            RegisteredOfficeAddressApi address = new RegisteredOfficeAddressApi();
+            address.setAddressLine1(ADDRESS_LINE_1);
+            address.setAddressLine2(ADDRESS_LINE_2);
+            address.setPostalCode(POSTAL_CODE);
+            companyProfile.setRegisteredOfficeAddress(address);
+        }
+
+        return companyProfile;
+    }
+
+    @Test
+    @DisplayName("Get Company Detail - All fields Populated Path")
+    void getCompanyDetailAllPopulated() {
+
+        CompanyDetail companyDetailReturned = companyDetailTransformer.getCompanyDetail(createMockCompanyProfileApi(true, true));
+
+        assertEquals(COMPANY_NAME, companyDetailReturned.getCompanyName());
+        assertEquals(COMPANY_NUMBER, companyDetailReturned.getCompanyNumber());
+        assertEquals(ADDRESS_FORMATTED, companyDetailReturned.getRegisteredOfficeAddress());
+        assertEquals(NEXT_ACCOUNT_DATE, companyDetailReturned.getAccountsNextMadeUpTo());
+        assertEquals(LAST_ACCOUNT_DATE, companyDetailReturned.getLastAccountsNextMadeUpTo());
+    }
+
+    @Test
+    @DisplayName("Get Company Detail - No Accounts Path")
+    void getCompanyDetailNoAccounts() {
+
+        CompanyDetail companyDetailReturned = companyDetailTransformer.getCompanyDetail(createMockCompanyProfileApi(true, false));
+
+        assertEquals(COMPANY_NAME, companyDetailReturned.getCompanyName());
+        assertEquals(COMPANY_NUMBER, companyDetailReturned.getCompanyNumber());
+        assertEquals(ADDRESS_FORMATTED, companyDetailReturned.getRegisteredOfficeAddress());
+        assertNull(companyDetailReturned.getAccountsNextMadeUpTo());
+        assertNull(companyDetailReturned.getLastAccountsNextMadeUpTo());
+    }
+
+    @Test
+    @DisplayName("Get Company Detail - No Address Path")
+    void getCompanyDetailNoAddress() {
+
+        CompanyDetail companyDetailReturned = companyDetailTransformer.getCompanyDetail(createMockCompanyProfileApi(false, true));
+
+        assertEquals(COMPANY_NAME, companyDetailReturned.getCompanyName());
+        assertEquals(COMPANY_NUMBER, companyDetailReturned.getCompanyNumber());
+        assertNull(companyDetailReturned.getRegisteredOfficeAddress());
+        assertEquals(NEXT_ACCOUNT_DATE, companyDetailReturned.getAccountsNextMadeUpTo());
+        assertEquals(LAST_ACCOUNT_DATE, companyDetailReturned.getLastAccountsNextMadeUpTo());
+    }
+}


### PR DESCRIPTION
- Added new controller to expose Gov UK company details page
- Updated company profile service to pull `CompanyDetails` from company profile
- Added new transformer

This change introduced a company details page which would previously belong to the lookup service. The reason for moving it is to allow flexibility in the display on this data.

[SFA - 1578]