### PR TITLE
Hide future dates from user logs in after periodEndOn

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
@@ -128,16 +128,15 @@ public class CompanyServiceImpl implements CompanyService {
     @Override
     public List<LocalDate> getFutureDatesForArd(LocalDate periodEndOn) {
 
+    	LocalDate todaysDate = LocalDate.now();
         List<LocalDate> futureValidDates = new ArrayList<>();
 
-
-        futureValidDates.add(periodEndOn.plusDays(1));
-        futureValidDates.add(periodEndOn.plusDays(2));
-        futureValidDates.add(periodEndOn.plusDays(3));
-        futureValidDates.add(periodEndOn.plusDays(4));
-        futureValidDates.add(periodEndOn.plusDays(5));
-        futureValidDates.add(periodEndOn.plusDays(6));
-        futureValidDates.add(periodEndOn.plusDays(7));
+        for(int i = 1; i <= 7; i++) {
+        	if(periodEndOn.plusDays(i).isBefore(todaysDate) ||
+        		periodEndOn.plusDays(i).isEqual(todaysDate)) {
+                futureValidDates.add(periodEndOn.plusDays(i));
+        	}
+        }
 
         Collections.sort(futureValidDates);
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImpl.java
@@ -132,10 +132,10 @@ public class CompanyServiceImpl implements CompanyService {
         List<LocalDate> futureValidDates = new ArrayList<>();
 
         for(int i = 1; i <= 7; i++) {
-        	if(periodEndOn.plusDays(i).isBefore(todaysDate) ||
-        		periodEndOn.plusDays(i).isEqual(todaysDate)) {
-                futureValidDates.add(periodEndOn.plusDays(i));
+        	if(periodEndOn.plusDays(i).isAfter(todaysDate)) {
+        		break;
         	}
+            futureValidDates.add(periodEndOn.plusDays(i));
         }
 
         Collections.sort(futureValidDates);

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/company/impl/CompanyServiceImplTests.java
@@ -11,6 +11,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
 import uk.gov.companieshouse.accountsdates.AccountsDatesHelper;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -255,5 +258,84 @@ public class CompanyServiceImplTests {
         assertNotNull(balanceSheetHeadings);
         assertEquals(NEXT_ACCOUNTS_HEADING, balanceSheetHeadings.getCurrentPeriodHeading());
         assertEquals(LAST_ACCOUNTS_HEADING, balanceSheetHeadings.getPreviousPeriodHeading());
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 1 day")
+    void getArdDatePlusOneDay() {
+    	int noOfDays = 1;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 2 days")
+    void getArdDatePlusTwoDays() {
+    	int noOfDays = 2;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 3 days")
+    void getArdDatePlusThreeDays() {
+    	int noOfDays = 3;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 4 days")
+    void getArdDatePlusFourDays() {
+    	int noOfDays = 4;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 5 days")
+    void getArdDatePlusFiveDays() {
+    	int noOfDays = 5;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 6 days")
+    void getArdDatePlusSixDays() {
+    	int noOfDays = 6;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 7 days")
+    void getArdDatePlusSevenDays() {
+    	int noOfDays = 7;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays, futureArdDates);
+    }
+    
+    @Test
+    @DisplayName("Get ARD date plus 8 days - Should only be up to 7")
+    void getArdDatePlusEightDays() {
+    	int noOfDays = 8;
+    	LocalDate periodEndOn = LocalDate.now().minusDays(noOfDays);
+    	List<LocalDate> futureArdDates = companyService.getFutureDatesForArd(periodEndOn);
+    	assertCorrectFutureDates(periodEndOn, noOfDays - 1, futureArdDates);
+    }
+    
+    private void assertCorrectFutureDates(LocalDate ardDate, int noOfDays, List<LocalDate> futureArdDates) {
+    	assertEquals(futureArdDates.size(), noOfDays);
+    	for(int i = 1; i <= noOfDays; i++) {
+    		assertEquals(ardDate.plusDays(i), futureArdDates.get(i-1));
+    	}
     }
 }


### PR DESCRIPTION
Hide future dates when user logs into service after period end date up to 7 days. Update method getFutureDatesForArd to loop through 7 days from periodEndOn and add to list if the new date is before or on today's date.

BI-3186