### PR TITLE
Fix validator NPE when `DirectorToAdd` is null

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/validation/smallfull/DirectorValidator.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/validation/smallfull/DirectorValidator.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.web.accounts.validation.smallfull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.web.accounts.model.directorsreport.AddOrRemoveDirectors;
@@ -59,7 +60,10 @@ public class DirectorValidator {
 
         List<ValidationError> validationErrors = new ArrayList<>();
 
-        if (StringUtils.isNotBlank(addOrRemoveDirectors.getDirectorToAdd().getName())) {
+        if (StringUtils.isNotBlank(Optional.ofNullable(addOrRemoveDirectors)
+                                    .map(AddOrRemoveDirectors::getDirectorToAdd)
+                                    .map(DirectorToAdd::getName)
+                                    .orElse(null))) {
 
             ValidationError error = new ValidationError();
             error.setFieldPath(DIRECTOR_TO_ADD);

--- a/src/main/resources/templates/smallfull/directorsReportReview.html
+++ b/src/main/resources/templates/smallfull/directorsReportReview.html
@@ -31,8 +31,8 @@
         </h2>
 
         <dl class="app-check-your-answers app-check-your-answers--very-long">
-          <div th:each="director : *{directors}" class="app-check-your-answers__contents">
-            <dt class="app-check-your-answers__question">
+          <div th:each="director, stat : *{directors}" class="app-check-your-answers__contents">
+            <dt class="app-check-your-answers__question" th:id="'director-' + ${stat}">
               <span th:text="${director.name}"></span>
               <span th:if="${director.appointmentDate != null and director.resignationDate == null}"
                     th:text="${'(appointed __${#temporals.format(director.appointmentDate, 'd MMM yyyy')}__)'}"
@@ -44,7 +44,7 @@
                     th:text="${'(appointed __${#temporals.format(director.appointmentDate, 'd MMM yyyy')}__, resigned __${#temporals.format(director.resignationDate, 'd MMM yyyy')}__)'}"
                     class="govuk-body govuk-!-font-weight-regular"></span>
             </dt>
-            <dd class="app-check-your-answers__change" id="directors-report-director-answer">&nbsp;</dd>
+            <dd class="app-check-your-answers__change">&nbsp;</dd>
           </div>
 
         </dl>
@@ -63,8 +63,8 @@
 
           <dl class="app-check-your-answers app-check-your-answers--very-long">
             <div class="app-check-your-answers__contents">
-              <dt th:text="*{secretary}" class="app-check-your-answers__question"></dt>
-              <dd class="app-check-your-answers__change" id="directors-report-secretary-answer">&nbsp;</dd>
+              <dt th:text="*{secretary}" class="app-check-your-answers__question" id="secretary"></dt>
+              <dd class="app-check-your-answers__change">&nbsp;</dd>
             </div>
 
           </dl>

--- a/src/main/resources/templates/smallfull/directorsReportReview.html
+++ b/src/main/resources/templates/smallfull/directorsReportReview.html
@@ -32,8 +32,8 @@
 
         <dl class="app-check-your-answers app-check-your-answers--very-long">
           <div th:each="director, stat : *{directors}" class="app-check-your-answers__contents">
-            <dt class="app-check-your-answers__question" th:id="'director-' + ${stat.index}">
-              <span th:text="${director.name}"></span>
+            <dt class="app-check-your-answers__question">
+              <span th:text="${director.name}" th:id="'director-' + ${stat.index}"></span>
               <span th:if="${director.appointmentDate != null and director.resignationDate == null}"
                     th:text="${'(appointed __${#temporals.format(director.appointmentDate, 'd MMM yyyy')}__)'}"
                     class="govuk-body govuk-!-font-weight-regular"></span>

--- a/src/main/resources/templates/smallfull/directorsReportReview.html
+++ b/src/main/resources/templates/smallfull/directorsReportReview.html
@@ -32,7 +32,7 @@
 
         <dl class="app-check-your-answers app-check-your-answers--very-long">
           <div th:each="director, stat : *{directors}" class="app-check-your-answers__contents">
-            <dt class="app-check-your-answers__question" th:id="'director-' + ${stat}">
+            <dt class="app-check-your-answers__question" th:id="'director-' + ${stat.index}">
               <span th:text="${director.name}"></span>
               <span th:if="${director.appointmentDate != null and director.resignationDate == null}"
                     th:text="${'(appointed __${#temporals.format(director.appointmentDate, 'd MMM yyyy')}__)'}"


### PR DESCRIPTION
When 20 directors exist, the `DirectorToAdd` model within `AddOrRemoveDirectors` is not bound to its template, and is thus `null`. This fix uses an `Optional#map` to avoid encountering the NPE.