### PR TITLE
Implement LTD DR warning banner on dr page

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsController.java
@@ -98,7 +98,7 @@ public class AddOrRemoveDirectorsController extends BaseController implements Co
             return ERROR_VIEW;
         }
 
-        addOrRemoveDirectors.setDisplayWarningBanner(displayLoansToDirectorsWarning);
+        addOrRemoveDirectors.setDisplayLtdWarningBanner(displayLoansToDirectorsWarning);
 
         model.addAttribute(ADD_OR_REMOVE_DIRECTORS, addOrRemoveDirectors);
         model.addAttribute(COMPANY_NUMBER, companyNumber);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import org.springframework.web.util.UriTemplate;
+import uk.gov.companieshouse.api.model.accounts.smallfull.loanstodirectors.LoansToDirectorsApi;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
@@ -23,6 +24,7 @@ import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.directorsreport.AddOrRemoveDirectors;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorsReportService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.LoansToDirectorsService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
 import java.util.List;
@@ -49,10 +51,15 @@ public class AddOrRemoveDirectorsController extends BaseController implements Co
     @Autowired
     private ApiClientService apiClientService;
 
+    @Autowired
+    private LoansToDirectorsService loansToDirectorsService;
+
     private static final UriTemplate URI =
             new UriTemplate("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/add-or-remove-directors");
 
     private static final String ADD_OR_REMOVE_DIRECTORS = "addOrRemoveDirectors";
+
+    private static final String DISPLAY_LTD_WARNING = "displayLoansToDirectorsWarning";
 
     private static final String COMPANY_NUMBER = "companyNumber";
 
@@ -70,6 +77,9 @@ public class AddOrRemoveDirectorsController extends BaseController implements Co
 
         AddOrRemoveDirectors addOrRemoveDirectors = new AddOrRemoveDirectors();
 
+        boolean displayLoansToDirectorsWarning = false;
+        LoansToDirectorsApi loansToDirectorsApi;
+
         try {
             addOrRemoveDirectors.setExistingDirectors(
                     directorService.getAllDirectors(transactionId, companyAccountsId, false));
@@ -77,11 +87,18 @@ public class AddOrRemoveDirectorsController extends BaseController implements Co
             addOrRemoveDirectors.setSecretary(
                     secretaryService.getSecretary(transactionId, companyAccountsId));
 
+            loansToDirectorsApi = loansToDirectorsService.getLoansToDirectors(apiClientService.getApiClient(), transactionId, companyAccountsId);
+            if (loansToDirectorsApi != null && loansToDirectorsApi.getLoans() != null) {
+                displayLoansToDirectorsWarning = !loansToDirectorsApi.getLoans().isEmpty();
+            }
+
         } catch (ServiceException e) {
 
             LOGGER.errorRequest(request, e.getMessage(), e);
             return ERROR_VIEW;
         }
