### PR TITLE
Cross validation of DR to LTD

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsController.java
@@ -72,7 +72,7 @@ public class AddOrRemoveDirectorsController extends BaseController implements Co
 
         try {
             addOrRemoveDirectors.setExistingDirectors(
-                    directorService.getAllDirectors(transactionId, companyAccountsId));
+                    directorService.getAllDirectors(transactionId, companyAccountsId, false));
 
             addOrRemoveDirectors.setSecretary(
                     secretaryService.getSecretary(transactionId, companyAccountsId));

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
@@ -64,8 +64,6 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
-    private static final String VALID_DIRECTOR_NAMES = "validDirectorNames";
-
     @GetMapping
     public String getAddOrRemoveLoans(@PathVariable String companyNumber,
                                       @PathVariable String transactionId,
@@ -93,6 +91,8 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
                 validDirectorNames.add(director.getName());
             }
 
+            addOrRemoveLoans.setValidDirectorNames(validDirectorNames);
+
         } catch (ServiceException e) {
 
             LOGGER.errorRequest(request, e.getMessage(), e);
@@ -100,7 +100,6 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
         }
 
         model.addAttribute(ADD_OR_REMOVE_LOANS, addOrRemoveLoans);
-        model.addAttribute(VALID_DIRECTOR_NAMES, validDirectorNames);
         model.addAttribute(COMPANY_NUMBER, companyNumber);
         model.addAttribute(TRANSACTION_ID, transactionId);
         model.addAttribute(COMPANY_ACCOUNTS_ID, companyAccountsId);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
@@ -20,13 +20,16 @@ import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.controller.ConditionalController;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.directorsreport.Director;
 import uk.gov.companieshouse.web.accounts.model.loanstodirectors.AddOrRemoveLoans;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
+import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.LoanService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -47,6 +50,9 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
     @Autowired
     private ApiClientService apiClientService;
 
+    @Autowired
+    private DirectorService directorService;
+
     private static final UriTemplate URI =
             new UriTemplate("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/note/add-or-remove-loans");
 
