### PR TITLE
SFA-1954: Add intangible assets to the balance sheet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>uk.gov.companieshouse</groupId>
@@ -31,7 +31,7 @@
 
         <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
 
-        <api-sdk-java.version>4.1.26</api-sdk-java.version>
+        <api-sdk-java.version>4.1.37</api-sdk-java.version>
 
         <sdk-manager-java.version>1.4.0-rc1</sdk-manager-java.version>
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/FixedAssets.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/FixedAssets.java
@@ -5,6 +5,7 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationMapping;
 public class FixedAssets {
 
     private TangibleAssets tangibleAssets;
+    private IntangibleAssets intangibleAssets;
     private FixedInvestments investments;
 
     @ValidationMapping("$.previous_period.balance_sheet.fixed_assets.total")
@@ -20,6 +21,14 @@ public class FixedAssets {
     public void setTangibleAssets(
         TangibleAssets tangibleAssets) {
         this.tangibleAssets = tangibleAssets;
+    }
+
+    public IntangibleAssets getIntangibleAssets() {
+        return intangibleAssets;
+    }
+
+    public void setIntangibleAssets(IntangibleAssets intangibleAssets) {
+        this.intangibleAssets = intangibleAssets;
     }
 
     public FixedInvestments getInvestments() {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/IntangibleAssets.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/smallfull/IntangibleAssets.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.web.accounts.model.smallfull;
+
+import uk.gov.companieshouse.web.accounts.validation.ValidationMapping;
+
+public class IntangibleAssets {
+
+    @ValidationMapping("$.current_period.balance_sheet.fixed_assets.intangible")
+    private Long currentAmount;
+
+    @ValidationMapping("$.previous_period.balance_sheet.fixed_assets.intangible")
+    private Long previousAmount;
+
+    public Long getCurrentAmount() {
+        return currentAmount;
+    }
+
+    public void setCurrentAmount(Long currentAmount) {
+        this.currentAmount = currentAmount;
+    }
+
+    public Long getPreviousAmount() {
+        return previousAmount;
+    }
+
+    public void setPreviousAmount(Long previousAmount) {
+        this.previousAmount = previousAmount;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/FixedAssetsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/FixedAssetsTransformerImpl.java
@@ -51,7 +51,7 @@ public class FixedAssetsTransformerImpl implements Transformer {
         FixedAssets fixedAssets = createFixedAssets(balanceSheet);
         FixedAssetsApi fixedAssetsApi = balanceSheetApi.getFixedAssets();
 
-        // InTangible assets
+        // Intangible assets
         if (fixedAssetsApi.getIntangible() != null) {
 
             IntangibleAssets intangibleAssets = createIntangibleAssets(balanceSheet);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/FixedAssetsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/FixedAssetsTransformerImpl.java
@@ -3,10 +3,7 @@ package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.FixedAssetsApi;
-import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
-import uk.gov.companieshouse.web.accounts.model.smallfull.FixedAssets;
-import uk.gov.companieshouse.web.accounts.model.smallfull.FixedInvestments;
-import uk.gov.companieshouse.web.accounts.model.smallfull.TangibleAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.*;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.Transformer;
 
 import java.util.Objects;
@@ -20,7 +17,7 @@ public class FixedAssetsTransformerImpl implements Transformer {
 
         if (hasCurrentPeriodFixedAssets(balanceSheet)) {
             FixedAssetsApi fixedAssetsApi = new FixedAssetsApi();
-
+            fixedAssetsApi.setIntangible(balanceSheet.getFixedAssets().getIntangibleAssets().getCurrentAmount());
             fixedAssetsApi.setTangible(balanceSheet.getFixedAssets().getTangibleAssets().getCurrentAmount());
             fixedAssetsApi.setInvestments(balanceSheet.getFixedAssets().getInvestments().getCurrentAmount());
             fixedAssetsApi.setTotal(balanceSheet.getFixedAssets().getCurrentTotal());
@@ -34,7 +31,7 @@ public class FixedAssetsTransformerImpl implements Transformer {
 
         if (hasPreviousPeriodFixedAssets(balanceSheet)) {
             FixedAssetsApi fixedAssetsApi = new FixedAssetsApi();
-
+            fixedAssetsApi.setIntangible(balanceSheet.getFixedAssets().getIntangibleAssets().getPreviousAmount());
             fixedAssetsApi.setTangible(balanceSheet.getFixedAssets().getTangibleAssets().getPreviousAmount());
             fixedAssetsApi.setInvestments(balanceSheet.getFixedAssets().getInvestments().getPreviousAmount());
             fixedAssetsApi.setTotal(balanceSheet.getFixedAssets().getPreviousTotal());
@@ -49,6 +46,13 @@ public class FixedAssetsTransformerImpl implements Transformer {
 
         FixedAssets fixedAssets = createFixedAssets(balanceSheet);
         FixedAssetsApi fixedAssetsApi = balanceSheetApi.getFixedAssets();
+
+        // InTangible assets
+        if (fixedAssetsApi.getIntangible() != null) {
+
+            IntangibleAssets intangibleAssets = createIntangibleAssets(balanceSheet);
+            intangibleAssets.setCurrentAmount(fixedAssetsApi.getIntangible());
+        }
 
         // Tangible assets
         if (fixedAssetsApi.getTangible() != null) {
@@ -75,6 +79,12 @@ public class FixedAssetsTransformerImpl implements Transformer {
 
         FixedAssets fixedAssets = createFixedAssets(balanceSheet);
         FixedAssetsApi fixedAssetsApi = balanceSheetApi.getFixedAssets();
+
+        // Intangible assets
+        if (fixedAssetsApi.getIntangible() != null) {
+            IntangibleAssets intangibleAssets = createIntangibleAssets(balanceSheet);
+            intangibleAssets.setPreviousAmount(fixedAssetsApi.getIntangible());
+        }
 
         // Tangible assets
         if (fixedAssetsApi.getTangible() != null) {
@@ -120,6 +130,20 @@ public class FixedAssetsTransformerImpl implements Transformer {
         }
 
         return tangibleAssets;
+    }
+
+    private IntangibleAssets createIntangibleAssets(BalanceSheet balanceSheet) {
+
+        IntangibleAssets intangibleAssets;
+
+        if (balanceSheet.getFixedAssets().getIntangibleAssets() == null) {
+            intangibleAssets = new IntangibleAssets();
+            balanceSheet.getFixedAssets().setIntangibleAssets(intangibleAssets);
+        } else {
+            intangibleAssets = balanceSheet.getFixedAssets().getIntangibleAssets();
+        }
+
+        return intangibleAssets;
     }
 
     private FixedInvestments createFixedInvestments(BalanceSheet balanceSheet){

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/FixedAssetsTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/impl/FixedAssetsTransformerImpl.java
@@ -3,7 +3,11 @@ package uk.gov.companieshouse.web.accounts.transformer.smallfull.impl;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.FixedAssetsApi;
-import uk.gov.companieshouse.web.accounts.model.smallfull.*;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
+import uk.gov.companieshouse.web.accounts.model.smallfull.FixedAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.FixedInvestments;
+import uk.gov.companieshouse.web.accounts.model.smallfull.TangibleAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.IntangibleAssets;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.Transformer;
 
 import java.util.Objects;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -7,9 +7,11 @@ calledUpShareCapitalNotPaid.currentAmount = Called up share capital not paid cur
 calledUpShareCapitalNotPaid.previousAmount = Called up share capital not paid previous period:
 
 # Fixed Assets
+fixedAssets.intangibleAssets.currentAmount = Intangible assets current period:
 fixedAssets.tangibleAssets.currentAmount = Tangible assets current period:
 fixedAssets.investments.currentAmount = Fixed assets investments current period:
 fixedAssets.currentTotal = Fixed assets total current period:
+fixedAssets.intangibleAssets.previousAmount = Intangible assets previous period:
 fixedAssets.tangibleAssets.previousAmount = Tangible assets previous period:
 fixedAssets.investments.previousAmount = Fixed assets investments previous period:
 fixedAssets.previousTotal = Fixed assets total previous period:

--- a/src/main/resources/templates/smallfull/balanceSheet.html
+++ b/src/main/resources/templates/smallfull/balanceSheet.html
@@ -85,6 +85,35 @@
                     <h2 class="govuk-heading-m" id="fixed-assets-title">Fixed assets</h2>
 
                     <div th:replace="fragments/fieldErrorRow :: fieldErrorRow (
+                        currentField = 'fixedAssets.intangibleAssets.currentAmount',
+                        previousField = 'fixedAssets.intangibleAssets.previousAmount'
+                        )">
+                    </div>
+
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-one-half" id="fixed-assets-intangible-subtitle">
+                            Intangible assets
+                        </div>
+
+                        <div class="govuk-grid-column-one-quarter">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'fixedAssets.intangibleAssets.currentAmount',
+                                text = 'Intangible assets current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
+                                class = 'govuk-input current current-fixed-assets-add',
+                                )">
+                            </div>
+                        </div>
+                        <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'fixedAssets.intangibleAssets.previousAmount',
+                                text = 'Intangible assets previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
+                                class= 'govuk-input previous previous-fixed-assets-add',
+                                )">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div th:replace="fragments/fieldErrorRow :: fieldErrorRow (
                         currentField = 'fixedAssets.tangibleAssets.currentAmount',
                         previousField = 'fixedAssets.tangibleAssets.previousAmount'
                         )">

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/FixedAssetsTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/FixedAssetsTransformerImplTests.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.FixedAssetsApi;
-import uk.gov.companieshouse.web.accounts.model.smallfull.*;
+import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
+import uk.gov.companieshouse.web.accounts.model.smallfull.FixedAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.FixedInvestments;
+import uk.gov.companieshouse.web.accounts.model.smallfull.TangibleAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.IntangibleAssets;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.impl.FixedAssetsTransformerImpl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/FixedAssetsTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/smallfull/FixedAssetsTransformerImplTests.java
@@ -4,10 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.model.accounts.smallfull.BalanceSheetApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.FixedAssetsApi;
-import uk.gov.companieshouse.web.accounts.model.smallfull.BalanceSheet;
-import uk.gov.companieshouse.web.accounts.model.smallfull.FixedAssets;
-import uk.gov.companieshouse.web.accounts.model.smallfull.FixedInvestments;
-import uk.gov.companieshouse.web.accounts.model.smallfull.TangibleAssets;
+import uk.gov.companieshouse.web.accounts.model.smallfull.*;
 import uk.gov.companieshouse.web.accounts.transformer.smallfull.impl.FixedAssetsTransformerImpl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,10 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FixedAssetsTransformerImplTests {
 
+    private static final Long CURRENT_INTANGIBLE_ASSETS = 1L;
     private static final Long CURRENT_TANGIBLE_ASSETS = 1L;
     private static final Long CURRENT_FIXED_ASSETS_INVESTMENTS = 1L;
     private static final Long CURRENT_TOTAL_FIXED_ASSETS = 2L;
 
+    private static final Long PREVIOUS_INTANGIBLE_ASSETS = 10L;
     private static final Long PREVIOUS_TANGIBLE_ASSETS = 10L;
     private static final Long PREVIOUS_FIXED_ASSETS_INVESTMENTS = 1L;
     private static final Long PREVIOUS_TOTAL_FIXED_ASSETS = 20L;
@@ -190,20 +189,24 @@ public class FixedAssetsTransformerImplTests {
 
     private BalanceSheet mockBalanceSheetWithPeriods(Boolean currentPeriod, Boolean previousPeriod) {
 
+        IntangibleAssets intangibleAssets = new IntangibleAssets();
         TangibleAssets tangibleAssets = new TangibleAssets();
         FixedInvestments fixedInvestments = new FixedInvestments();
 
         if (currentPeriod) {
+            intangibleAssets.setCurrentAmount(CURRENT_INTANGIBLE_ASSETS);
             tangibleAssets.setCurrentAmount(CURRENT_TANGIBLE_ASSETS);
             fixedInvestments.setCurrentAmount(CURRENT_FIXED_ASSETS_INVESTMENTS);
         }
 
         if (previousPeriod) {
+            intangibleAssets.setPreviousAmount(PREVIOUS_INTANGIBLE_ASSETS);
             tangibleAssets.setPreviousAmount(PREVIOUS_TANGIBLE_ASSETS);
             fixedInvestments.setPreviousAmount(PREVIOUS_FIXED_ASSETS_INVESTMENTS);
         }
 
         FixedAssets fixedAssets = new FixedAssets();
+        fixedAssets.setIntangibleAssets(intangibleAssets);
         fixedAssets.setTangibleAssets(tangibleAssets);
         fixedAssets.setInvestments(fixedInvestments);
 
@@ -232,6 +235,7 @@ public class FixedAssetsTransformerImplTests {
     private BalanceSheetApi mockBalanceSheetApiForCurrentPeriod() {
 
         FixedAssetsApi fixedAssetsApi = new FixedAssetsApi();
+        fixedAssetsApi.setIntangible(CURRENT_INTANGIBLE_ASSETS);
         fixedAssetsApi.setTangible(CURRENT_TANGIBLE_ASSETS);
         fixedAssetsApi.setInvestments(CURRENT_FIXED_ASSETS_INVESTMENTS);
         fixedAssetsApi.setTotal(CURRENT_TOTAL_FIXED_ASSETS);
@@ -245,6 +249,7 @@ public class FixedAssetsTransformerImplTests {
     private BalanceSheetApi mockBalanceSheetApiForPreviousPeriod() {
 
         FixedAssetsApi fixedAssetsApi = new FixedAssetsApi();
+        fixedAssetsApi.setIntangible(PREVIOUS_INTANGIBLE_ASSETS);
         fixedAssetsApi.setTangible(PREVIOUS_TANGIBLE_ASSETS);
         fixedAssetsApi.setInvestments(PREVIOUS_FIXED_ASSETS_INVESTMENTS);
         fixedAssetsApi.setTotal(PREVIOUS_TOTAL_FIXED_ASSETS);
@@ -266,31 +271,37 @@ public class FixedAssetsTransformerImplTests {
     }
 
     private void assertCurrentPeriodFieldsNotNull(BalanceSheet balanceSheet) {
+        assertNotNull(balanceSheet.getFixedAssets().getIntangibleAssets().getCurrentAmount());
         assertNotNull(balanceSheet.getFixedAssets().getTangibleAssets().getCurrentAmount());
         assertNotNull(balanceSheet.getFixedAssets().getCurrentTotal());
     }
 
     private void assertPreviousPeriodFieldsNotNull(BalanceSheet balanceSheet) {
+        assertNotNull(balanceSheet.getFixedAssets().getIntangibleAssets().getPreviousAmount());
         assertNotNull(balanceSheet.getFixedAssets().getTangibleAssets().getPreviousAmount());
         assertNotNull(balanceSheet.getFixedAssets().getPreviousTotal());
     }
 
     private void assertCurrentPeriodFieldsNull(BalanceSheet balanceSheet) {
+        assertNull(balanceSheet.getFixedAssets().getIntangibleAssets().getCurrentAmount());
         assertNull(balanceSheet.getFixedAssets().getTangibleAssets().getCurrentAmount());
         assertNull(balanceSheet.getFixedAssets().getCurrentTotal());
     }
 
     private void assertPreviousPeriodFieldsNull(BalanceSheet balanceSheet) {
+        assertNull(balanceSheet.getFixedAssets().getIntangibleAssets().getPreviousAmount());
         assertNull(balanceSheet.getFixedAssets().getTangibleAssets().getPreviousAmount());
         assertNull(balanceSheet.getFixedAssets().getPreviousTotal());
     }
 
     private void assertCurrentPeriodValuesCorrect(BalanceSheet balanceSheet) {
+        assertEquals(CURRENT_INTANGIBLE_ASSETS, balanceSheet.getFixedAssets().getIntangibleAssets().getCurrentAmount());
         assertEquals(CURRENT_TANGIBLE_ASSETS, balanceSheet.getFixedAssets().getTangibleAssets().getCurrentAmount());
         assertEquals(CURRENT_TOTAL_FIXED_ASSETS, balanceSheet.getFixedAssets().getCurrentTotal());
     }
 
     private void assertPreviousPeriodValuesCorrect(BalanceSheet balanceSheet) {
+        assertEquals(PREVIOUS_INTANGIBLE_ASSETS, balanceSheet.getFixedAssets().getIntangibleAssets().getPreviousAmount());
         assertEquals(PREVIOUS_TANGIBLE_ASSETS, balanceSheet.getFixedAssets().getTangibleAssets().getPreviousAmount());
         assertEquals(PREVIOUS_TOTAL_FIXED_ASSETS, balanceSheet.getFixedAssets().getPreviousTotal());
     }
@@ -299,14 +310,17 @@ public class FixedAssetsTransformerImplTests {
         assertNotNull(balanceSheetApi.getFixedAssets());
         assertNotNull(balanceSheetApi.getFixedAssets().getTotal());
         assertNotNull(balanceSheetApi.getFixedAssets().getTangible());
+        assertNotNull(balanceSheetApi.getFixedAssets().getIntangible());
     }
 
     private void assertCurrentPeriodApiModelValuesCorrect(BalanceSheetApi balanceSheetApi) {
+        assertEquals(CURRENT_INTANGIBLE_ASSETS, balanceSheetApi.getFixedAssets().getIntangible());
         assertEquals(CURRENT_TANGIBLE_ASSETS, balanceSheetApi.getFixedAssets().getTangible());
         assertEquals(CURRENT_TOTAL_FIXED_ASSETS, balanceSheetApi.getFixedAssets().getTotal());
     }
 
     private void assertPreviousPeriodApiModelValuesCorrect(BalanceSheetApi balanceSheetApi) {
+        assertEquals(PREVIOUS_INTANGIBLE_ASSETS, balanceSheetApi.getFixedAssets().getIntangible());
         assertEquals(PREVIOUS_TANGIBLE_ASSETS, balanceSheetApi.getFixedAssets().getTangible());
         assertEquals(PREVIOUS_TOTAL_FIXED_ASSETS, balanceSheetApi.getFixedAssets().getTotal());
     }


### PR DESCRIPTION
- Add Intangible assets to the balance sheet.
- Add Intangible assets to the Fixed assets totalling.
- Make sure it works with javascript(on/off)

Note:navigation is a part of a separate story hence not included in this.


Resolves:SFA-1954