### PR TITLE
Handle closure of a payable transaction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>4.1.0</api-sdk-java.version>
+        <api-sdk-java.version>4.1.4</api-sdk-java.version>
 
-        <sdk-manager-java.version>1.3.0-rc3</sdk-manager-java.version>
+        <sdk-manager-java.version>1.4.0-rc1</sdk-manager-java.version>
 
         <structured-logging.version>1.5.0-rc2</structured-logging.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>4.0.0</api-sdk-java.version>
+        <api-sdk-java.version>4.0.6</api-sdk-java.version>
 
         <sdk-manager-java.version>1.3.0-rc3</sdk-manager-java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>4.0.6</api-sdk-java.version>
+        <api-sdk-java.version>4.1.0</api-sdk-java.version>
 
         <sdk-manager-java.version>1.3.0-rc3</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/exception/MalformedPaymentUrlException.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/exception/MalformedPaymentUrlException.java
@@ -1,0 +1,6 @@
+package uk.gov.companieshouse.web.accounts.exception;
+
+public class MalformedPaymentUrlException extends RuntimeException {
+
+    public MalformedPaymentUrlException(String message) { super(message); }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/PaymentService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/PaymentService.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.web.accounts.service.payment;
+
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+
+public interface PaymentService {
+
+    /**
+     * Creates a payment session in order to pay to close a transaction
+     *
+     * @param transactionId The id of the CHS transaction
+     * @param paymentUrl The url to use to create a payment session
+     * @return A URL to to which to redirect to perform the payment
+     * @throws ServiceException if there's an error creating the payment session
+     */
+    String createPaymentSessionForTransaction(String transactionId, String paymentUrl)
+            throws ServiceException;
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
@@ -10,6 +10,7 @@ import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.payment.PaymentSessionApi;
 import uk.gov.companieshouse.environment.EnvironmentReader;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.MalformedPaymentUrlException;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.service.payment.PaymentService;
 
@@ -56,9 +57,12 @@ public class PaymentServiceImpl implements PaymentService {
 
         Matcher paymentUrlMatcher = PAYMENT_URL_PATTERN.matcher(paymentUrl);
 
-        String paymentEndpoint = "";
+        String paymentEndpoint;
         if (paymentUrlMatcher.find()) {
             paymentEndpoint = paymentUrlMatcher.group(3);
+        } else {
+            throw new MalformedPaymentUrlException(
+                    "Invalid payment url for which to create payment session. Payment url: " + paymentUrl);
         }
 
         try {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
@@ -19,8 +19,6 @@ public class PaymentServiceImpl implements PaymentService {
 
     private ApiClientService apiClientService;
 
-    private EnvironmentReader environmentReader;
-
     private String chsUrl;
 
     private String apiUrl;
@@ -37,7 +35,6 @@ public class PaymentServiceImpl implements PaymentService {
     public PaymentServiceImpl(ApiClientService apiClientService, EnvironmentReader environmentReader) {
 
         this.apiClientService = apiClientService;
-        this.environmentReader = environmentReader;
         this.chsUrl = environmentReader.getMandatoryString(CHS_URL);
         this.apiUrl = environmentReader.getMandatoryString(API_URL);
     }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
@@ -1,0 +1,74 @@
+package uk.gov.companieshouse.web.accounts.service.payment.impl;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.model.payment.PaymentSessionApi;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.service.payment.PaymentService;
+
+@Service
+public class PaymentServiceImpl implements PaymentService {
+
+    private ApiClientService apiClientService;
+
+    private EnvironmentReader environmentReader;
+
+    private String chsUrl;
+
+    private String apiUrl;
+
+    private static final String CHS_URL = "CHS_URL";
+
+    private static final String API_URL = "API_URL";
+
+    private static final Pattern PAYMENT_URL_PATTERN = Pattern.compile("^(http|https)://([^/]+)(.*)");
+
+    @Autowired
+    public PaymentServiceImpl(ApiClientService apiClientService, EnvironmentReader environmentReader) {
+
+        this.apiClientService = apiClientService;
+        this.environmentReader = environmentReader;
+        this.chsUrl = environmentReader.getMandatoryString(CHS_URL);
+        this.apiUrl = environmentReader.getMandatoryString(API_URL);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String createPaymentSessionForTransaction(String transactionId, String paymentUrl)
+            throws ServiceException {
+
+        PaymentSessionApi paymentSessionApi = new PaymentSessionApi();
+        paymentSessionApi.setRedirectUri(chsUrl + "/transaction/" + transactionId + "/confirmation");
+        paymentSessionApi.setResource(apiUrl + "/transactions/" + transactionId + "/payment");
+        paymentSessionApi.setReference("cic_report_and_accounts_" + transactionId);
+        paymentSessionApi.setState(UUID.randomUUID().toString());
+
+        Matcher paymentUrlMatcher = PAYMENT_URL_PATTERN.matcher(paymentUrl);
+
+        String paymentEndpoint = "";
+        if (paymentUrlMatcher.find()) {
+            paymentEndpoint = paymentUrlMatcher.group(3);
+        }
+
+        try {
+            return apiClientService.getApiClient()
+                    .payment().create(paymentEndpoint, paymentSessionApi)
+                            .execute().getData().getLinks().get("journey");
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException("Error creating payment session", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for payment resource", e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImpl.java
@@ -30,6 +30,8 @@ public class PaymentServiceImpl implements PaymentService {
 
     private static final Pattern PAYMENT_URL_PATTERN = Pattern.compile("^(http|https)://([^/]+)(.*)");
 
+    private static final String JOURNEY_LINK = "journey";
+
     @Autowired
     public PaymentServiceImpl(ApiClientService apiClientService, EnvironmentReader environmentReader) {
 
@@ -62,7 +64,7 @@ public class PaymentServiceImpl implements PaymentService {
         try {
             return apiClientService.getApiClient()
                     .payment().create(paymentEndpoint, paymentSessionApi)
-                            .execute().getData().getLinks().get("journey");
+                            .execute().getData().getLinks().get(JOURNEY_LINK);
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException("Error creating payment session", e);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.web.accounts.service.transaction;
 
+import java.util.Optional;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
 public interface TransactionService {
@@ -16,12 +17,14 @@ public interface TransactionService {
     String createTransactionWithDescription(String companyNumber, String description) throws ServiceException;
 
     /**
-     * Set the status to 'closed' for an accounts filing transaction
+     * Closes an accounts filing transaction
      *
      * @param transactionId The ID of the transaction to close
      * @throws ServiceException
+     * @return an {@link Optional<String>} containing the URL to be used to create a payment
+     *         session, if the transaction is payable
      */
-    void closeTransaction(String transactionId) throws ServiceException;
+    Optional<String> closeTransaction(String transactionId) throws ServiceException;
 
     /**
      * Add a resume link to the transaction for resuming the web journey at
@@ -33,4 +36,14 @@ public interface TransactionService {
      * @throws ServiceException
      */
     void createResumeLink(String companyNumber, String transactionId, String companyAccountsId) throws ServiceException;
+
+    /**
+     * Determine whether a transaction is payable
+     *
+     * @param transactionId     the ID of the CHS transaction
+     * @param companyAccountsId the company accounts identifier
+     * @return true if the transaction is payable
+     * @throws ServiceException
+     */
+    boolean isPayableTransaction(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/TransactionService.java
@@ -43,7 +43,7 @@ public interface TransactionService {
      * @param transactionId     the ID of the CHS transaction
      * @param companyAccountsId the company accounts identifier
      * @return true if the transaction is payable
-     * @throws ServiceException
+     * @throws ServiceException if there's an error when fetching a transaction
      */
     boolean isPayableTransaction(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
@@ -1,5 +1,9 @@
 package uk.gov.companieshouse.web.accounts.service.transaction.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
@@ -19,6 +23,8 @@ public class TransactionServiceImpl implements TransactionService {
     private ApiClientService apiClientService;
 
     private static final UriTemplate TRANSACTIONS_URI = new UriTemplate("/transactions/{transactionId}");
+
+    private static final String PAYMENT_REQUIRED_HEADER = "x-payment-required";
 
     /**
      *
@@ -60,14 +66,28 @@ public class TransactionServiceImpl implements TransactionService {
      * {@inheritDoc}
      */
     @Override
-    public void closeTransaction(String transactionId) throws ServiceException {
+    public Optional<String> closeTransaction(String transactionId) throws ServiceException {
 
         String uri = TRANSACTIONS_URI.expand(transactionId).toString();
 
         try {
             Transaction transaction = apiClientService.getApiClient().transactions().get(uri).execute().getData();
             transaction.setStatus(TransactionStatus.CLOSED);
-            apiClientService.getApiClient().transactions().update(uri, transaction).execute();
+
+            Map<String, Object> headers =
+                    apiClientService.getApiClient()
+                            .transactions().update(uri, transaction)
+                                    .execute().getHeaders();
+
+            String paymentUrl = null;
+
+            List<String> paymentRequiredHeaders = (ArrayList) headers.get(PAYMENT_REQUIRED_HEADER);
+            if (paymentRequiredHeaders != null) {
+                paymentUrl = paymentRequiredHeaders.get(0);
+            }
+
+            return Optional.ofNullable(paymentUrl);
+
         } catch (ApiErrorResponseException e) {
 
             throw new ServiceException("Error closing transaction", e);
@@ -101,6 +121,30 @@ public class TransactionServiceImpl implements TransactionService {
         } catch (URIValidationException e) {
 
             throw new ServiceException("Invalid URI for updating transactions resource", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isPayableTransaction(String transactionId, String companyAccountsId) throws ServiceException {
+
+        String uri = TRANSACTIONS_URI.expand(transactionId).toString();
+
+        try {
+            Transaction transaction =
+                    apiClientService.getApiClient().transactions().get(uri).execute().getData();
+
+            return transaction.getResources()
+                    .get("/transactions/" + transactionId + "/company-accounts/" + companyAccountsId)
+                            .getLinks().get("costs") != null;
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Error fetching transaction", e);
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException("Invalid URI for fetching transactions resource", e);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/transaction/impl/TransactionServiceImpl.java
@@ -26,6 +26,8 @@ public class TransactionServiceImpl implements TransactionService {
 
     private static final String PAYMENT_REQUIRED_HEADER = "x-payment-required";
 
+    private static final String COSTS_LINK = "costs";
+
     /**
      *
      * {@inheritDoc}
@@ -138,7 +140,7 @@ public class TransactionServiceImpl implements TransactionService {
 
             return transaction.getResources()
                     .get("/transactions/" + transactionId + "/company-accounts/" + companyAccountsId)
-                            .getLinks().get("costs") != null;
+                            .getLinks().get(COSTS_LINK) != null;
         } catch (URIValidationException e) {
 
             throw new ServiceException("Error fetching transaction", e);

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -135,7 +135,7 @@
 
         </fieldset>
 
-        <input id="next-button" class="govuk-button" type="submit" role="button" value="Submit your accounts"/>
+        <input id="next-button" class="govuk-button" type="submit" role="button" th:value="${isPayableTransaction ? 'Save and continue to payment' : 'Submit your accounts'}"/>
 
       </div>
     </div>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -79,6 +79,8 @@ public class ApprovalControllerTests {
 
     private static final String COMPANY_ACCOUNTS_ID_MODEL_ATTR = "company_accounts_id";
 
+    private static final String IS_PAYABLE_TRANSACTION_ATTR = "isPayableTransaction";
+
     private static final String ERROR_VIEW = "error";
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
@@ -103,7 +105,19 @@ public class ApprovalControllerTests {
                 .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR))
                 .andExpect(model().attributeExists(APPROVAL_MODEL_ATTR))
                 .andExpect(model().attributeExists(TRANSACTION_ID_MODEL_ATTR))
-                .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID_MODEL_ATTR));
+                .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID_MODEL_ATTR))
+                .andExpect(model().attributeExists(IS_PAYABLE_TRANSACTION_ATTR));
+    }
+
+    @Test
+    @DisplayName("Get approval - throws service exception")
+    void getRequestServiceException() throws Exception {
+
+        when(transactionService.isPayableTransaction(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenThrow(ServiceException.class);
+
+        this.mockMvc.perform(get(APPROVAL_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR_VIEW));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.smallfull.Approval;
+import uk.gov.companieshouse.web.accounts.service.payment.PaymentService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.ApprovalService;
 import uk.gov.companieshouse.web.accounts.service.transaction.TransactionService;
 import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
@@ -22,7 +24,6 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -45,6 +46,9 @@ public class ApprovalControllerTests {
 
     @Mock
     private NavigatorService navigatorService;
+
+    @Mock
+    private PaymentService paymentService;
 
     @InjectMocks
     private ApprovalController approvalController;
@@ -78,6 +82,10 @@ public class ApprovalControllerTests {
     private static final String ERROR_VIEW = "error";
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
+
+    private static final String PAYMENT_URL = "paymentUrl";
+
+    private static final String PAYMENT_WEB_ENDPOINT = "/paymentWebEndpoint";
 
     @BeforeEach
     private void setup() {
@@ -162,18 +170,36 @@ public class ApprovalControllerTests {
     }
 
     @Test
-    @DisplayName("Post approval success path")
-    void postRequestSuccess() throws Exception {
+    @DisplayName("Post approval success path for non-payable transaction")
+    void postRequestSuccessForNonPayableTransaction() throws Exception {
 
         when(approvalService.validateApprovalDate(any(Approval.class))).thenReturn(new ArrayList<>());
 
         when(approvalService.submitApproval(anyString(), anyString(), any(Approval.class)))
                 .thenReturn(new ArrayList<>());
 
-        doNothing().when(transactionService).closeTransaction(TRANSACTION_ID);
+        when(transactionService.closeTransaction(TRANSACTION_ID)).thenReturn(Optional.ofNullable(null));
 
         this.mockMvc.perform(post(APPROVAL_PATH))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + CONFIRMATION_VIEW));
+    }
+
+    @Test
+    @DisplayName("Post approval success path for payable transaction")
+    void postRequestSuccessForPayableTransaction() throws Exception {
+
+        when(approvalService.validateApprovalDate(any(Approval.class))).thenReturn(new ArrayList<>());
+
+        when(approvalService.submitApproval(anyString(), anyString(), any(Approval.class)))
+                .thenReturn(new ArrayList<>());
+
+        when(transactionService.closeTransaction(TRANSACTION_ID)).thenReturn(Optional.ofNullable(PAYMENT_URL));
+
+        when(paymentService.createPaymentSessionForTransaction(TRANSACTION_ID, PAYMENT_URL)).thenReturn(PAYMENT_WEB_ENDPOINT);
+
+        this.mockMvc.perform(post(APPROVAL_PATH))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + PAYMENT_WEB_ENDPOINT));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/payment/impl/PaymentServiceImplTest.java
@@ -1,0 +1,145 @@
+package uk.gov.companieshouse.web.accounts.service.payment.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.handler.payment.PaymentResourceHandler;
+import uk.gov.companieshouse.api.handler.payment.request.PaymentCreate;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.payment.PaymentApi;
+import uk.gov.companieshouse.api.model.payment.PaymentSessionApi;
+import uk.gov.companieshouse.environment.EnvironmentReader;
+import uk.gov.companieshouse.web.accounts.api.ApiClientService;
+import uk.gov.companieshouse.web.accounts.exception.MalformedPaymentUrlException;
+import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.service.payment.PaymentService;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class PaymentServiceImplTest {
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private EnvironmentReader environmentReader;
+
+    @Mock
+    private PaymentResourceHandler paymentResourceHandler;
+
+    @Mock
+    private PaymentCreate paymentCreate;
+
+    @Mock
+    private ApiResponse<PaymentApi> apiResponse;
+
+    @Mock
+    private PaymentApi paymentApi;
+
+    @Mock
+    private Map<String, String> links;
+
+    private PaymentService paymentService;
+
+    private static final String PAYMENT_ENDPOINT = "/payment";
+
+    private static final String PAYMENT_URL = "https://domain" + PAYMENT_ENDPOINT;
+
+    private static final String TRANSACTION_ID = "transactionId";
+
+    private static final String JOURNEY_LINK = "journey";
+
+    private static final String JOURNEY_URL = "journeyUrl";
+
+    @BeforeEach
+    private void setUp() {
+
+        paymentService = new PaymentServiceImpl(apiClientService, environmentReader);
+    }
+
+    @Test
+    @DisplayName("Create payment session with malformed payment url")
+    void createPaymentSessionMalformedPaymentUrl() {
+
+        assertThrows(MalformedPaymentUrlException.class, () ->
+                paymentService.createPaymentSessionForTransaction(TRANSACTION_ID, ""));
+    }
+
+    @Test
+    @DisplayName("Create payment session - success")
+    void createPaymentSessionSuccess()
+            throws ApiErrorResponseException, URIValidationException, ServiceException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+
+        when(apiClient.payment()).thenReturn(paymentResourceHandler);
+
+        when(paymentResourceHandler.create(eq(PAYMENT_ENDPOINT), any(PaymentSessionApi.class)))
+                .thenReturn(paymentCreate);
+
+        when(paymentCreate.execute()).thenReturn(apiResponse);
+
+        when(apiResponse.getData()).thenReturn(paymentApi);
+
+        when(paymentApi.getLinks()).thenReturn(links);
+
+        when(links.get(JOURNEY_LINK)).thenReturn(JOURNEY_URL);
+
+        String journeyUrl = paymentService.createPaymentSessionForTransaction(TRANSACTION_ID, PAYMENT_URL);
+
+        assertEquals(JOURNEY_URL, journeyUrl);
+    }
+
+    @Test
+    @DisplayName("Create payment session - throws ApiErrorResponseException")
+    void createPaymentSessionThrowsApiErrorResponseException()
+            throws ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+
+        when(apiClient.payment()).thenReturn(paymentResourceHandler);
+
+        when(paymentResourceHandler.create(eq(PAYMENT_ENDPOINT), any(PaymentSessionApi.class)))
+                .thenReturn(paymentCreate);
+
+        when(paymentCreate.execute()).thenThrow(ApiErrorResponseException.class);
+
+        assertThrows(ServiceException.class, () ->
+                paymentService.createPaymentSessionForTransaction(TRANSACTION_ID, PAYMENT_URL));
+    }
+
+    @Test
+    @DisplayName("Create payment session - throws URIValidationException")
+    void createPaymentSessionThrowsURIValidationException()
+            throws ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+
+        when(apiClient.payment()).thenReturn(paymentResourceHandler);
+
+        when(paymentResourceHandler.create(eq(PAYMENT_ENDPOINT), any(PaymentSessionApi.class)))
+                .thenReturn(paymentCreate);
+
+        when(paymentCreate.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(ServiceException.class, () ->
+                paymentService.createPaymentSessionForTransaction(TRANSACTION_ID, PAYMENT_URL));
+    }
+}


### PR DESCRIPTION
Handle the closure of a payable transaction;

The transactions service now returns an optional string which, if present, will contain the url used to create a payment session.
The payment service uses this url to execute a payment session create request, and in turn returns a url to which to redirect to view the 'payment review' screen.
The button on the approvals page has been updated to read 'save and continue to payment' if the transaction to close is payable.

Resolves SFA-1453, SFA-1363