@@ -58,6 +64,8 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
+    private static final String VALID_DIRECTOR_NAMES = "validDirectorNames";
+
     @GetMapping
     public String getAddOrRemoveLoans(@PathVariable String companyNumber,
                                       @PathVariable String transactionId,
@@ -68,6 +76,9 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
 
         AddOrRemoveLoans addOrRemoveLoans = new AddOrRemoveLoans();
 
+        Director[] validDirectors;
+        List<String> validDirectorNames = new ArrayList<>();
+
         ApiClient apiClient = apiClientService.getApiClient();
         try {
             SmallFullApi smallFullApi = smallFullService.getSmallFullAccounts(apiClient, transactionId, companyAccountsId);
@@ -77,6 +88,11 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
 
             addOrRemoveLoans.setNextAccount(smallFullApi.getNextAccounts());
 
+            validDirectors = directorService.getAllDirectors(transactionId, companyAccountsId, true);
+            for (Director director: validDirectors) {
+                validDirectorNames.add(director.getName());
+            }
+
         } catch (ServiceException e) {
 
             LOGGER.errorRequest(request, e.getMessage(), e);
@@ -84,6 +100,7 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
         }
 
         model.addAttribute(ADD_OR_REMOVE_LOANS, addOrRemoveLoans);
+        model.addAttribute(VALID_DIRECTOR_NAMES, validDirectorNames);
         model.addAttribute(COMPANY_NUMBER, companyNumber);
         model.addAttribute(TRANSACTION_ID, transactionId);
         model.addAttribute(COMPANY_ACCOUNTS_ID, companyAccountsId);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -72,8 +72,7 @@ public class ApprovalController extends BaseController {
                     transactionService.isPayableTransaction(transactionId, companyAccountsId));
 
             List<String> approverOptions =
-                    Arrays.stream(directorService.getAllDirectors(transactionId, companyAccountsId))
-                            .filter(d -> d.getResignationDate() == null)
+                    Arrays.stream(directorService.getAllDirectors(transactionId, companyAccountsId, true))
                             .map(Director::getName)
                             .collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalController.java
@@ -70,12 +70,8 @@ public class DirectorsReportApprovalController extends BaseController implements
 
             List<String> approverOptions = new ArrayList<>();
 
-            for(Director director : directorService.getAllDirectors(transactionId, companyAccountsId)) {
-
-                if (director.getResignationDate() == null || (director.getAppointmentDate() != null
-                        && director.getAppointmentDate().isAfter(director.getResignationDate()))) {
-                        approverOptions.add(director.getName());
-                }
+            for(Director director : directorService.getAllDirectors(transactionId, companyAccountsId, true)) {
+                approverOptions.add(director.getName());
             }
 
             String secretary = secretaryService.getSecretary(transactionId, companyAccountsId);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/enumeration/ValidationMessage.java
@@ -25,6 +25,7 @@ public enum ValidationMessage {
     PREVIOUS_BALANCESHEET_NOT_EQUAL("value_not_equal_to_previous_period_on_balance_sheet", "previous.balancesheet.not.equal", false),
     VALUE_REQUIRED("value_required", "value.required", true),
     UNEXPECTED_DATA("unexpected_data", "validation.unexpected.data", false),
+    DR_LTD_CROSS_VALIDATION("must_match_a_director_given_in_directors_report", "validation.cross_validation_dr_ltd", false),
     DATE_OUTSIDE_CURRENT_PERIOD("date_outside_current_period", "validation.date.outside.currentPeriod", false);
 
     private String messageKey;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/loanstodirectors/AddOrRemoveLoans.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/loanstodirectors/AddOrRemoveLoans.java
@@ -3,6 +3,8 @@ package uk.gov.companieshouse.web.accounts.model.loanstodirectors;
 import uk.gov.companieshouse.api.model.accounts.smallfull.AccountingPeriodApi;
 import uk.gov.companieshouse.web.accounts.validation.ValidationModel;
 
+import java.util.List;
+
 @ValidationModel
 public class AddOrRemoveLoans {
 
@@ -11,6 +13,8 @@ public class AddOrRemoveLoans {
     private LoanToAdd loanToAdd;
 
     private AccountingPeriodApi nextAccount;
+
+    private List<String> validDirectorNames;
 
     public AccountingPeriodApi getNextAccount() {
         return nextAccount;
@@ -34,5 +38,13 @@ public class AddOrRemoveLoans {
 
     public void setLoanToAdd(LoanToAdd loanToAdd) {
         this.loanToAdd = loanToAdd;
+    }
+
+    public List<String> getValidDirectorNames() {
+        return validDirectorNames;
+    }
+
+    public void setValidDirectorNames(List<String> validDirectorNames) {
+        this.validDirectorNames = validDirectorNames;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/DirectorService.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/DirectorService.java
@@ -10,7 +10,7 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 public interface DirectorService {
 
-    Director[] getAllDirectors(String transactionId, String companyAccountsId) throws ServiceException;
+    Director[] getAllDirectors(String transactionId, String companyAccountsId, boolean isActive) throws ServiceException;
 
     List<ValidationError> createDirector(String transactionId, String companyAccountsId, DirectorToAdd directorToAdd) throws ServiceException;
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorServiceImpl.java
@@ -1,9 +1,7 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collector;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorsReportReviewServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorsReportReviewServiceImpl.java
@@ -39,7 +39,7 @@ public class DirectorsReportReviewServiceImpl implements DirectorsReportReviewSe
 
         DirectorsReportReview review = new DirectorsReportReview();
 
-        review.setDirectors(directorService.getAllDirectors(transactionId, companyAccountsId));
+        review.setDirectors(directorService.getAllDirectors(transactionId, companyAccountsId, false));
         review.setSecretary(secretaryService.getSecretary(transactionId, companyAccountsId));
         review.setAdditionalInformation(
                 additionalInformationService.getAdditionalInformation(transactionId, companyAccountsId));

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -483,7 +483,6 @@ loanToAdd.breakdown.balanceAtPeriodEnd = Balance at period end:
 loanToAdd.breakdown.advancesCreditsMade = Advances and credits made:
 loanToAdd.breakdown.advancesCreditsRepaid = Advances and credits repaid:
 
-
 validation.element.missing.loanToAdd.directorName = Enter the director's name
 validation.cross_validation_dr_ltd.loan.director_name = Name provided must match one previously given in the directors report
 validation.element.missing.loanToAdd.description = Enter a description

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -485,6 +485,7 @@ loanToAdd.breakdown.advancesCreditsRepaid = Advances and credits repaid:
 
 
 validation.element.missing.loanToAdd.directorName = Enter the director's name
+validation.cross_validation_dr_ltd.loan.director_name = Name provided must match one previously given in the directors report
 validation.element.missing.loanToAdd.description = Enter a description
 validation.element.missing.loanToAdd.breakdown.balanceAtPeriodStart = Enter a value
 validation.element.missing.loanToAdd.breakdown.balanceAtPeriodEnd = Enter a value

--- a/src/main/resources/templates/smallfull/addOrRemoveLoans.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveLoans.html
@@ -210,11 +210,30 @@
                               th:each="e : *{#fields.errors('loanToAdd.directorName')}" th:text="${e}">
                         </span>
 
-                        <textarea class="govuk-textarea"
-                                  id="loanToAdd-director-name"
-                                  th:field="*{loanToAdd.directorName}"
-                                  type="text" rows="1">
-                                </textarea>
+                        <div th:if="${validDirectorNames.size() == 0}">
+                            <textarea class="govuk-textarea"
+                                      id="loanToAdd-director-name"
+                                      th:field="*{loanToAdd.directorName}"
+                                      type="text" rows="1">
+                            </textarea>
+                        </div>
+                        <div th:unless="${validDirectorNames.size() == 0}">
+                            <div th:each="director, stat : ${validDirectorNames}" class="govuk-radios__item" id="director-name-options">
+                                <input class="govuk-radios__input"
+                                       th:id="${stat.index}"
+                                       type="radio"
+                                       th:value="${director}"/>
+
+                                <label class="govuk-label govuk-radios__label"
+                                       th:for="${stat.index}"
+                                       th:id="${stat.index + '-label'}"
+                                       th:text="${director}"></label>
+                            </div>
+
+                            <!--<div th:each="director, stat : ${validDirectorNames}">
+                                <input type="hidden" th:field="${validDirectorNames[__${stat.index}__]}" th:id="validDirectorNames[__${stat.index}__]"/>
+                            </div>-->
+                        </div>
                     </div>
 
                     <div th:classappend="*{#fields.hasErrors('loanToAdd.description')} ? 'govuk-form-group--error' : ''">

--- a/src/main/resources/templates/smallfull/addOrRemoveLoans.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveLoans.html
@@ -177,9 +177,10 @@
                 <!--Hidden fields for form binding-->
                 <input th:field="*{nextAccount.periodStartOn}" type="hidden">
                 <input th:field="*{nextAccount.periodEndOn}" type="hidden">
-                <div th:each="director, stat : ${validDirectorNames}">
-                    <input type="hidden" th:value="${validDirectorNames[__${stat.index}__]}" th:id="validDirectorNames[__${stat.index}__]"/>
-                </div>
+
+                <th:block th:each="director, stat : *{validDirectorNames}">
+                    <input type="hidden" th:field="*{validDirectorNames[__${stat.index}__]}" th:id="validDirectorNames[__${stat.index}__]"/>
+                </th:block>
 
                 <div th:each="loan, stat : ${addOrRemoveLoans.existingLoans}">
                     <input type="hidden" th:field="*{existingLoans[__${stat.index}__].directorName}"
@@ -194,47 +195,50 @@
                 <div th:if="${addOrRemoveLoans.existingLoans == null or addOrRemoveLoans.existingLoans.length < 20}"
                      class="govuk-form-group govuk-form-group-block-important">
 
-                    <th:block th:if="${validDirectorNames == null or validDirectorNames.size() == 0}">
+                    <span class="govuk-error-message"
+                          id="loanToAdd-errorId"
+                          th:if="*{#fields.hasErrors('loanToAdd')}"
+                          th:each="e : *{#fields.errors('loanToAdd')}" th:text="${e}">
+                    </span>
 
+                    <label id="loanToAdd-director-name-label"
+                           class="govuk-label govuk-label--m"
+                           for="loanToAdd-director-name">
+                        Name of director receiving advance or credit
+                    </label>
+
+                    <span class="govuk-error-message"
+                          id="loanToAdd.directorName-errorId"
+                          th:if="*{#fields.hasErrors('loanToAdd.directorName')}"
+                          th:each="e : *{#fields.errors('loanToAdd.directorName')}" th:text="${e}">
+                    </span>
+
+                    <th:block th:if="*{validDirectorNames == null or validDirectorNames.size() == 0}">
                         <div th:classappend="*{#fields.hasErrors('loanToAdd.directorName')} ? 'govuk-form-group--error' : ''">
-                            <span class="govuk-error-message"
-                                  id="loanToAdd-errorId"
-                                  th:if="*{#fields.hasErrors('loanToAdd')}"
-                                  th:each="e : *{#fields.errors('loanToAdd')}" th:text="${e}">
-                            </span>
-
-                            <label id="loanToAdd-director-name-label"
-                                   class="govuk-label govuk-label--m"
-                                   for="loanToAdd-director-name">
-                                Name of director receiving advance or credit
-                            </label>
-
-                            <span class="govuk-error-message"
-                                  id="loanToAdd.directorName-errorId"
-                                  th:if="*{#fields.hasErrors('loanToAdd.directorName')}"
-                                  th:each="e : *{#fields.errors('loanToAdd.directorName')}" th:text="${e}">
-                            </span>
-
                             <textarea class="govuk-textarea"
-                                      id="loanToAdd-director-name"
-                                      th:field="*{loanToAdd.directorName}"
-                                      type="text" rows="1">
+                                  id="loanToAdd-director-name"
+                                  th:field="*{loanToAdd.directorName}"
+                                  type="text" rows="1">
                             </textarea>
                         </div>
                     </th:block>
-                    <th:block th:unless="${validDirectorNames == null or validDirectorNames.size() == 0}">
-                        <div th:each="director, stat : ${validDirectorNames}" class="govuk-radios__item" id="director-name-options">
-                            <input class="govuk-radios__input"
+
+                    <th:block th:unless="*{validDirectorNames == null or validDirectorNames.size() == 0}">
+                        <div th:classappend="*{#fields.hasErrors('loanToAdd.directorName')} ? 'govuk-form-group--error' : ''">
+                            <div th:each="director, stat : *{validDirectorNames}" class="govuk-radios__item">
+                                <input class="govuk-radios__input"
                                    th:id="${stat.index}"
                                    type="radio"
                                    th:value="${director}"
                                    th:field="*{loanToAdd.directorName}"/>
 
-                            <label class="govuk-label govuk-radios__label"
+                                <label class="govuk-label govuk-radios__label"
                                    th:for="${stat.index}"
                                    th:id="${stat.index + '-label'}"
                                    th:text="${director}"></label>
+                            </div>
                         </div>
+                        <p></p>
                     </th:block>
 
                     <div th:classappend="*{#fields.hasErrors('loanToAdd.description')} ? 'govuk-form-group--error' : ''">

--- a/src/main/resources/templates/smallfull/addOrRemoveLoans.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveLoans.html
@@ -174,8 +174,12 @@
             <form id="data-submission-form" th:action="@{''}" class="form currency-included-within-inputs govuk-body"
                   th:object="${addOrRemoveLoans}" method="post">
 
+                <!--Hidden fields for form binding-->
                 <input th:field="*{nextAccount.periodStartOn}" type="hidden">
                 <input th:field="*{nextAccount.periodEndOn}" type="hidden">
+                <div th:each="director, stat : ${validDirectorNames}">
+                    <input type="hidden" th:value="${validDirectorNames[__${stat.index}__]}" th:id="validDirectorNames[__${stat.index}__]"/>
+                </div>
 
                 <div th:each="loan, stat : ${addOrRemoveLoans.existingLoans}">
                     <input type="hidden" th:field="*{existingLoans[__${stat.index}__].directorName}"
@@ -190,51 +194,48 @@
                 <div th:if="${addOrRemoveLoans.existingLoans == null or addOrRemoveLoans.existingLoans.length < 20}"
                      class="govuk-form-group govuk-form-group-block-important">
 
-                    <div th:classappend="*{#fields.hasErrors('loanToAdd.directorName')} ? 'govuk-form-group--error' : ''">
+                    <th:block th:if="${validDirectorNames == null or validDirectorNames.size() == 0}">
 
-                        <span class="govuk-error-message"
-                              id="loanToAdd-errorId"
-                              th:if="*{#fields.hasErrors('loanToAdd')}"
-                              th:each="e : *{#fields.errors('loanToAdd')}" th:text="${e}">
-                        </span>
+                        <div th:classappend="*{#fields.hasErrors('loanToAdd.directorName')} ? 'govuk-form-group--error' : ''">
+                            <span class="govuk-error-message"
+                                  id="loanToAdd-errorId"
+                                  th:if="*{#fields.hasErrors('loanToAdd')}"
+                                  th:each="e : *{#fields.errors('loanToAdd')}" th:text="${e}">
+                            </span>
 
-                        <label id="loanToAdd-director-name-label"
-                               class="govuk-label govuk-label--m"
-                               for="loanToAdd-director-name">
-                            Name of director receiving advance or credit
-                        </label>
+                            <label id="loanToAdd-director-name-label"
+                                   class="govuk-label govuk-label--m"
+                                   for="loanToAdd-director-name">
+                                Name of director receiving advance or credit
+                            </label>
 
-                        <span class="govuk-error-message"
-                              id="loanToAdd.directorName-errorId"
-                              th:if="*{#fields.hasErrors('loanToAdd.directorName')}"
-                              th:each="e : *{#fields.errors('loanToAdd.directorName')}" th:text="${e}">
-                        </span>
+                            <span class="govuk-error-message"
+                                  id="loanToAdd.directorName-errorId"
+                                  th:if="*{#fields.hasErrors('loanToAdd.directorName')}"
+                                  th:each="e : *{#fields.errors('loanToAdd.directorName')}" th:text="${e}">
+                            </span>
 
-                        <div th:if="${validDirectorNames.size() == 0}">
                             <textarea class="govuk-textarea"
                                       id="loanToAdd-director-name"
                                       th:field="*{loanToAdd.directorName}"
                                       type="text" rows="1">
                             </textarea>
                         </div>
-                        <div th:unless="${validDirectorNames.size() == 0}">
-                            <div th:each="director, stat : ${validDirectorNames}" class="govuk-radios__item" id="director-name-options">
-                                <input class="govuk-radios__input"
-                                       th:id="${stat.index}"
-                                       type="radio"
-                                       th:value="${director}"/>
+                    </th:block>
+                    <th:block th:unless="${validDirectorNames == null or validDirectorNames.size() == 0}">
+                        <div th:each="director, stat : ${validDirectorNames}" class="govuk-radios__item" id="director-name-options">
+                            <input class="govuk-radios__input"
+                                   th:id="${stat.index}"
+                                   type="radio"
+                                   th:value="${director}"
+                                   th:field="*{loanToAdd.directorName}"/>
 
-                                <label class="govuk-label govuk-radios__label"
-                                       th:for="${stat.index}"
-                                       th:id="${stat.index + '-label'}"
-                                       th:text="${director}"></label>
-                            </div>
-
-                            <!--<div th:each="director, stat : ${validDirectorNames}">
-                                <input type="hidden" th:field="${validDirectorNames[__${stat.index}__]}" th:id="validDirectorNames[__${stat.index}__]"/>
-                            </div>-->
+                            <label class="govuk-label govuk-radios__label"
+                                   th:for="${stat.index}"
+                                   th:id="${stat.index + '-label'}"
+                                   th:text="${director}"></label>
                         </div>
-                    </div>
+                    </th:block>
 
                     <div th:classappend="*{#fields.hasErrors('loanToAdd.description')} ? 'govuk-form-group--error' : ''">
                         <label id="loanToAdd-description-label"

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
@@ -123,7 +123,7 @@ public class AddOrRemoveDirectorsControllerTest {
     @DisplayName("Get add or remove directors view - success path")
     void getRequestSuccess() throws Exception {
 
-        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new Director[0]);
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false)).thenReturn(new Director[0]);
 
         when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(SECRETARY_NAME);
 
@@ -141,7 +141,7 @@ public class AddOrRemoveDirectorsControllerTest {
     @DisplayName("Get add or remove directors view - service exception")
     void getRequestServiceException() throws Exception {
 
-        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenThrow(ServiceException.class);
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false)).thenThrow(ServiceException.class);
 
         this.mockMvc.perform(get(ADD_OR_REMOVE_DIRECTORS_PATH))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansControllerTest.java
@@ -16,17 +16,20 @@ import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
+import uk.gov.companieshouse.web.accounts.model.directorsreport.Director;
 import uk.gov.companieshouse.web.accounts.model.loanstodirectors.AddOrRemoveLoans;
 import uk.gov.companieshouse.web.accounts.model.loanstodirectors.Loan;
 import uk.gov.companieshouse.web.accounts.model.loanstodirectors.LoanToAdd;
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.LoanService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,6 +55,9 @@ class AddOrRemoveLoansControllerTest {
 
     @Mock
     private LoanService loanService;
+
+    @Mock
+    private DirectorService directorService;
 
     @Mock
     private HttpServletRequest request;
@@ -125,6 +131,7 @@ class AddOrRemoveLoansControllerTest {
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
         when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(smallFullApi);
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, true)).thenReturn(createValidDirectors());
         when(loanService.getAllLoans(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new Loan[0]);
 
         this.mockMvc.perform(get(ADD_OR_REMOVE_LOAN_PATH))
@@ -303,5 +310,18 @@ class AddOrRemoveLoansControllerTest {
         when(httpSession.getAttribute(COMPANY_ACCOUNTS_STATE)).thenReturn(companyAccountsDataState);
         when(companyAccountsDataState.getHasIncludedLoansToDirectors()).thenReturn(false);
         assertFalse(controller.willRender(COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+    }
+
+    private Director[] createValidDirectors() {
+        Director[] directors = new Director[1];
+
+        Director newDirector = new Director();
+        newDirector.setName("test");
+        newDirector.setAppointmentDate(LocalDate.of(2017, 05, 01));
+        newDirector.setResignationDate(null);
+
+        directors[0] = newDirector;
+
+        return directors;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -109,7 +109,7 @@ public class ApprovalControllerTests {
     @DisplayName("Get approval view success path")
     void getRequestSuccess() throws Exception {
 
-        when (directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new Director[]{});
+        when (directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, true)).thenReturn(new Director[]{});
 
         this.mockMvc.perform(get(APPROVAL_PATH))
                 .andExpect(status().isOk())
@@ -139,7 +139,7 @@ public class ApprovalControllerTests {
 
         Director director = new Director();
         director.setName(DIRECTOR_NAME);
-        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new Director[]{director});
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, true)).thenReturn(new Director[]{director});
 
         this.mockMvc.perform(get(APPROVAL_PATH))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalControllerTest.java
@@ -126,7 +126,7 @@ public class DirectorsReportApprovalControllerTest {
         Director director = new Director();
         director.setName(DIRECTOR_NAME);
         Director[] directors = new Director[]{director};
-        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(directors);
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, true)).thenReturn(directors);
 
         when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(SECRETARY_NAME);
 
@@ -156,7 +156,7 @@ public class DirectorsReportApprovalControllerTest {
         newDirector.setResignationDate(LocalDate.of(2017, 04, 01));
         newDirector.setAppointmentDate(LocalDate.of(2017, 03, 01));
 
-        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(directors);
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, true)).thenReturn(directors);
 
         when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(null);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorServiceImplTest.java
@@ -5,12 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -124,6 +126,9 @@ public class DirectorServiceImplTest {
 
     private static final String RESOURCE_NAME = "directors";
 
+    private static final LocalDate APPOINTMENT_DATE = LocalDate.of(2019, 1, 1);
+    private static final LocalDate RESIGNATION_DATE = LocalDate.of(2019, 2, 1);
+
     @Test
     @DisplayName("GET - all directors - success")
     void getAllDirectorsSuccess()
@@ -143,6 +148,27 @@ public class DirectorServiceImplTest {
         Director[] response = directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false);
 
         assertEquals(allDirectors, response);
+    }
+
+    @Test
+    @DisplayName("GET - all directors - success with isActive flag true")
+    void getAllDirectorsSuccessIsActiveTrue()
+            throws ServiceException, ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(apiClient.smallFull()).thenReturn(smallFullResourceHandler);
+        when(smallFullResourceHandler.directorsReport()).thenReturn(directorsReportResourceHandler);
+        when(directorsReportResourceHandler.directors()).thenReturn(directorResourceHandler);
+        when(directorResourceHandler.getAll(DIRECTORS_URI)).thenReturn(directorGetAll);
+        when(directorGetAll.execute()).thenReturn(responseWithMultipleDirectors);
+        DirectorApi[] allDirectors = createArrayOfDirectorsApi();
+        when(responseWithMultipleDirectors.getData()).thenReturn(allDirectors);
+        Director[] responseDirectors = createArrayOfDirectors();
+        when(directorTransformer.getAllDirectors(any())).thenReturn(responseDirectors);
+
+        Director[] response = directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, true);
+
+        assertEquals(responseDirectors, response);
     }
 
     @Test
@@ -383,5 +409,63 @@ public class DirectorServiceImplTest {
         when(directorValidator.validateSubmitAddOrRemoveDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, addOrRemoveDirectors)).thenReturn(validationErrors);
 
         assertEquals(validationErrors, directorService.submitAddOrRemoveDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, addOrRemoveDirectors));
+    }
+
+    private DirectorApi[] createArrayOfDirectorsApi() {
+
+        DirectorApi[] allDirectorsApi = new DirectorApi[4];
+
+        DirectorApi activeDirector = new DirectorApi();
+        activeDirector.setName("active");
+        activeDirector.setAppointmentDate(null);
+        activeDirector.setResignationDate(null);
+
+        DirectorApi activeDirector2 = new DirectorApi();
+        activeDirector2.setName("active2");
+        activeDirector2.setAppointmentDate(APPOINTMENT_DATE);
+        activeDirector2.setResignationDate(null);
+
+        DirectorApi activeDirector3 = new DirectorApi();
+        activeDirector3.setName("active3");
+        activeDirector3.setAppointmentDate(RESIGNATION_DATE.plusDays(1));
+        activeDirector3.setResignationDate(RESIGNATION_DATE);
+
+        DirectorApi inactiveDirector = new DirectorApi();
+        inactiveDirector.setName("inactive");
+        inactiveDirector.setAppointmentDate(APPOINTMENT_DATE);
+        inactiveDirector.setResignationDate(RESIGNATION_DATE);
+
+        allDirectorsApi[0] = activeDirector;
+        allDirectorsApi[1] = activeDirector2;
+        allDirectorsApi[2] = activeDirector3;
+        allDirectorsApi[3] = inactiveDirector;
+
+        return allDirectorsApi;
+    }
+
+    private Director[] createArrayOfDirectors() {
+
+        Director[] allDirectors = new Director[3];
+
+        Director activeDirector = new Director();
+        activeDirector.setName("active");
+        activeDirector.setAppointmentDate(null);
+        activeDirector.setResignationDate(null);
+
+        Director activeDirector2 = new Director();
+        activeDirector2.setName("active2");
+        activeDirector2.setAppointmentDate(APPOINTMENT_DATE);
+        activeDirector2.setResignationDate(null);
+
+        Director activeDirector3 = new Director();
+        activeDirector3.setName("active3");
+        activeDirector3.setAppointmentDate(RESIGNATION_DATE.plusDays(1));
+        activeDirector3.setResignationDate(RESIGNATION_DATE);
+
+        allDirectors[0] = activeDirector;
+        allDirectors[1] = activeDirector2;
+        allDirectors[2] = activeDirector3;
+
+        return allDirectors;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorServiceImplTest.java
@@ -140,7 +140,7 @@ public class DirectorServiceImplTest {
         Director[] allDirectors = new Director[1];
         when(directorTransformer.getAllDirectors(directors)).thenReturn(allDirectors);
 
-        Director[] response = directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+        Director[] response = directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false);
 
         assertEquals(allDirectors, response);
     }
@@ -158,7 +158,7 @@ public class DirectorServiceImplTest {
         when(directorGetAll.execute()).thenThrow(apiErrorResponseException);
         doNothing().when(serviceExceptionHandler).handleRetrievalException(apiErrorResponseException, RESOURCE_NAME);
 
-        Director[] response = directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+        Director[] response = directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false);
 
         assertNotNull(response);
         assertEquals(0, response.length);
@@ -177,7 +177,7 @@ public class DirectorServiceImplTest {
         when(directorGetAll.execute()).thenThrow(apiErrorResponseException);
         doThrow(ServiceException.class).when(serviceExceptionHandler).handleRetrievalException(apiErrorResponseException, RESOURCE_NAME);
 
-        assertThrows(ServiceException.class, () -> directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+        assertThrows(ServiceException.class, () -> directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class DirectorServiceImplTest {
         when(directorGetAll.execute()).thenThrow(uriValidationException);
         doThrow(ServiceException.class).when(serviceExceptionHandler).handleURIValidationException(uriValidationException, RESOURCE_NAME);
 
-        assertThrows(ServiceException.class, () -> directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
+        assertThrows(ServiceException.class, () -> directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorsReportReviewServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/DirectorsReportReviewServiceImplTest.java
@@ -74,7 +74,7 @@ public class DirectorsReportReviewServiceImplTest {
     void getReview() throws ServiceException {
 
         Director[] directors = new Director[]{new Director()};
-        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false))
                 .thenReturn(directors);
 
         when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID))


### PR DESCRIPTION
-Capture the API error thrown back when a directors report cross validation to LoansToDirectors is fired.

-Implement functionality where if a directors report exists then we change the Name free text field on the LTD page to a list of radio buttons (a list of valid director names from the directors report).

-Handle error tracking on the page and ensure if bindingResults occur then the radio buttons stay on the page.

-Add new unit tests to cover new functionality and adjust existing unit tests to cover code layout changes.

Pair programmed with Matt Reis.

