### PR TITLE
Create operating profit or loss section of P&L

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/OperatingProfitAndLossTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/OperatingProfitAndLossTransformer.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl;
 
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.accounts.profitandloss.GrossProfitOrLoss;
 import uk.gov.companieshouse.api.model.accounts.profitandloss.ProfitAndLossApi;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.ProfitAndLoss;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss;
@@ -11,6 +12,8 @@ import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorl
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OtherOperatingIncome;
 
 import javax.print.attribute.standard.MediaSize;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Component
 public class OperatingProfitAndLossTransformer {
@@ -52,14 +55,78 @@ public class OperatingProfitAndLossTransformer {
 
     public void addPreviousPeriodToWebModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi previousPeriodProfitAndLoss) {
 
+        if (previousPeriodProfitAndLoss.getOperatingProfitOrLoss() != null) {
+
+            createOperatingProfitOrLoss(profitAndLoss);
+
+            if (previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses() != null) {
+
+                AdministrativeExpenses administrativeExpenses = createAdministrativeExpenses(profitAndLoss);
+                administrativeExpenses.setPreviousAmount(
+                        previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses());
+            }
+
+            if (previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getDistributionCosts() != null) {
+
+                DistributionCosts distributionCosts = createDistributionCosts(profitAndLoss);
+                distributionCosts.setPreviousAmount(
+                        previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getDistributionCosts());
+            }
+
+            if (previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getOperatingTotal() != null) {
+
+                OperatingTotal operatingTotal = createOperatingTotal(profitAndLoss);
+                operatingTotal.setPreviousAmount(
+                        previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getOperatingTotal());
+            }
+
+            if (previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome() != null) {
+
+                OtherOperatingIncome otherOperatingIncome = createOtherOperatingIncome(profitAndLoss);
+                otherOperatingIncome.setPreviousAmount(
+                        previousPeriodProfitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome());
+            }
+        }
     }
 
     public void addCurrentPeriodToApiModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi currentPeriodProfitAndLoss) {
 
+        if (hasCurrentPeriodOperatingProfitOrLoss(profitAndLoss)) {
+
+            uk.gov.companieshouse.api.model.accounts.profitandloss.OperatingProfitOrLoss operatingProfitOrLoss =
+                    new uk.gov.companieshouse.api.model.accounts.profitandloss.OperatingProfitOrLoss();
+
+            operatingProfitOrLoss.setAdministrativeExpenses(profitAndLoss.getOperatingProfitOrLoss().
+                    getAdministrativeExpenses().getCurrentAmount());
+            operatingProfitOrLoss.setDistributionCosts(profitAndLoss.getOperatingProfitOrLoss().
+                    getDistributionCosts().getCurrentAmount());
+            operatingProfitOrLoss.setOperatingTotal(profitAndLoss.getOperatingProfitOrLoss().
+                    getOperatingTotal().getCurrentAmount());
+            operatingProfitOrLoss.setOtherOperatingIncome(profitAndLoss.getOperatingProfitOrLoss().
+                    getOtherOperatingIncome().getCurrentAmount());
+
+            currentPeriodProfitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLoss);
+        }
     }
 
     public void addPreviousPeriodToApiModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi previousPeriodProfitAndLoss) {
 
+        if (hasPreviousPeriodOperatingProfitOrLoss(profitAndLoss)) {
+
+            uk.gov.companieshouse.api.model.accounts.profitandloss.OperatingProfitOrLoss operatingProfitOrLoss =
+                    new uk.gov.companieshouse.api.model.accounts.profitandloss.OperatingProfitOrLoss();
+
+            operatingProfitOrLoss.setAdministrativeExpenses(profitAndLoss.getOperatingProfitOrLoss().
+                    getAdministrativeExpenses().getPreviousAmount());
+            operatingProfitOrLoss.setDistributionCosts(profitAndLoss.getOperatingProfitOrLoss().
+                    getDistributionCosts().getPreviousAmount());
+            operatingProfitOrLoss.setOperatingTotal(profitAndLoss.getOperatingProfitOrLoss().
+                    getOperatingTotal().getPreviousAmount());
+            operatingProfitOrLoss.setOtherOperatingIncome(profitAndLoss.getOperatingProfitOrLoss().
+                    getOtherOperatingIncome().getPreviousAmount());
+
+            previousPeriodProfitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLoss);
+        }
     }
 
     private void createOperatingProfitOrLoss(ProfitAndLoss profitAndLoss) {
@@ -117,5 +184,23 @@ public class OperatingProfitAndLossTransformer {
             otherOperatingIncome = profitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome();
         }
         return otherOperatingIncome;
+    }
+
+    private boolean hasCurrentPeriodOperatingProfitOrLoss(ProfitAndLoss profitAndLoss) {
+
+        return Stream.of(profitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses().getCurrentAmount(),
+                profitAndLoss.getOperatingProfitOrLoss().getDistributionCosts().getCurrentAmount(),
+                profitAndLoss.getOperatingProfitOrLoss().getOperatingTotal().getCurrentAmount(),
+                profitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome().getCurrentAmount()).
+                anyMatch(Objects::nonNull);
+    }
+
+    private boolean hasPreviousPeriodOperatingProfitOrLoss(ProfitAndLoss profitAndLoss) {
+
+        return Stream.of(profitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses().getPreviousAmount(),
+                profitAndLoss.getOperatingProfitOrLoss().getDistributionCosts().getPreviousAmount(),
+                profitAndLoss.getOperatingProfitOrLoss().getOperatingTotal().getPreviousAmount(),
+                profitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome().getPreviousAmount()).
+                anyMatch(Objects::nonNull);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/OperatingProfitAndLossTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/OperatingProfitAndLossTransformer.java
@@ -1,8 +1,7 @@
 package uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl;
 
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.model.accounts.profitandloss.GrossProfitOrLoss;
 import uk.gov.companieshouse.api.model.accounts.profitandloss.ProfitAndLossApi;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.ProfitAndLoss;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss;
@@ -11,7 +10,6 @@ import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorl
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OperatingTotal;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OtherOperatingIncome;
 
-import javax.print.attribute.standard.MediaSize;
 import java.util.Objects;
 import java.util.stream.Stream;
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/OperatingProfitAndLossTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/OperatingProfitAndLossTransformer.java
@@ -1,0 +1,121 @@
+package uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl;
+
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.model.accounts.profitandloss.ProfitAndLossApi;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.ProfitAndLoss;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.AdministrativeExpenses;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.DistributionCosts;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OperatingTotal;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OtherOperatingIncome;
+
+import javax.print.attribute.standard.MediaSize;
+
+@Component
+public class OperatingProfitAndLossTransformer {
+
+    public void addCurrentPeriodToWebModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi currentPeriodProfitAndLoss) {
+        if (currentPeriodProfitAndLoss.getOperatingProfitOrLoss() != null) {
+
+            createOperatingProfitOrLoss(profitAndLoss);
+
+            if (currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses() != null) {
+
+                AdministrativeExpenses administrativeExpenses = createAdministrativeExpenses(profitAndLoss);
+                administrativeExpenses.setCurrentAmount(
+                        currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses());
+            }
+
+            if (currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getDistributionCosts() != null) {
+
+                DistributionCosts distributionCosts = createDistributionCosts(profitAndLoss);
+                distributionCosts.setCurrentAmount(
+                        currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getDistributionCosts());
+            }
+
+            if (currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getOperatingTotal() != null) {
+
+                OperatingTotal operatingTotal = createOperatingTotal(profitAndLoss);
+                operatingTotal.setCurrentAmount(
+                        currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getOperatingTotal());
+            }
+
+            if (currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome() != null) {
+
+                OtherOperatingIncome otherOperatingIncome = createOtherOperatingIncome(profitAndLoss);
+                otherOperatingIncome.setCurrentAmount(
+                        currentPeriodProfitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome());
+            }
+        }
+    }
+
+    public void addPreviousPeriodToWebModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi previousPeriodProfitAndLoss) {
+
+    }
+
+    public void addCurrentPeriodToApiModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi currentPeriodProfitAndLoss) {
+
+    }
+
+    public void addPreviousPeriodToApiModel(ProfitAndLoss profitAndLoss, ProfitAndLossApi previousPeriodProfitAndLoss) {
+
+    }
+
+    private void createOperatingProfitOrLoss(ProfitAndLoss profitAndLoss) {
+
+        if (profitAndLoss.getOperatingProfitOrLoss() == null) {
+
+            profitAndLoss.setOperatingProfitOrLoss(new OperatingProfitOrLoss());
+        }
+    }
+
+    private AdministrativeExpenses createAdministrativeExpenses(ProfitAndLoss profitAndLoss) {
+        AdministrativeExpenses administrativeExpenses;
+
+        if (profitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses() == null) {
+            administrativeExpenses = new AdministrativeExpenses();
+            profitAndLoss.getOperatingProfitOrLoss().setAdministrativeExpenses(administrativeExpenses);
+        } else {
+            administrativeExpenses = profitAndLoss.getOperatingProfitOrLoss().getAdministrativeExpenses();
+        }
+        return administrativeExpenses;
+    }
+
+    private DistributionCosts createDistributionCosts(ProfitAndLoss profitAndLoss) {
+        DistributionCosts distributionCosts;
+
+        if (profitAndLoss.getOperatingProfitOrLoss().getDistributionCosts() == null) {
+            distributionCosts = new DistributionCosts();
+            profitAndLoss.getOperatingProfitOrLoss().setDistributionCosts(distributionCosts);
+        } else {
+            distributionCosts = profitAndLoss.getOperatingProfitOrLoss().getDistributionCosts();
+        }
+        return distributionCosts;
+
+    }
+
+    private OperatingTotal createOperatingTotal(ProfitAndLoss profitAndLoss) {
+        OperatingTotal operatingTotal;
+
+        if (profitAndLoss.getOperatingProfitOrLoss().getOperatingTotal() == null) {
+            operatingTotal = new OperatingTotal();
+            profitAndLoss.getOperatingProfitOrLoss().setOperatingTotal(operatingTotal);
+        } else {
+            operatingTotal = profitAndLoss.getOperatingProfitOrLoss().getOperatingTotal();
+        }
+        return operatingTotal;
+    }
+
+    private OtherOperatingIncome createOtherOperatingIncome(ProfitAndLoss profitAndLoss) {
+        OtherOperatingIncome otherOperatingIncome;
+
+        if (profitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome() == null) {
+            otherOperatingIncome = new OtherOperatingIncome();
+            profitAndLoss.getOperatingProfitOrLoss().setOtherOperatingIncome(otherOperatingIncome);
+        } else {
+            otherOperatingIncome = profitAndLoss.getOperatingProfitOrLoss().getOtherOperatingIncome();
+        }
+        return otherOperatingIncome;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/ProfitAndLossTransformerImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/impl/ProfitAndLossTransformerImpl.java
@@ -12,6 +12,9 @@ public class ProfitAndLossTransformerImpl implements ProfitAndLossTransformer {
     @Autowired
     private GrossProfitAndLossTransformer grossProfitAndLossTransformer;
 
+    @Autowired
+    private OperatingProfitAndLossTransformer operatingProfitAndLossTransformer;
+
     @Override
     public ProfitAndLoss getProfitAndLoss(ProfitAndLossApi currentPeriodProfitAndLoss,
             ProfitAndLossApi previousPeriodProfitAndLoss) {
@@ -21,10 +24,14 @@ public class ProfitAndLossTransformerImpl implements ProfitAndLossTransformer {
         if (currentPeriodProfitAndLoss != null) {
             grossProfitAndLossTransformer
                     .addCurrentPeriodToWebModel(profitAndLoss, currentPeriodProfitAndLoss);
+            operatingProfitAndLossTransformer
+                    .addCurrentPeriodToWebModel(profitAndLoss, currentPeriodProfitAndLoss);
         }
 
         if (previousPeriodProfitAndLoss != null) {
             grossProfitAndLossTransformer
+                    .addPreviousPeriodToWebModel(profitAndLoss, previousPeriodProfitAndLoss);
+            operatingProfitAndLossTransformer
                     .addPreviousPeriodToWebModel(profitAndLoss, previousPeriodProfitAndLoss);
         }
 
@@ -37,6 +44,7 @@ public class ProfitAndLossTransformerImpl implements ProfitAndLossTransformer {
         ProfitAndLossApi currentPeriodProfitAndLoss = new ProfitAndLossApi();
 
         grossProfitAndLossTransformer.addCurrentPeriodToApiModel(profitAndLoss, currentPeriodProfitAndLoss);
+        operatingProfitAndLossTransformer.addCurrentPeriodToApiModel(profitAndLoss, currentPeriodProfitAndLoss);
 
         return currentPeriodProfitAndLoss;
     }
@@ -47,6 +55,7 @@ public class ProfitAndLossTransformerImpl implements ProfitAndLossTransformer {
         ProfitAndLossApi previousPeriodProfitAndLoss = new ProfitAndLossApi();
 
         grossProfitAndLossTransformer.addPreviousPeriodToApiModel(profitAndLoss, previousPeriodProfitAndLoss);
+        operatingProfitAndLossTransformer.addPreviousPeriodToApiModel(profitAndLoss, previousPeriodProfitAndLoss);
 
         return previousPeriodProfitAndLoss;
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -386,8 +386,8 @@ operatingProfitOrLoss.distributionCosts.previousAmount=Operating profit or loss 
 operatingProfitOrLoss.otherOperatingIncome.currentAmount=Operating profit or loss other operating income current period:
 operatingProfitOrLoss.otherOperatingIncome.previousAmount=Operating profit or loss other operating income previous period:
 
-operatingProfitOrLoss.operatingTotal.currentAmount=Operating profit or loss operating total current period:
-operatingProfitOrLoss.operatingTotal.previousAmount=Operating profit or loss operating total previous period:
+operatingProfitOrLoss.operatingTotal.currentAmount=Operating profit or loss total current period:
+operatingProfitOrLoss.operatingTotal.previousAmount=Operating profit or loss total previous period:
 
 validation.element.missing.cic_statements.report_statements.company_activities_and_impact=Enter the company’s activities and impact
 validation.characters.invalid.cic_statements.report_statements.company_activities_and_impact=Enter valid characters

--- a/src/main/resources/templates/smallfull/profitAndLoss.html
+++ b/src/main/resources/templates/smallfull/profitAndLoss.html
@@ -130,6 +130,120 @@
                             </div>
                         </div>
                     </div>
+
+                    <br>
+
+                    <div th:replace="fragments/fieldErrorRow :: fieldErrorRow (
+                        currentField = 'operatingProfitOrLoss.distributionCosts.currentAmount',
+                        previousField = 'operatingProfitOrLoss.distributionCosts.previousAmount'
+                        )">
+                    </div>
+                    <div class="govuk-grid-row column-flex">
+                        <div class="govuk-grid-column-one-half" id="operatingProfitOrLoss-distributionCosts-subtitle">
+                            Distribution costs
+                        </div>
+                        <div class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.distributionCosts.currentAmount',
+                                text = 'Distribution costs current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
+                                class = 'govuk-input current',
+                                )">
+                            </div>
+                        </div>
+                        <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.distributionCosts.previousAmount',
+                                text = 'Distribution costs previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
+                                class= 'govuk-input previous',
+                                )">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div th:replace="fragments/fieldErrorRow :: fieldErrorRow (
+                        currentField = 'operatingProfitOrLoss.administrativeExpenses.currentAmount',
+                        previousField = 'operatingProfitOrLoss.administrativeExpenses.previousAmount'
+                        )">
+                    </div>
+                    <div class="govuk-grid-row column-flex">
+                        <div class="govuk-grid-column-one-half" id="operatingProfitOrLoss-administrativeExpenses-subtitle">
+                            Administrative expenses
+                        </div>
+
+                        <div class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.administrativeExpenses.currentAmount',
+                                text = 'Administrative expenses current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
+                                class = 'govuk-input current',
+                                )">
+                            </div>
+                        </div>
+                        <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.administrativeExpenses.previousAmount',
+                                text = 'Administrative expenses previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
+                                class= 'govuk-input previous',
+                                )">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div th:replace="fragments/fieldErrorRow :: fieldErrorRow (
+                        currentField = 'operatingProfitOrLoss.otherOperatingIncome.currentAmount',
+                        previousField = 'operatingProfitOrLoss.otherOperatingIncome.previousAmount'
+                        )">
+                    </div>
+                    <div class="govuk-grid-row column-flex">
+                        <div class="govuk-grid-column-one-half" id="operatingProfitOrLoss-otherOperatingIncome-subtitle">
+                            Other operating income
+                        </div>
+
+                        <div class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.otherOperatingIncome.currentAmount',
+                                text = 'Other operating income current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
+                                class = 'govuk-input current',
+                                )">
+                            </div>
+                        </div>
+                        <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.otherOperatingIncome.previousAmount',
+                                text = 'Other operating income previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
+                                class= 'govuk-input previous',
+                                )">
+                            </div>
+                        </div>
+                    </div>
+
+                    <div th:replace="fragments/fieldErrorRow :: fieldErrorRow (
+                        currentField = 'operatingProfitOrLoss.operatingTotal.currentAmount',
+                        previousField = 'operatingProfitOrLoss.operatingTotal.previousAmount'
+                        )">
+                    </div>
+                    <div class="govuk-grid-row column-flex accounts-total">
+                        <div class="govuk-grid-column-one-half">
+                            <strong id="operatingProfitOrLoss-operatingTotal-subtitle">Operating profit (or loss)</strong>
+                        </div>
+
+                        <div class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.operatingTotal.currentAmount',
+                                text = 'Operating profit (or loss) current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
+                                class = 'govuk-input current',
+                                )">
+                            </div>
+                        </div>
+                        <div th:unless="*{#strings.isEmpty(balanceSheetHeadings.previousPeriodHeading)}" class="govuk-grid-column-one-quarter column-flex">
+                            <div th:replace="fragments/numberInput :: numberInput (
+                                id = 'operatingProfitOrLoss.operatingTotal.previousAmount',
+                                text = 'Operating profit (or loss) previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
+                                class= 'govuk-input previous',
+                                )">
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
 
                 <br>

