### PR TITLE
Address NPE's

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteController.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.web.accounts.controller.smallfull;
 import java.util.ArrayList;
 import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.PreviousPeriodApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
@@ -108,8 +110,8 @@ public class StepsToCompleteController extends BaseController {
 
             ApiClient apiClient = apiClientService.getApiClient();
 
-            SmallFullApi smallFull = smallFullService.getSmallFullAccounts(apiClient, transactionID, companyAccountsID);
-            if (smallFull == null) {
+            CompanyAccountsApi companyAccountsApi = companyAccountsService.getCompanyAccounts(transactionID, companyAccountsID);
+            if (StringUtils.isBlank(companyAccountsApi.getLinks().getSmallFullAccounts())) {
                 smallFullService.createSmallFullAccounts(transactionID, companyAccountsID);
             }
 
@@ -136,7 +138,7 @@ public class StepsToCompleteController extends BaseController {
 
         SmallFullApi smallFull = smallFullService.getSmallFullAccounts(apiClient, transactionId, companyAccountsId);
 
-        if (currentPeriodService.getCurrentPeriod(apiClient, transactionId, companyAccountsId) == null) {
+        if (StringUtils.isBlank(smallFull.getLinks().getCurrentPeriod())) {
 
             currentPeriodService
                     .submitCurrentPeriod(apiClient, smallFull, transactionId, companyAccountsId,
@@ -145,7 +147,7 @@ public class StepsToCompleteController extends BaseController {
 
         CompanyProfileApi companyProfile = companyService.getCompanyProfile(companyNumber);
         if (companyService.isMultiYearFiler(companyProfile) &&
-            previousPeriodService.getPreviousPeriod(apiClient, transactionId, companyAccountsId) == null) {
+                StringUtils.isBlank(smallFull.getLinks().getPreviousPeriod())) {
 
             previousPeriodService
                     .submitPreviousPeriod(apiClient, smallFull, transactionId,

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/CompanyAccountsService.java
@@ -1,8 +1,11 @@
 package uk.gov.companieshouse.web.accounts.service.companyaccounts;
 
+import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 
 public interface CompanyAccountsService {
 
     String createCompanyAccounts(String transactionId) throws ServiceException;
+
+    CompanyAccountsApi getCompanyAccounts(String transactionId, String companyAccountsId) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImpl.java
@@ -24,6 +24,9 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
     private static final UriTemplate CREATE_COMPANY_ACCOUNTS_URI =
             new UriTemplate("/transactions/{transactionId}/company-accounts");
 
+    private static final UriTemplate GET_COMPANY_ACCOUNTS_URI =
+            new UriTemplate("/transactions/{transactionId}/company-accounts/{companyAccountsId}");
+
     @Override
     public String createCompanyAccounts(String transactionId) throws ServiceException {
 
@@ -49,5 +52,24 @@ public class CompanyAccountsServiceImpl implements CompanyAccountsService {
         matcher.find();
 
         return matcher.group(1);
+    }
+
+    @Override
+    public CompanyAccountsApi getCompanyAccounts(String transactionId, String companyAccountsId)
+            throws ServiceException {
+
+        ApiClient apiClient = apiClientService.getApiClient();
+
+        String uri = GET_COMPANY_ACCOUNTS_URI.expand(transactionId, companyAccountsId).toString();
+
+        try {
+            return apiClient.companyAccounts().get(uri).execute().getData();
+        } catch (ApiErrorResponseException e) {
+
+            throw new ServiceException("Error retrieving company accounts", e);
+        } catch (URIValidationException e) {
+
+            throw new ServiceException("Invalid URI for company accounts resource", e);
+        }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CurrentPeriodServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CurrentPeriodServiceImpl.java
@@ -40,12 +40,10 @@ public class CurrentPeriodServiceImpl implements CurrentPeriodService {
                     .get(CURRENT_PERIOD_URI.expand(transactionId, companyAccountsId).toString())
                             .execute().getData();
         } catch (ApiErrorResponseException e) {
-            serviceExceptionHandler.handleRetrievalException(e, CURRENT_PERIOD_RESOURCE);
+            throw new ServiceException("Error retrieving resource: " + CURRENT_PERIOD_RESOURCE, e);
         } catch (URIValidationException e) {
-            serviceExceptionHandler.handleURIValidationException(e, CURRENT_PERIOD_RESOURCE);
+            throw new ServiceException("Invalid URI for resource: " + CURRENT_PERIOD_RESOURCE, e);
         }
-
-        return null;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/PreviousPeriodServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/PreviousPeriodServiceImpl.java
@@ -40,12 +40,10 @@ public class PreviousPeriodServiceImpl implements PreviousPeriodService {
                     .get(PREVIOUS_PERIOD_URI.expand(transactionId, companyAccountsId).toString())
                             .execute().getData();
         } catch (ApiErrorResponseException e) {
-            serviceExceptionHandler.handleRetrievalException(e, PREVIOUS_PERIOD_RESOURCE);
+            throw new ServiceException("Error retrieving resource: " + PREVIOUS_PERIOD_RESOURCE, e);
         } catch (URIValidationException e) {
-            serviceExceptionHandler.handleURIValidationException(e, PREVIOUS_PERIOD_RESOURCE);
+            throw new ServiceException("Invalid URI for resource: " + PREVIOUS_PERIOD_RESOURCE, e);
         }
-
-        return null;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/SmallFullServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/SmallFullServiceImpl.java
@@ -54,9 +54,6 @@ public class SmallFullServiceImpl implements SmallFullService {
             return apiClient.smallFull().get(uri).execute().getData();
         } catch (ApiErrorResponseException e) {
 
-            if (e.getStatusCode() == 404) {
-                return null;
-            }
             throw new ServiceException("Error retrieving small full accounts", e);
         } catch (URIValidationException e) {
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/StepsToCompleteControllerTests.java
@@ -29,9 +29,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
+import uk.gov.companieshouse.api.model.accounts.CompanyAccountsLinks;
 import uk.gov.companieshouse.api.model.accounts.smallfull.CurrentPeriodApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.PreviousPeriodApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
+import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullLinks;
 import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
@@ -61,7 +64,16 @@ public class StepsToCompleteControllerTests {
     private SmallFullService smallFullService;
 
     @Mock
+    private CompanyAccountsApi companyAccountsApi;
+
+    @Mock
+    private CompanyAccountsLinks companyAccountsLinks;
+
+    @Mock
     private SmallFullApi smallFull;
+
+    @Mock
+    private SmallFullLinks smallFullLinks;
 
     @Mock
     private StatementsService statementsService;
@@ -112,6 +124,10 @@ public class StepsToCompleteControllerTests {
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
 
+    private static final String SMALL_FULL_LINK = "smallFullLink";
+
+    private static final String CURRENT_PERIOD_LINK = "currentPeriodLink";
+
     @BeforeEach
     private void setup() {
 
@@ -139,6 +155,10 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
+        when(companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(companyAccountsApi);
+
+        when(companyAccountsApi.getLinks()).thenReturn(companyAccountsLinks);
+
         when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         doNothing().when(statementsService).createBalanceSheetStatementsResource(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
@@ -146,6 +166,8 @@ public class StepsToCompleteControllerTests {
         when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(smallFull);
+
+        when(smallFull.getLinks()).thenReturn(smallFullLinks);
 
         when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
 
@@ -176,6 +198,10 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
+        when(companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(companyAccountsApi);
+
+        when(companyAccountsApi.getLinks()).thenReturn(companyAccountsLinks);
+
         when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
@@ -187,6 +213,8 @@ public class StepsToCompleteControllerTests {
         when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(smallFull);
+
+        when(smallFull.getLinks()).thenReturn(smallFullLinks);
 
         when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfile);
 
@@ -217,11 +245,21 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
+        when(companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(companyAccountsApi);
+
+        when(companyAccountsApi.getLinks()).thenReturn(companyAccountsLinks);
+
+        when(companyAccountsLinks.getSmallFullAccounts()).thenReturn(SMALL_FULL_LINK);
+
         when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(smallFull);
+
+        when(smallFull.getLinks()).thenReturn(smallFullLinks);
+
+        when(smallFullLinks.getCurrentPeriod()).thenReturn(CURRENT_PERIOD_LINK);
 
         when(statementsService.getBalanceSheetStatements(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(statements);
 
@@ -236,6 +274,9 @@ public class StepsToCompleteControllerTests {
         verify(smallFullService, never()).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         verify(statementsService, never()).createBalanceSheetStatementsResource(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        verify(currentPeriodService, never()).submitCurrentPeriod(eq(apiClient), eq(smallFull), eq(TRANSACTION_ID), eq(COMPANY_ACCOUNTS_ID), any(
+                CurrentPeriodApi.class), anyList());
     }
 
     @Test
@@ -272,9 +313,11 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
-        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(companyAccountsApi);
 
-        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(null);
+        when(companyAccountsApi.getLinks()).thenReturn(companyAccountsLinks);
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         doThrow(ServiceException.class)
                 .when(smallFullService).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
@@ -292,9 +335,11 @@ public class StepsToCompleteControllerTests {
 
         when(companyAccountsService.createCompanyAccounts(TRANSACTION_ID)).thenReturn(COMPANY_ACCOUNTS_ID);
 
-        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(companyAccountsApi);
 
-        when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(null);
+        when(companyAccountsApi.getLinks()).thenReturn(companyAccountsLinks);
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
 
         doNothing().when(smallFullService).createSmallFullAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/companyaccounts/impl/CompanyAccountsServiceImplTests.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.accounts.service.companyaccounts.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -18,6 +19,7 @@ import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.companyaccount.CompanyAccountsResourceHandler;
 import uk.gov.companieshouse.api.handler.companyaccount.request.CompanyAccountsCreate;
+import uk.gov.companieshouse.api.handler.companyaccount.request.CompanyAccountsGet;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.accounts.CompanyAccountsApi;
@@ -41,6 +43,12 @@ public class CompanyAccountsServiceImplTests {
 
     @Mock
     private CompanyAccountsCreate companyAccountsCreate;
+    
+    @Mock
+    private CompanyAccountsGet companyAccountsGet;
+
+    @Mock
+    private CompanyAccountsApi companyAccountsApi;
 
     @Mock
     private ApiResponse<CompanyAccountsApi> responseWithData;
@@ -112,5 +120,48 @@ public class CompanyAccountsServiceImplTests {
 
         assertThrows(ServiceException.class, () ->
                 companyAccountsService.createCompanyAccounts(TRANSACTION_ID));
+    }
+
+    @Test
+    @DisplayName("Get company accounts - success")
+    void getCompanyAccountsSuccess() throws ServiceException, ApiErrorResponseException, URIValidationException {
+
+        when(apiClient.companyAccounts()).thenReturn(companyAccountsResourceHandler);
+
+        when(companyAccountsResourceHandler.get(anyString())).thenReturn(companyAccountsGet);
+        when(companyAccountsGet.execute()).thenReturn(responseWithData);
+        when(responseWithData.getData()).thenReturn(companyAccountsApi);
+
+        CompanyAccountsApi returnedCompanyAccounts =
+                companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        assertNotNull(returnedCompanyAccounts);
+        assertEquals(companyAccountsApi, returnedCompanyAccounts);
+    }
+
+    @Test
+    @DisplayName("Get company accounts - api error response exception")
+    void getCompanyAccountsApiErrorResponseException() throws ApiErrorResponseException, URIValidationException {
+
+        when(apiClient.companyAccounts()).thenReturn(companyAccountsResourceHandler);
+
+        when(companyAccountsResourceHandler.get(anyString())).thenReturn(companyAccountsGet);
+        when(companyAccountsGet.execute()).thenThrow(ApiErrorResponseException.class);
+
+        assertThrows(ServiceException.class,
+                () -> companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+    }
+
+    @Test
+    @DisplayName("Get company accounts - uri validation exception")
+    void getCompanyAccountsURIValidationException() throws ApiErrorResponseException, URIValidationException {
+
+        when(apiClient.companyAccounts()).thenReturn(companyAccountsResourceHandler);
+
+        when(companyAccountsResourceHandler.get(anyString())).thenReturn(companyAccountsGet);
+        when(companyAccountsGet.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(ServiceException.class,
+                () -> companyAccountsService.getCompanyAccounts(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CurrentPeriodServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/CurrentPeriodServiceImplTests.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -139,29 +137,11 @@ public class CurrentPeriodServiceImplTests {
     }
 
     @Test
-    @DisplayName("Get current period - not found")
-    void getCurrentPeriodNotFound() throws ServiceException, ApiErrorResponseException, URIValidationException {
-
-        when(currentPeriodResourceHandler.get(CURRENT_PERIOD_URI)).thenReturn(currentPeriodGet);
-        when(currentPeriodGet.execute()).thenThrow(apiErrorResponseException);
-
-        doNothing()
-                .when(serviceExceptionHandler)
-                        .handleRetrievalException(apiErrorResponseException, CURRENT_PERIOD_RESOURCE);
-
-        assertNull(currentPeriodService.getCurrentPeriod(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
-    }
-
-    @Test
     @DisplayName("Get current period - api error response exception")
-    void getCurrentPeriodApiErrorResponseException() throws ServiceException, ApiErrorResponseException, URIValidationException {
+    void getCurrentPeriodApiErrorResponseException() throws ApiErrorResponseException, URIValidationException {
 
         when(currentPeriodResourceHandler.get(CURRENT_PERIOD_URI)).thenReturn(currentPeriodGet);
         when(currentPeriodGet.execute()).thenThrow(apiErrorResponseException);
-
-        doThrow(serviceException)
-                .when(serviceExceptionHandler)
-                        .handleRetrievalException(apiErrorResponseException, CURRENT_PERIOD_RESOURCE);
 
         assertThrows(ServiceException.class,
                 () -> currentPeriodService.getCurrentPeriod(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
@@ -169,14 +149,10 @@ public class CurrentPeriodServiceImplTests {
 
     @Test
     @DisplayName("Get current period - uri validation exception")
-    void getCurrentPeriodURIValidationException() throws ServiceException, ApiErrorResponseException, URIValidationException {
+    void getCurrentPeriodURIValidationException() throws ApiErrorResponseException, URIValidationException {
 
         when(currentPeriodResourceHandler.get(CURRENT_PERIOD_URI)).thenReturn(currentPeriodGet);
         when(currentPeriodGet.execute()).thenThrow(uriValidationException);
-
-        doThrow(serviceException)
-                .when(serviceExceptionHandler)
-                        .handleURIValidationException(uriValidationException, CURRENT_PERIOD_RESOURCE);
 
         assertThrows(ServiceException.class,
                 () -> currentPeriodService.getCurrentPeriod(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/PreviousPeriodServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/PreviousPeriodServiceImplTests.java
@@ -3,10 +3,8 @@ package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -139,29 +137,11 @@ public class PreviousPeriodServiceImplTests {
     }
 
     @Test
-    @DisplayName("Get previous period - not found")
-    void getPreviousPeriodNotFound() throws ServiceException, ApiErrorResponseException, URIValidationException {
-
-        when(previousPeriodResourceHandler.get(PREVIOUS_PERIOD_URI)).thenReturn(previousPeriodGet);
-        when(previousPeriodGet.execute()).thenThrow(apiErrorResponseException);
-
-        doNothing()
-                .when(serviceExceptionHandler)
-                        .handleRetrievalException(apiErrorResponseException, PREVIOUS_PERIOD_RESOURCE);
-
-        assertNull(previousPeriodService.getPreviousPeriod(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
-    }
-
-    @Test
     @DisplayName("Get previous period - api error response exception")
-    void getPreviousPeriodApiErrorResponseException() throws ServiceException, ApiErrorResponseException, URIValidationException {
+    void getPreviousPeriodApiErrorResponseException() throws ApiErrorResponseException, URIValidationException {
 
         when(previousPeriodResourceHandler.get(PREVIOUS_PERIOD_URI)).thenReturn(previousPeriodGet);
         when(previousPeriodGet.execute()).thenThrow(apiErrorResponseException);
-
-        doThrow(serviceException)
-                .when(serviceExceptionHandler)
-                        .handleRetrievalException(apiErrorResponseException, PREVIOUS_PERIOD_RESOURCE);
 
         assertThrows(ServiceException.class,
                 () -> previousPeriodService.getPreviousPeriod(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
@@ -169,14 +149,10 @@ public class PreviousPeriodServiceImplTests {
 
     @Test
     @DisplayName("Get previous period - uri validation exception")
-    void getPreviousPeriodURIValidationException() throws ServiceException, ApiErrorResponseException, URIValidationException {
+    void getPreviousPeriodURIValidationException() throws ApiErrorResponseException, URIValidationException {
 
         when(previousPeriodResourceHandler.get(PREVIOUS_PERIOD_URI)).thenReturn(previousPeriodGet);
         when(previousPeriodGet.execute()).thenThrow(uriValidationException);
-
-        doThrow(serviceException)
-                .when(serviceExceptionHandler)
-                        .handleURIValidationException(uriValidationException, PREVIOUS_PERIOD_RESOURCE);
 
         assertThrows(ServiceException.class,
                 () -> previousPeriodService.getPreviousPeriod(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));


### PR DESCRIPTION
NPE's have been observed in Live and this PR aims to address them.

What was happening before was: should the API become unreachable at any time, 404's were being returned to the web client which was resulting in the passing around of `null`s. Now in most cases this, whilst not ideal, does not result in NPE's because the app is designed to handle nulls gracefully - in _most_ cases.

That said, there are certain resources which we expect to exist, and the app didn't guard against those resources being null. 

Before this change, a `ServiceExceptionHandler` utility class was used in the event of an exception to check for a 404 response status and, if so, return `null` from the fetch of the resource.

Now, following the change, if a 404 is encountered for a 'mandatory' resource, an exception is thrown from the method, rather than having a null returned.

This is not only more semantically correct, but also highlights the case that an exception has been encountered. Prior to this change, the NPE obfuscated the real issue of a 'mandatory' resource not being found.

Resolves SFA-3125