### PR TITLE
Move minus sign for negative numbers on Check Your Answers page

### DIFF
--- a/src/main/resources/templates/fragments/review/balanceSheetValueRow.html
+++ b/src/main/resources/templates/fragments/review/balanceSheetValueRow.html
@@ -10,16 +10,16 @@
             <dd class="app-check-your-answers__answer" th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
                 <span class="mobile-only-label" th:text="*{balanceSheet.balanceSheetHeadings.currentPeriodHeading + ':'}"></span>
 
-                <span th:id="${identifier != null} ? 'review-' + ${identifier} + '-current-amount' : null" th:if="${isEmployees==true}" th:text="${currentAmount != null ? #numbers.formatInteger(currentAmount, 0, 'COMMA') : ''}"></span>
-                <span th:id="${identifier != null} ? 'review-' + ${identifier} + '-current-amount' : null" th:unless="${isEmployees==true}" th:text="${currentAmount != null ? '£' + #numbers.formatInteger(currentAmount, 0, 'COMMA') : ''}"></span>
+                <span th:id="${identifier != null} ? 'review-' + ${identifier} + '-current-amount' : null" th:if="${isEmployees==true}" th:text="${currentAmount != null ? new java.text.DecimalFormat('£#0;-£#0').format(currentAmount) : ''}"></span>
+                <span th:id="${identifier != null} ? 'review-' + ${identifier} + '-current-amount' : null" th:unless="${isEmployees==true}" th:text="${currentAmount != null ? new java.text.DecimalFormat('£#0;-£#0').format(currentAmount) : ''}"></span>
 
             </dd>
             <dd class="app-check-your-answers__answer" th:classappend="${isTotalRow} ? 'govuk-!-font-weight-bold' : ''">
                 <span class="mobile-only-label" th:text="${previousAmount != null} ? *{balanceSheet.balanceSheetHeadings.previousPeriodHeading + ':'} : ''"></span>
               <span th:id="${identifier != null} ? 'review-' + ${identifier} + '-previous-amount' : null"
-                    th:if="${isEmployees==true}" th:text="${previousAmount != null ? #numbers.formatInteger(previousAmount, 0, 'COMMA') : ''}"></span>
+                    th:if="${isEmployees==true}" th:text="${previousAmount != null ? new java.text.DecimalFormat('£#0;-£#0').format(previousAmount) : ''}"></span>
               <span th:id="${identifier != null} ? 'review-' + ${identifier} + '-previous-amount' : null"
-                    th:unless="${isEmployees==true}" th:text="${previousAmount != null ? '£' + #numbers.formatInteger(previousAmount, 0, 'COMMA') : ''}"></span>
+                    th:unless="${isEmployees==true}" th:text="${previousAmount != null ? new java.text.DecimalFormat('£#0;-£#0').format(previousAmount) : ''}"></span>
             </dd>
 
             <dd class="app-check-your-answers__change"></dd>


### PR DESCRIPTION
Moves the minus sign to BEFORE the currency symbol on the company accounts check your answers page.
Resolves:
SFA-3094