--- a/src/main/resources/templates/smallfull/profitAndLoss.html
+++ b/src/main/resources/templates/smallfull/profitAndLoss.html
@@ -59,7 +59,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.turnover.currentAmount',
                                 text = 'Turnover current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
-                                class = 'govuk-input current',
+                                class = 'govuk-input current validate gross-c-add',
                                 )">
                             </div>
                         </div>
@@ -67,7 +67,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.turnover.previousAmount',
                                 text = 'Turnover previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
-                                class= 'govuk-input previous',
+                                class= 'govuk-input previous validate gross-p-add',
                                 )">
                             </div>
                         </div>
@@ -88,7 +88,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.costOfSales.currentAmount',
                                 text = 'Cost of sales current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
-                                class = 'govuk-input current',
+                                class = 'govuk-input current validate gross-c-subtract',
                                 )">
                             </div>
                         </div>
@@ -96,7 +96,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.costOfSales.previousAmount',
                                 text = 'Cost of sales previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
-                                class= 'govuk-input previous',
+                                class= 'govuk-input previous validate gross-p-subtract',
                                 )">
                             </div>
                         </div>
@@ -117,7 +117,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.grossTotal.currentAmount',
                                 text = 'Gross profit (or loss) current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
-                                class = 'govuk-input current',
+                                class = 'govuk-input current gross-c-total',
                                 )">
                             </div>
                         </div>
