### PR TITLE
Wording changes and error fix

### DIFF
--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -32,4 +32,4 @@ approval.selectionNotMade=Tell us which officer signed off the accounts
 offBalanceSheetArrangementsQuestion.selectionNotMade=Tell us if your prepared accounts include any ''Off balance sheet arrangements'' notes
 offBalanceSheetArrangements.details.missing=Give details of your ''off balance sheet arrangements''
 accountsReferenceDateQuestion.selectionNotMade=Please confirm the dates that you have prepared your accounts to
-accountsReferenceDate.selectionNotMade=Please confirm your new company account date
+accountsReferenceDate.selectionNotMade=Please choose the date the accounts are made up to

--- a/src/main/resources/templates/smallfull/accountsReferenceDate.html
+++ b/src/main/resources/templates/smallfull/accountsReferenceDate.html
@@ -30,7 +30,7 @@
                      th:classappend="${#fields.hasErrors('chosenDate')} ? 'govuk-form-group--error' : ''">
 
                     <span class="govuk-error-message"
-                          id="choosenDate-errorId"
+                          id="chosenDate-errorId"
                           th:if="${#fields.hasErrors('chosenDate')}"
                           th:each="e : ${#fields.errors('chosenDate')}" th:text="${e}">
                     </span>

--- a/src/main/resources/templates/smallfull/accountsReferenceDate.html
+++ b/src/main/resources/templates/smallfull/accountsReferenceDate.html
@@ -18,15 +18,23 @@
                 <div th:replace="fragments/globalErrors :: globalErrors"></div>
 
                 <h1 id="page-title" class="govuk-heading-l">
-                    <span>Confirm your new company account date</span>
+                    <span>Choose the date the accounts are made up to</span>
                 </h1>
                 <span id="new-company-account-date-hint" class="govuk-hint">
-                  You can change the end date of the period you're filing for by up to 7 days.
+                  A company can file its accounts up to 7 days before or 7 days after its accounting period date.
+                    This will not change the end date of its future accounting periods.
                 </span>
 
 
                 <div class="govuk-form-group"
                      th:classappend="${#fields.hasErrors('chosenDate')} ? 'govuk-form-group--error' : ''">
+
+                    <span class="govuk-error-message"
+                          id="choosenDate-errorId"
+                          th:if="${#fields.hasErrors('chosenDate')}"
+                          th:each="e : ${#fields.errors('chosenDate')}" th:text="${e}">
+                    </span>
+
                     <div class="govuk-radios">
                         <div class="govuk-grid-row">
                             <div class="govuk-grid-column-one-half">


### PR DESCRIPTION
-Title wording changed
-Hint text wording changed
-Error wording changed

-Fixed issue where Error text wasn't displaying above the Radio selection buttons.