### PR TITLE
Change Debtors to use smallFullService instead of BalanceSheetService

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImpl.java
@@ -54,10 +54,12 @@ public class DebtorsServiceImpl implements DebtorsService {
     @Override
     public Debtors getDebtors(String transactionId, String companyAccountsId, String companyNumber) throws ServiceException {
 
-        DebtorsApi debtorsApi = getDebtorsApi(transactionId, companyAccountsId);
+        ApiClient apiClient = apiClientService.getApiClient();
+
+        DebtorsApi debtorsApi = getDebtorsApi(apiClient, transactionId, companyAccountsId);
         Debtors debtors = transformer.getDebtors(debtorsApi);
 
-        BalanceSheetHeadings balanceSheetHeadings = balanceSheetService.getBalanceSheet(transactionId, companyAccountsId, companyNumber).getBalanceSheetHeadings();
+        BalanceSheetHeadings balanceSheetHeadings = getDebtorsBalanceSheetHeadings(apiClient, transactionId, companyAccountsId);
         debtors.setBalanceSheetHeadings(balanceSheetHeadings);
 
         return debtors;
@@ -112,8 +114,7 @@ public class DebtorsServiceImpl implements DebtorsService {
         }
     }
 
-    private DebtorsApi getDebtorsApi(String transactionId, String companyAccountsId) throws ServiceException {
-        ApiClient apiClient = apiClientService.getApiClient();
+    private DebtorsApi getDebtorsApi(ApiClient apiClient, String transactionId, String companyAccountsId) throws ServiceException {
 
         String uri = DEBTORS_URI.expand(transactionId, companyAccountsId).toString();
 
@@ -130,5 +131,13 @@ public class DebtorsServiceImpl implements DebtorsService {
 
     private boolean hasDebtors(SmallFullLinks smallFullLinks) {
         return smallFullLinks.getDebtorsNote() != null;
+    }
+
+    private BalanceSheetHeadings getDebtorsBalanceSheetHeadings(ApiClient apiClient, String transactionId, String companyAccountsId)
+            throws ServiceException {
+
+        SmallFullApi smallFullApi = smallFullService.getSmallFullAccounts(apiClient, transactionId, companyAccountsId);
+
+        return smallFullService.getBalanceSheetHeadings(smallFullApi);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DebtorsServiceImplTests.java
@@ -89,12 +89,6 @@ public class DebtorsServiceImplTests {
     private SmallFullService smallFullService;
 
     @Mock
-    private BalanceSheetService mockBalanceSheetService;
-
-    @Mock
-    private BalanceSheet mockBalanceSheet;
-
-    @Mock
     private List<ValidationError> mockValidationErrors;
 
     @Mock
@@ -134,8 +128,6 @@ public class DebtorsServiceImplTests {
         getMockDebtorsApi(debtorsApi);
 
         when(mockDebtorsTransformer.getDebtors(debtorsApi)).thenReturn(createDebtors());
-        when(mockBalanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER)).thenReturn(mockBalanceSheet);
-        when(mockBalanceSheet.getBalanceSheetHeadings()).thenReturn(new BalanceSheetHeadings());
 
         Debtors debtors = debtorsService.getDebtors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER);
 
@@ -158,8 +150,6 @@ public class DebtorsServiceImplTests {
         doNothing()
                 .when(serviceExceptionHandler)
                 .handleRetrievalException(apiErrorResponseException, RESOURCE_NAME);
-
-        when(mockBalanceSheetService.getBalanceSheet(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, COMPANY_NUMBER)).thenReturn(mockBalanceSheet);
 
         when(mockDebtorsTransformer.getDebtors(null)).thenReturn(createDebtors());
 


### PR DESCRIPTION
-Debtors note will now go through the smallFullService to retrieve the balance sheet headings.
-Unit tests have been updated to remove reference to the balanceSheetService.