@@ -125,7 +125,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.grossTotal.previousAmount',
                                 text = 'Gross profit (or loss) previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
-                                class= 'govuk-input previous',
+                                class= 'govuk-input previous gross-p-total',
                                 )">
                             </div>
                         </div>

--- a/src/main/resources/templates/smallfull/profitAndLoss.html
+++ b/src/main/resources/templates/smallfull/profitAndLoss.html
@@ -59,7 +59,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.turnover.currentAmount',
                                 text = 'Turnover current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
-                                class = 'govuk-input current validate gross-c-add range-from-minus',
+                                class = 'govuk-input current validate range-from-minus gross-c-add',
                                 )">
                             </div>
                         </div>
@@ -67,7 +67,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.turnover.previousAmount',
                                 text = 'Turnover previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
-                                class= 'govuk-input previous validate gross-p-add range-from-minus',
+                                class= 'govuk-input previous validate range-from-minus gross-p-add',
                                 )">
                             </div>
                         </div>
@@ -117,7 +117,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.grossTotal.currentAmount',
                                 text = 'Gross profit (or loss) current '  + *{balanceSheetHeadings.currentPeriodHeading} + ' in £',
-                                class = 'govuk-input current gross-c-total range-from-minus',
+                                class = 'govuk-input current range-from-minus gross-c-total',
                                 )">
                             </div>
                         </div>
