### PR TITLE
Resolve issue with LTD Question page

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/LoansToDirectorsQuestionController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/LoansToDirectorsQuestionController.java
@@ -89,8 +89,10 @@ public class LoansToDirectorsQuestionController extends BaseController {
         try {
             LoansToDirectorsApi loansToDirectorsApi = loansToDirectorsService.getLoansToDirectors(apiClient, transactionId, companyAccountsId);
 
-            if (loansToDirectorsQuestion.getHasIncludedLoansToDirectors() && loansToDirectorsApi == null) {
+            if (loansToDirectorsQuestion.getHasIncludedLoansToDirectors()) {
+                if (loansToDirectorsApi == null) {
                     loansToDirectorsService.createLoansToDirectors(transactionId, companyAccountsId);
+                }
             } else {
                 if (loansToDirectorsApi != null) {
                     if (loansToDirectorsApi.getLinks().getAdditionalInformation() != null) {


### PR DESCRIPTION
- Resolves issue with loans to directors question page where if users go to the ltd question, select 'yes', and add some loans. Click the back button on the page (the chs one, not the browser one) and resubmit with 'yes' selected then the loans to directors resource gets deleted - including all of the loans users would just added

Resolves: BI-5012