### PR TITLE
Add comma to the figures

### DIFF
--- a/src/main/resources/templates/smallfull/review.html
+++ b/src/main/resources/templates/smallfull/review.html
@@ -1461,7 +1461,7 @@
 
                         <div class="govuk-grid-row">
                             <strong class="govuk-grid-column-one-half cya-desktop-only" th:id="loans-director-name[__${stat.index}__]">Name of director receiving advance or credit</strong>
-                            <div class="mobile-only-label column-fifth column-flexs">
+                            <div class="mobile-only-label column-fifth column-flex-with-min-width">
                                 <strong th:id="mobile-loans-director-name[__${stat.index}__]">Name of director receiving advance or credit</strong>
                             </div>
                             <div class="govuk-grid-column-one-half cya-desktop-only govuk-table__cell--numeric ">
@@ -1469,7 +1469,7 @@
                                         th:text="${loan.directorName}">
                                 </strong>
                             </div>
-                            <div class="mobile-only-label column-fifth column-flexs govuk-!-margin-top-4">
+                            <div class="mobile-only-label column-fifth column-flex-with-min-width govuk-!-margin-top-4">
                                 <strong th:id="mobile-review-director-name[__${stat.index}__]"
                                         th:text="${loan.directorName}">
                                 </strong>
@@ -1480,7 +1480,7 @@
                                 Description of the loan
                             </p>
 
-                            <div class="mobile-only-label column-fifth column-flexs govuk-!-margin-top-4">
+                            <div class="mobile-only-label column-fifth column-flex-with-min-width govuk-!-margin-top-4">
                                 <span th:id="mobile-loans-table-breakdown-description-header[__${stat.index}__]">
                                     Description of the loan
                                 </span>
@@ -1489,20 +1489,13 @@
                                   th:id="loans-table-breakdown-description[__${stat.index}__]"
                                   th:text="${loan.description}">
                             </div>
-                            <div class="mobile-only-label column-fifth column-flexs govuk-!-margin-top-4">
+                            <div class="mobile-only-label column-fifth column-flex-with-min-width govuk-!-margin-top-4">
                                 <span th:id="mobile-loans-table-breakdown-description[__${stat.index}__]"
                                         th:text="${loan.description}">
                                 </span>
                             </div>
                         </div>
-                        <div class="govuk-grid-row govuk-!-margin-top-4">
-                            <div class="govuk-grid-column-one-half govuk-body"></div>
-                            <div class="govuk-grid-column-one-half column-flex cya-desktop-only govuk-table__cell--numeric">
-                                <strong th:id="loans-table-breakdown-currency[__${stat.index}__]">
-                                    £
-                                </strong>
-                            </div>
-                        </div>
+
                         <div class="govuk-grid-row govuk-!-margin-top-4">
                             <div class="govuk-grid-column-one-half govuk-body cya-desktop-only"
                                  th:id="loans-table-breakdown-balance-at-period-start-heading[__${stat.index}__]"
@@ -1510,11 +1503,11 @@
                             </div>
                             <div class="mobile-only-label column-fifth">
                                             <span th:id="loans-table-breakdown-balance-at-period-start-mobile-heading[__${stat.index}__]"
-                                                  th:text="'Balance at ' + *{#temporals.format(periodStartOn, 'd MMMM yyyy')} + ' in £'"></span>
+                                                  th:text="'Balance at ' + *{#temporals.format(periodStartOn, 'd MMMM yyyy')}"></span>
                             </div>
-                            <div class="govuk-grid-column-one-half column-flexs govuk-table__cell--numeric">
+                            <div class="govuk-grid-column-one-half column-flex-with-min-width govuk-table__cell--numeric">
                                             <span th:id="loans-table-breakdown-balance-at-period-start[__${stat.index}__]"
-                                                  th:text="${loan.breakdown.balanceAtPeriodStart}">
+                                                  th:text="${new java.text.DecimalFormat('£###,###;-£###,###').format(loan.breakdown.balanceAtPeriodStart)}">
                                             </span>
                             </div>
                         </div>
@@ -1525,12 +1518,12 @@
                             </div>
                             <div class="mobile-only-label column-fifth">
                                             <span th:id="loans-table-breakdown-advances-and-credits-made-mobile-heading[__${stat.index}__]">
-                                                Advances and credits made in £
+                                                Advances and credits made
                                             </span>
                             </div>
-                            <div class="govuk-grid-column-one-half column-flexs govuk-table__cell--numeric">
+                            <div class="govuk-grid-column-one-half column-flex-with-min-width govuk-table__cell--numeric">
                                             <span th:id="loans-table-breakdown-advances-and-credits-made[__${stat.index}__]"
-                                                  th:text="${loan.breakdown.advancesCreditsMade}">
+                                                  th:text="${new java.text.DecimalFormat('£###,###;-£###,###').format(loan.breakdown.advancesCreditsMade)}">
                                             </span>
                             </div>
                         </div>
@@ -1541,12 +1534,12 @@
                             </div>
                             <div class="mobile-only-label column-fifth">
                                             <span th:id="loans-table-breakdown-advances-and-credits-repaid-mobile-heading[__${stat.index}__]">
-                                                Advances and credits repaid in £
+                                                Advances and credits repaid
                                             </span>
                             </div>
-                            <div class="govuk-grid-column-one-half column-flexs govuk-table__cell--numeric">
+                            <div class="govuk-grid-column-one-half column-flex-with-min-width govuk-table__cell--numeric">
                                             <span th:id="loans-table-breakdown-advances-and-credits-repaid[__${stat.index}__]"
-                                                  th:text="${loan.breakdown.advancesCreditsRepaid}">
+                                                  th:text="${new java.text.DecimalFormat('£###,###;-£###,###').format(loan.breakdown.advancesCreditsRepaid)}">
                                             </span>
                             </div>
                         </div>
@@ -1558,11 +1551,11 @@
                             </div>
                             <div class="mobile-only-label column-fifth">
                                 <strong th:id="loans-table-breakdown-balance-at-period-end-mobile-heading[__${stat.index}__]"
-                                        th:text="'Balance at ' + *{#temporals.format(periodEndOn, 'd MMMM yyyy')} + ' in £'"></strong>
+                                        th:text="'Balance at ' + *{#temporals.format(periodEndOn, 'd MMMM yyyy')}"></strong>
                             </div>
-                            <div class="govuk-grid-column-one-half column-flexs govuk-table__cell--numeric">
+                            <div class="govuk-grid-column-one-half column-flex-with-min-width govuk-table__cell--numeric">
                                 <strong th:id="loans-table-breakdown-balance-at-period-end[__${stat.index}__]"
-                                        th:text="${loan.breakdown.balanceAtPeriodEnd}">
+                                        th:text="${new java.text.DecimalFormat('£###,###;-£###,###').format(loan.breakdown.balanceAtPeriodEnd)}">
                                 </strong>
                             </div>
                         </div>


### PR DESCRIPTION
- Add comma to the loans figures and remove £ sign from the top and add it to individual figures so that it is consistent with rest of the balance sheet

Resolves: BI-4784