@@ -125,7 +125,7 @@
                             <div th:replace="fragments/numberInput :: numberInput (
                                 id = 'grossProfitOrLoss.grossTotal.previousAmount',
                                 text = 'Gross profit (or loss) previous '  + *{balanceSheetHeadings.previousPeriodHeading} + ' in £',
-                                class= 'govuk-input previous gross-p-total range-from-minus',
+                                class= 'govuk-input previous range-from-minus gross-p-total',
                                 )">
                             </div>
                         </div>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/OperatingProfitAndLossTransformerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/OperatingProfitAndLossTransformerTests.java
@@ -193,16 +193,16 @@ public class OperatingProfitAndLossTransformerTests {
                 new uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss();
 
         AdministrativeExpenses administrativeExpenses = new AdministrativeExpenses();
-        administrativeExpenses.setPreviousAmount(CURRENT_ADMINISTRATIVE_EXPENSES);
+        administrativeExpenses.setPreviousAmount(PREVIOUS_ADMINISTRATIVE_EXPENSES);
 
         DistributionCosts distributionCosts = new DistributionCosts();
-        distributionCosts.setPreviousAmount(CURRENT_DISTRIBUTION_COSTS);
+        distributionCosts.setPreviousAmount(PREVIOUS_DISTRIBUTION_COSTS);
 
         OtherOperatingIncome otherOperatingIncome = new OtherOperatingIncome();
-        otherOperatingIncome.setPreviousAmount(CURRENT_OTHER_OPERATING_INCOME);
+        otherOperatingIncome.setPreviousAmount(PREVIOUS_OTHER_OPERATING_INCOME);
 
         OperatingTotal operatingTotal = new OperatingTotal();
-        operatingTotal.setPreviousAmount(CURRENT_OPERATING_TOTAL);
+        operatingTotal.setPreviousAmount(PREVIOUS_OPERATING_TOTAL);
 
         operatingProfitOrLoss.setAdministrativeExpenses(administrativeExpenses);
         operatingProfitOrLoss.setDistributionCosts(distributionCosts);
@@ -213,13 +213,13 @@ public class OperatingProfitAndLossTransformerTests {
 
         transformer.addPreviousPeriodToApiModel(profitAndLoss, previousPeriodProfitAndLoss);
 
-        assertEquals(CURRENT_ADMINISTRATIVE_EXPENSES, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+        assertEquals(PREVIOUS_ADMINISTRATIVE_EXPENSES, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
                 getAdministrativeExpenses());
-        assertEquals(CURRENT_DISTRIBUTION_COSTS, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+        assertEquals(PREVIOUS_DISTRIBUTION_COSTS, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
                 getDistributionCosts());
-        assertEquals(CURRENT_OTHER_OPERATING_INCOME, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+        assertEquals(PREVIOUS_OTHER_OPERATING_INCOME, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
                 getOtherOperatingIncome());
-        assertEquals(CURRENT_OPERATING_TOTAL, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+        assertEquals(PREVIOUS_OPERATING_TOTAL, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
                 getOperatingTotal());
     }
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/OperatingProfitAndLossTransformerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/OperatingProfitAndLossTransformerTests.java
@@ -2,8 +2,7 @@ package uk.gov.companieshouse.web.accounts.transformer.profitandloss;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
-import uk.gov.companieshouse.api.model.accounts.profitandloss.GrossProfitOrLoss;
+
 import uk.gov.companieshouse.api.model.accounts.profitandloss.OperatingProfitOrLoss;
 import uk.gov.companieshouse.api.model.accounts.profitandloss.ProfitAndLossApi;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.ProfitAndLoss;
@@ -11,7 +10,6 @@ import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorl
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.DistributionCosts;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OperatingTotal;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OtherOperatingIncome;
-import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.GrossProfitAndLossTransformer;
 import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.OperatingProfitAndLossTransformer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -19,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class OperatingProfitAndLossTransformerTests {
-
-    private static final Long CURRENT_GROSS_TOTAL = 1L;
 
     private static final Long CURRENT_ADMINISTRATIVE_EXPENSES = 1L;
     private static final Long CURRENT_DISTRIBUTION_COSTS = 1L;
@@ -41,10 +37,8 @@ public class OperatingProfitAndLossTransformerTests {
 
         ProfitAndLossApi currentPeriodProfitAndLossApi = new ProfitAndLossApi();
 
-        GrossProfitOrLoss grossProfitOrLoss = new GrossProfitOrLoss();
         OperatingProfitOrLoss operatingProfitOrLoss = new OperatingProfitOrLoss();
 
-        grossProfitOrLoss.setGrossTotal(CURRENT_GROSS_TOTAL);
         operatingProfitOrLoss.setDistributionCosts(CURRENT_DISTRIBUTION_COSTS);
         operatingProfitOrLoss.setAdministrativeExpenses(CURRENT_ADMINISTRATIVE_EXPENSES);
         operatingProfitOrLoss.setOtherOperatingIncome(CURRENT_OTHER_OPERATING_INCOME);

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/OperatingProfitAndLossTransformerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/OperatingProfitAndLossTransformerTests.java
@@ -1,0 +1,280 @@
+package uk.gov.companieshouse.web.accounts.transformer.profitandloss;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import uk.gov.companieshouse.api.model.accounts.profitandloss.GrossProfitOrLoss;
+import uk.gov.companieshouse.api.model.accounts.profitandloss.OperatingProfitOrLoss;
+import uk.gov.companieshouse.api.model.accounts.profitandloss.ProfitAndLossApi;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.ProfitAndLoss;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.AdministrativeExpenses;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.DistributionCosts;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OperatingTotal;
+import uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.items.OtherOperatingIncome;
+import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.GrossProfitAndLossTransformer;
+import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.OperatingProfitAndLossTransformer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class OperatingProfitAndLossTransformerTests {
+
+    private static final Long CURRENT_GROSS_TOTAL = 1L;
+
+    private static final Long CURRENT_ADMINISTRATIVE_EXPENSES = 1L;
+    private static final Long CURRENT_DISTRIBUTION_COSTS = 1L;
+    private static final Long CURRENT_OTHER_OPERATING_INCOME = 2L;
+    private static final Long CURRENT_OPERATING_TOTAL = 2L;
+
+    private static final Long PREVIOUS_ADMINISTRATIVE_EXPENSES = 10L;
+    private static final Long PREVIOUS_DISTRIBUTION_COSTS = 10L;
+    private static final Long PREVIOUS_OTHER_OPERATING_INCOME = 20L;
+    private static final Long PREVIOUS_OPERATING_TOTAL = 50L;
+
+
+    private OperatingProfitAndLossTransformer transformer = new OperatingProfitAndLossTransformer();
+
+    @Test
+    @DisplayName("Add current period to web model")
+    void addCurrentPeriodToWebModel() {
+
+        ProfitAndLossApi currentPeriodProfitAndLossApi = new ProfitAndLossApi();
+
+        GrossProfitOrLoss grossProfitOrLoss = new GrossProfitOrLoss();
+        OperatingProfitOrLoss operatingProfitOrLoss = new OperatingProfitOrLoss();
+
+        grossProfitOrLoss.setGrossTotal(CURRENT_GROSS_TOTAL);
+        operatingProfitOrLoss.setDistributionCosts(CURRENT_DISTRIBUTION_COSTS);
+        operatingProfitOrLoss.setAdministrativeExpenses(CURRENT_ADMINISTRATIVE_EXPENSES);
+        operatingProfitOrLoss.setOtherOperatingIncome(CURRENT_OTHER_OPERATING_INCOME);
+        operatingProfitOrLoss.setOperatingTotal(CURRENT_OPERATING_TOTAL);
+
+        currentPeriodProfitAndLossApi.setOperatingProfitOrLoss(operatingProfitOrLoss);
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        transformer.addCurrentPeriodToWebModel(profitAndLoss, currentPeriodProfitAndLossApi);
+
+        assertNotNull(profitAndLoss.getOperatingProfitOrLoss());
+
+        assertEquals(CURRENT_ADMINISTRATIVE_EXPENSES, profitAndLoss.getOperatingProfitOrLoss().
+                getAdministrativeExpenses().getCurrentAmount());
+        assertEquals(CURRENT_DISTRIBUTION_COSTS, profitAndLoss.getOperatingProfitOrLoss().
+                getDistributionCosts().getCurrentAmount());
+        assertEquals(CURRENT_OTHER_OPERATING_INCOME, profitAndLoss.getOperatingProfitOrLoss().
+                getOtherOperatingIncome().getCurrentAmount());
+        assertEquals(CURRENT_OPERATING_TOTAL, profitAndLoss.getOperatingProfitOrLoss().
+                getOperatingTotal().getCurrentAmount());
+
+    }
+
+    @Test
+    @DisplayName("Add previous period to web models which has current period values")
+    void addPreviousPeriodToWebModelWhichHasCurrentPeriodValues() {
+
+        ProfitAndLossApi previousPeriodProfitAndLossApi = new ProfitAndLossApi();
+
+        OperatingProfitOrLoss operatingProfitOrLoss = new OperatingProfitOrLoss();
+        operatingProfitOrLoss.setAdministrativeExpenses(PREVIOUS_ADMINISTRATIVE_EXPENSES);
+        operatingProfitOrLoss.setDistributionCosts(PREVIOUS_DISTRIBUTION_COSTS);
+        operatingProfitOrLoss.setOtherOperatingIncome(PREVIOUS_OTHER_OPERATING_INCOME);
+        operatingProfitOrLoss.setOperatingTotal(PREVIOUS_OPERATING_TOTAL);
+
+        previousPeriodProfitAndLossApi.setOperatingProfitOrLoss(operatingProfitOrLoss);
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss
+                operatingProfitOrLossWeb =
+                new uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss();
+
+        AdministrativeExpenses administrativeExpenses = new AdministrativeExpenses();
+        administrativeExpenses.setCurrentAmount(CURRENT_ADMINISTRATIVE_EXPENSES);
+
+        DistributionCosts distributionCosts = new DistributionCosts();
+        distributionCosts.setCurrentAmount(CURRENT_DISTRIBUTION_COSTS);
+
+        OtherOperatingIncome otherOperatingIncome = new OtherOperatingIncome();
+        otherOperatingIncome.setCurrentAmount(CURRENT_OTHER_OPERATING_INCOME);
+
+        OperatingTotal operatingTotal = new OperatingTotal();
+        operatingTotal.setCurrentAmount(CURRENT_OPERATING_TOTAL);
+
+        operatingProfitOrLossWeb.setAdministrativeExpenses(administrativeExpenses);
+        operatingProfitOrLossWeb.setDistributionCosts(distributionCosts);
+        operatingProfitOrLossWeb.setOtherOperatingIncome(otherOperatingIncome);
+        operatingProfitOrLossWeb.setOperatingTotal(operatingTotal);
+
+        profitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLossWeb);
+
+        transformer.addPreviousPeriodToWebModel(profitAndLoss, previousPeriodProfitAndLossApi);
+
+        assertEquals(CURRENT_ADMINISTRATIVE_EXPENSES, profitAndLoss.getOperatingProfitOrLoss().
+                getAdministrativeExpenses().getCurrentAmount());
+        assertEquals(CURRENT_DISTRIBUTION_COSTS, profitAndLoss.getOperatingProfitOrLoss().
+                getDistributionCosts().getCurrentAmount());
+        assertEquals(CURRENT_OTHER_OPERATING_INCOME, profitAndLoss.getOperatingProfitOrLoss().
+                getOtherOperatingIncome().getCurrentAmount());
+        assertEquals(CURRENT_OPERATING_TOTAL, profitAndLoss.getOperatingProfitOrLoss().
+                getOtherOperatingIncome().getCurrentAmount());
+
+    }
+
+
+    @Test
+    @DisplayName("Add current period to web model - no operating profit or loss")
+    void addCurrentPeriodToWebModelNoOperatingProfitOrLoss() {
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        transformer.addCurrentPeriodToWebModel(profitAndLoss, new ProfitAndLossApi());
+
+        assertNull(profitAndLoss.getOperatingProfitOrLoss());
+    }
+
+    @Test
+    @DisplayName("Add previous period to web model - no operating profit or loss")
+    void addPreviousPeriodToWebModelNoOperatingProfitOrLoss() {
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        transformer.addPreviousPeriodToWebModel(profitAndLoss, new ProfitAndLossApi());
+
+        assertNull(profitAndLoss.getOperatingProfitOrLoss());
+    }
+
+    @Test
+    @DisplayName("Add current period to api model")
+    void addCurrentPeriodToApiModel() {
+
+        ProfitAndLossApi currentPeriodProfitAndLoss = new ProfitAndLossApi();
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss
+                operatingProfitOrLoss =
+                new uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss();
+
+        AdministrativeExpenses administrativeExpenses = new AdministrativeExpenses();
+        administrativeExpenses.setCurrentAmount(CURRENT_ADMINISTRATIVE_EXPENSES);
+
+        DistributionCosts distributionCosts = new DistributionCosts();
+        distributionCosts.setCurrentAmount(CURRENT_DISTRIBUTION_COSTS);
+
+        OtherOperatingIncome otherOperatingIncome = new OtherOperatingIncome();
+        otherOperatingIncome.setCurrentAmount(CURRENT_OTHER_OPERATING_INCOME);
+
+        OperatingTotal operatingTotal = new OperatingTotal();
+        operatingTotal.setCurrentAmount(CURRENT_OPERATING_TOTAL);
+
+        operatingProfitOrLoss.setAdministrativeExpenses(administrativeExpenses);
+        operatingProfitOrLoss.setDistributionCosts(distributionCosts);
+        operatingProfitOrLoss.setOtherOperatingIncome(otherOperatingIncome);
+        operatingProfitOrLoss.setOperatingTotal(operatingTotal);
+
+        profitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLoss);
+
+        transformer.addCurrentPeriodToApiModel(profitAndLoss, currentPeriodProfitAndLoss);
+
+        assertEquals(CURRENT_ADMINISTRATIVE_EXPENSES, currentPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getAdministrativeExpenses());
+        assertEquals(CURRENT_DISTRIBUTION_COSTS, currentPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getDistributionCosts());
+        assertEquals(CURRENT_OTHER_OPERATING_INCOME, currentPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getOtherOperatingIncome());
+        assertEquals(CURRENT_OPERATING_TOTAL, currentPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getOperatingTotal());
+    }
+
+    @Test
+    @DisplayName("Add previous period to api model")
+    void addPreviousPeriodToApiModel() {
+
+        ProfitAndLossApi previousPeriodProfitAndLoss = new ProfitAndLossApi();
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss
+                operatingProfitOrLoss =
+                new uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss();
+
+        AdministrativeExpenses administrativeExpenses = new AdministrativeExpenses();
+        administrativeExpenses.setPreviousAmount(CURRENT_ADMINISTRATIVE_EXPENSES);
+
+        DistributionCosts distributionCosts = new DistributionCosts();
+        distributionCosts.setPreviousAmount(CURRENT_DISTRIBUTION_COSTS);
+
+        OtherOperatingIncome otherOperatingIncome = new OtherOperatingIncome();
+        otherOperatingIncome.setPreviousAmount(CURRENT_OTHER_OPERATING_INCOME);
+
+        OperatingTotal operatingTotal = new OperatingTotal();
+        operatingTotal.setPreviousAmount(CURRENT_OPERATING_TOTAL);
+
+        operatingProfitOrLoss.setAdministrativeExpenses(administrativeExpenses);
+        operatingProfitOrLoss.setDistributionCosts(distributionCosts);
+        operatingProfitOrLoss.setOtherOperatingIncome(otherOperatingIncome);
+        operatingProfitOrLoss.setOperatingTotal(operatingTotal);
+
+        profitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLoss);
+
+        transformer.addPreviousPeriodToApiModel(profitAndLoss, previousPeriodProfitAndLoss);
+
+        assertEquals(CURRENT_ADMINISTRATIVE_EXPENSES, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getAdministrativeExpenses());
+        assertEquals(CURRENT_DISTRIBUTION_COSTS, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getDistributionCosts());
+        assertEquals(CURRENT_OTHER_OPERATING_INCOME, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getOtherOperatingIncome());
+        assertEquals(CURRENT_OPERATING_TOTAL, previousPeriodProfitAndLoss.getOperatingProfitOrLoss().
+                getOperatingTotal());
+    }
+
+    @Test
+    @DisplayName("Add current period to api model without operating profit and loss to map")
+    void addCurrentPeriodToApiModelWithoutOperatingProfitAndLossToMap() {
+
+        ProfitAndLossApi currentPeriodProfitAndLoss = new ProfitAndLossApi();
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss
+                operatingProfitOrLossWeb =
+                new uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss();
+
+        operatingProfitOrLossWeb.setAdministrativeExpenses(new AdministrativeExpenses());
+        operatingProfitOrLossWeb.setDistributionCosts(new DistributionCosts());
+        operatingProfitOrLossWeb.setOtherOperatingIncome(new OtherOperatingIncome());
+        operatingProfitOrLossWeb.setOperatingTotal(new OperatingTotal());
+
+        profitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLossWeb);
+
+        transformer.addPreviousPeriodToApiModel(profitAndLoss, currentPeriodProfitAndLoss);
+
+        assertNull(currentPeriodProfitAndLoss.getOperatingProfitOrLoss());
+    }
+
+    @Test
+    @DisplayName("Add previous period to api model without operating profit and loss to map")
+    void addPreviousPeriodToApiModelWithoutOperatingProfitAndLossToMap() {
+
+        ProfitAndLossApi previousPeriodProfitAndLoss = new ProfitAndLossApi();
+
+        ProfitAndLoss profitAndLoss = new ProfitAndLoss();
+
+        uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss
+                operatingProfitOrLossWeb =
+                new uk.gov.companieshouse.web.accounts.model.profitandloss.operatingprofitorloss.OperatingProfitOrLoss();
+
+        operatingProfitOrLossWeb.setAdministrativeExpenses(new AdministrativeExpenses());
+        operatingProfitOrLossWeb.setDistributionCosts(new DistributionCosts());
+        operatingProfitOrLossWeb.setOtherOperatingIncome(new OtherOperatingIncome());
+        operatingProfitOrLossWeb.setOperatingTotal(new OperatingTotal());
+
+        profitAndLoss.setOperatingProfitOrLoss(operatingProfitOrLossWeb);
+
+        transformer.addPreviousPeriodToApiModel(profitAndLoss, previousPeriodProfitAndLoss);
+
+        assertNull(previousPeriodProfitAndLoss.getOperatingProfitOrLoss());
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/ProfitAndLossTransformerImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/transformer/profitandloss/ProfitAndLossTransformerImplTests.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.accounts.profitandloss.ProfitAndLossApi;
 import uk.gov.companieshouse.web.accounts.model.profitandloss.ProfitAndLoss;
 import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.GrossProfitAndLossTransformer;
+import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.OperatingProfitAndLossTransformer;
 import uk.gov.companieshouse.web.accounts.transformer.profitandloss.impl.ProfitAndLossTransformerImpl;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +25,9 @@ public class ProfitAndLossTransformerImplTests {
 
     @Mock
     private GrossProfitAndLossTransformer grossProfitAndLossTransformer;
+
+    @Mock
+    OperatingProfitAndLossTransformer operatingProfitAndLossTransformer;
 
     @InjectMocks
     private ProfitAndLossTransformer transformer = new ProfitAndLossTransformerImpl();
@@ -41,6 +45,11 @@ public class ProfitAndLossTransformerImplTests {
                 .addCurrentPeriodToWebModel(any(ProfitAndLoss.class), eq(currentPeriodProfitAndLoss));
         verify(grossProfitAndLossTransformer)
                 .addPreviousPeriodToWebModel(any(ProfitAndLoss.class), eq(previousPeriodProfitAndLoss));
+
+        verify(operatingProfitAndLossTransformer)
+                .addCurrentPeriodToWebModel(any(ProfitAndLoss.class), eq(currentPeriodProfitAndLoss));
+        verify(operatingProfitAndLossTransformer)
+                .addPreviousPeriodToWebModel(any(ProfitAndLoss.class), eq(previousPeriodProfitAndLoss));
     }
 
     @Test
@@ -53,6 +62,11 @@ public class ProfitAndLossTransformerImplTests {
                 .addCurrentPeriodToWebModel(any(ProfitAndLoss.class), any(ProfitAndLossApi.class));
         verify(grossProfitAndLossTransformer, never())
                 .addPreviousPeriodToWebModel(any(ProfitAndLoss.class), any(ProfitAndLossApi.class));
+
+        verify(operatingProfitAndLossTransformer, never())
+                .addCurrentPeriodToWebModel(any(ProfitAndLoss.class), any(ProfitAndLossApi.class));
+        verify(operatingProfitAndLossTransformer, never())
+                .addPreviousPeriodToWebModel(any(ProfitAndLoss.class), any(ProfitAndLossApi.class));
     }
 
     @Test
@@ -64,6 +78,7 @@ public class ProfitAndLossTransformerImplTests {
         assertNotNull(transformer.getCurrentPeriodProfitAndLoss(profitAndLoss));
 
         verify(grossProfitAndLossTransformer).addCurrentPeriodToApiModel(eq(profitAndLoss), any(ProfitAndLossApi.class));
+        verify(operatingProfitAndLossTransformer).addCurrentPeriodToApiModel(eq(profitAndLoss), any(ProfitAndLossApi.class));
     }
 
     @Test
@@ -75,6 +90,7 @@ public class ProfitAndLossTransformerImplTests {
         assertNotNull(transformer.getPreviousPeriodProfitAndLoss(profitAndLoss));
 
         verify(grossProfitAndLossTransformer).addPreviousPeriodToApiModel(eq(profitAndLoss), any(ProfitAndLossApi.class));
+        verify(operatingProfitAndLossTransformer).addPreviousPeriodToApiModel(eq(profitAndLoss), any(ProfitAndLossApi.class));
     }
 }
 


### PR DESCRIPTION
Creation of Operating Profit Or Loss section of Profit and Loss.
Includes addition to HTML page and P&L transformer.
Resolves:
SFA-1944 Company accounts Web