### PR TITLE
CIC criteria back button implementation

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/cic/CicCriteriaController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/cic/CicCriteriaController.java
@@ -44,6 +44,7 @@ public class CicCriteriaController extends BaseController {
                                   BindingResult bindingResult, Model model, RedirectAttributes attributes) {
 
         if (bindingResult.hasErrors()) {
+            addBackPageAttributeToModel(model);
             return getTemplateName();
         }
 


### PR DESCRIPTION
-Handles page validation which accidentally removes back button functionality when fired. Page will now render the back button as expected even when validation fires.

[SFA-1388]