+
+        addOrRemoveDirectors.setDisplayWarningBanner(displayLoansToDirectorsWarning);
 
         model.addAttribute(ADD_OR_REMOVE_DIRECTORS, addOrRemoveDirectors);
         model.addAttribute(COMPANY_NUMBER, companyNumber);

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/directorsreport/AddOrRemoveDirectors.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/directorsreport/AddOrRemoveDirectors.java
@@ -6,7 +6,7 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationModel;
 @ValidationModel
 public class AddOrRemoveDirectors {
 
-    private boolean displayWarningBanner;
+    private boolean displayLtdWarningBanner;
 
     private Director[] existingDirectors;
 
@@ -40,11 +40,11 @@ public class AddOrRemoveDirectors {
         this.secretary = secretary;
     }
 
-    public boolean isDisplayWarningBanner() {
-        return displayWarningBanner;
+    public boolean isDisplayLtdWarningBanner() {
+        return displayLtdWarningBanner;
     }
 
-    public void setDisplayWarningBanner(boolean displayWarningBanner) {
-        this.displayWarningBanner = displayWarningBanner;
+    public void setDisplayLtdWarningBanner(boolean displayLtdWarningBanner) {
+        this.displayLtdWarningBanner = displayLtdWarningBanner;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/model/directorsreport/AddOrRemoveDirectors.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/model/directorsreport/AddOrRemoveDirectors.java
@@ -6,6 +6,8 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationModel;
 @ValidationModel
 public class AddOrRemoveDirectors {
 
+    private boolean displayWarningBanner;
+
     private Director[] existingDirectors;
 
     private DirectorToAdd directorToAdd;
@@ -36,5 +38,13 @@ public class AddOrRemoveDirectors {
 
     public void setSecretary(String secretary) {
         this.secretary = secretary;
+    }
+
+    public boolean isDisplayWarningBanner() {
+        return displayWarningBanner;
+    }
+
+    public void setDisplayWarningBanner(boolean displayWarningBanner) {
+        this.displayWarningBanner = displayWarningBanner;
     }
 }

--- a/src/main/resources/templates/smallfull/addOrRemoveDirectors.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveDirectors.html
@@ -17,6 +17,14 @@
                 <div th:replace="fragments/globalErrors :: globalErrors"></div>
             </form>
 
+            <div th:object="${addOrRemoveDirectors}">
+                <input type="hidden" th:field="*{displayWarningBanner}" th:id="display-ltd-flag"/>
+                <p th:if="*{displayWarningBanner == true}" class="warning-note warning-note-large" id="ltd-removal-warning-note">
+                    If you make changes to the directors’ report, the information entered on the loans to directors note will need to be re-entered.
+                </p>
+            </div>
+
+
             <div th:replace="fragments/numberedHeading :: numberedHeading (
                   headingText = 'Directors\' report'
               )">

--- a/src/main/resources/templates/smallfull/addOrRemoveDirectors.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveDirectors.html
@@ -18,8 +18,8 @@
             </form>
 
             <div th:object="${addOrRemoveDirectors}">
-                <input type="hidden" th:field="*{displayWarningBanner}" th:id="display-ltd-flag"/>
-                <p th:if="*{displayWarningBanner == true}" class="warning-note warning-note-large" id="ltd-removal-warning-note">
+                <input type="hidden" th:field="*{displayLtdWarningBanner}" th:id="display-ltd-flag"/>
+                <p th:if="*{displayLtdWarningBanner == true}" class="warning-note warning-note-large" id="ltd-removal-warning-note">
                     If you make changes to the directors’ report, the information entered on the loans to directors note will need to be re-entered.
                 </p>
             </div>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
@@ -151,6 +151,50 @@ public class AddOrRemoveDirectorsControllerTest {
     }
 
     @Test
+    @DisplayName("Get add or remove directors view when a user has no LTD loans - success path")
+    void getRequestUserHasNoLTDLoansSuccess() throws Exception {
+
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false)).thenReturn(new Director[0]);
+
+        when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(SECRETARY_NAME);
+
+        when(loansToDirectorsService.getLoansToDirectors(apiClientService.getApiClient(), TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(loansToDirectorsApi);
+
+        when(loansToDirectorsApi.getLoans()).thenReturn(new HashMap<String, String>());
+
+        this.mockMvc.perform(get(ADD_OR_REMOVE_DIRECTORS_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ADD_OR_REMOVE_DIRECTORS_VIEW))
+                .andExpect(model().attributeExists(ADD_OR_REMOVE_DIRECTORS_MODEL_ATTR))
+                .andExpect(model().attributeExists(COMPANY_NUMBER))
+                .andExpect(model().attributeExists(TRANSACTION_ID))
+                .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
+    }
+
+    @Test
+    @DisplayName("Get add or remove directors view when a user has null LTD loans - success path")
+    void getRequestUserHasNullLTDLoansSuccess() throws Exception {
+
+        when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false)).thenReturn(new Director[0]);
+
+        when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(SECRETARY_NAME);
+
+        when(loansToDirectorsService.getLoansToDirectors(apiClientService.getApiClient(), TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(loansToDirectorsApi);
+
+        when(loansToDirectorsApi.getLoans()).thenReturn(null);
+
+        this.mockMvc.perform(get(ADD_OR_REMOVE_DIRECTORS_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ADD_OR_REMOVE_DIRECTORS_VIEW))
+                .andExpect(model().attributeExists(ADD_OR_REMOVE_DIRECTORS_MODEL_ATTR))
+                .andExpect(model().attributeExists(COMPANY_NUMBER))
+                .andExpect(model().attributeExists(TRANSACTION_ID))
+                .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID))
+                .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
+    }
+
+    @Test
     @DisplayName("Get add or remove directors view when a user has existing LTD loans - success path")
     void getRequestUserHasLTDLoansSuccess() throws Exception {
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
@@ -151,17 +151,15 @@ public class AddOrRemoveDirectorsControllerTest {
     }
 
     @Test
-    @DisplayName("Get add or remove directors view when a user has no LTD loans - success path")
-    void getRequestUserHasNoLTDLoansSuccess() throws Exception {
+    @DisplayName("Get add or remove directors view LTD resource is null- success path")
+    void getRequestWithNullLTDResourceSuccess() throws Exception {
 
         when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false)).thenReturn(new Director[0]);
 
         when(secretaryService.getSecretary(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(SECRETARY_NAME);
 
-        when(loansToDirectorsService.getLoansToDirectors(apiClientService.getApiClient(), TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(loansToDirectorsApi);
-
-        when(loansToDirectorsApi.getLoans()).thenReturn(new HashMap<String, String>());
-
+        when(loansToDirectorsService.getLoansToDirectors(apiClientService.getApiClient(), TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(null);
+        
         this.mockMvc.perform(get(ADD_OR_REMOVE_DIRECTORS_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(ADD_OR_REMOVE_DIRECTORS_VIEW))
@@ -173,8 +171,8 @@ public class AddOrRemoveDirectorsControllerTest {
     }
 
     @Test
-    @DisplayName("Get add or remove directors view when a user has null LTD loans - success path")
-    void getRequestUserHasNullLTDLoansSuccess() throws Exception {
+    @DisplayName("Get add or remove directors view when a user has no LTD loans - success path")
+    void getRequestUserHasNoLTDLoansSuccess() throws Exception {
 
         when(directorService.getAllDirectors(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, false)).thenReturn(new Director[0]);
 
@@ -182,7 +180,7 @@ public class AddOrRemoveDirectorsControllerTest {
 
         when(loansToDirectorsService.getLoansToDirectors(apiClientService.getApiClient(), TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(loansToDirectorsApi);
 
-        when(loansToDirectorsApi.getLoans()).thenReturn(null);
+        when(loansToDirectorsApi.getLoans()).thenReturn(new HashMap<String, String>());
 
         this.mockMvc.perform(get(ADD_OR_REMOVE_DIRECTORS_PATH))
                 .andExpect(status().isOk())

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveDirectorsControllerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.web.accounts.controller.smallfull;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,7 +27,6 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
@@ -122,6 +123,8 @@ public class AddOrRemoveDirectorsControllerTest {
 
     private static final String COMPANY_ACCOUNTS_DATA_STATE = "companyAccountsDataState";
 
+    private static final String DISPLAY_WARNING_BANNER = "displayLtdWarningBanner";
+
     @BeforeEach
     private void setup() {
 
@@ -167,6 +170,7 @@ public class AddOrRemoveDirectorsControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NUMBER))
                 .andExpect(model().attributeExists(TRANSACTION_ID))
                 .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID))
+                .andExpect(model().attribute(ADD_OR_REMOVE_DIRECTORS_MODEL_ATTR, hasProperty(DISPLAY_WARNING_BANNER, is(false))))
                 .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
@@ -189,6 +193,7 @@ public class AddOrRemoveDirectorsControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NUMBER))
                 .andExpect(model().attributeExists(TRANSACTION_ID))
                 .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID))
+                .andExpect(model().attribute(ADD_OR_REMOVE_DIRECTORS_MODEL_ATTR, hasProperty(DISPLAY_WARNING_BANNER, is(false))))
                 .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
@@ -211,6 +216,7 @@ public class AddOrRemoveDirectorsControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NUMBER))
                 .andExpect(model().attributeExists(TRANSACTION_ID))
                 .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID))
+                .andExpect(model().attribute(ADD_OR_REMOVE_DIRECTORS_MODEL_ATTR, hasProperty(DISPLAY_WARNING_BANNER, is(true))))
                 .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 


### PR DESCRIPTION
Implement the banner which will warn users that if they have a LTD resource with loans, and they choose to edit the DR page, then their LTD will be deleted and will need to be re-entered.

-Added unit tests where needed.