### PR TITLE
Persist the `isPayableTransaction` flag

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -88,15 +88,19 @@ public class ApprovalController extends BaseController {
 
         addBackPageAttributeToModel(model, companyNumber, transactionId, companyAccountsId);
 
-        List<ValidationError> validationErrors = approvalService.validateApprovalDate(approval);
-        if (!validationErrors.isEmpty()) {
-            bindValidationErrors(bindingResult, validationErrors);
-            return getTemplateName();
-        }
-
         try {
+            List<ValidationError> validationErrors = approvalService.validateApprovalDate(approval);
+            if (!validationErrors.isEmpty()) {
+                model.addAttribute(IS_PAYABLE_TRANSACTION,
+                        transactionService.isPayableTransaction(transactionId, companyAccountsId));
+                bindValidationErrors(bindingResult, validationErrors);
+                return getTemplateName();
+            }
+
             validationErrors.addAll(approvalService.submitApproval(transactionId, companyAccountsId, approval));
             if (!validationErrors.isEmpty()) {
+                model.addAttribute(IS_PAYABLE_TRANSACTION,
+                        transactionService.isPayableTransaction(transactionId, companyAccountsId));
                 bindValidationErrors(bindingResult, validationErrors);
                 return getTemplateName();
             }

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -136,7 +136,7 @@
         </fieldset>
 
         <input id="next-button" class="govuk-button" type="submit" role="button" th:value="${isPayableTransaction ? 'Save and continue to payment' : 'Submit your accounts'}"/>
-        <input th:value="${isPayableTransaction}" id="isPayableTransaction" name="isPayableTransaction" type="hidden"/>
+        <input th:field="${isPayableTransaction}" type="hidden"/>
 
       </div>
     </div>

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -136,6 +136,7 @@
         </fieldset>
 
         <input id="next-button" class="govuk-button" type="submit" role="button" th:value="${isPayableTransaction ? 'Save and continue to payment' : 'Submit your accounts'}"/>
+        <input th:field="${isPayableTransaction}" type="hidden">
 
       </div>
     </div>

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -136,7 +136,6 @@
         </fieldset>
 
         <input id="next-button" class="govuk-button" type="submit" role="button" th:value="${isPayableTransaction ? 'Save and continue to payment' : 'Submit your accounts'}"/>
-        <input th:field="${isPayableTransaction}" type="hidden"/>
 
       </div>
     </div>

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -136,7 +136,7 @@
         </fieldset>
 
         <input id="next-button" class="govuk-button" type="submit" role="button" th:value="${isPayableTransaction ? 'Save and continue to payment' : 'Submit your accounts'}"/>
-        <input th:field="${isPayableTransaction}" type="hidden">
+        <input th:value="${isPayableTransaction}" id="isPayableTransaction" name="isPayableTransaction" type="hidden"/>
 
       </div>
     </div>


### PR DESCRIPTION
Persist the `isPayableTransaction` flag to prevent an NPE when approval re-renders owing to binding result errors