### PR TITLE
Hide balance at period start on loans

### DIFF
--- a/src/main/resources/templates/smallfull/review.html
+++ b/src/main/resources/templates/smallfull/review.html
@@ -1470,7 +1470,7 @@
                             </div>
                         </div>
 
-                        <div class="govuk-grid-row govuk-!-margin-top-4">
+                        <div class="govuk-grid-row govuk-!-margin-top-4" th:if="${loan.breakdown.balanceAtPeriodStart != null}">
                             <div class="govuk-grid-column-one-half govuk-body cya-desktop-only"
                                  th:id="review-loans-to-directors-balance-at-period-start[__${stat.index}__]-heading"
                                  th:text="'Balance at ' + *{#temporals.format(periodStartOn, 'd MMMM yyyy')}">


### PR DESCRIPTION
Add condition to check if the balance at period start is not null on a loan. This has been added for when the company is a single year filer this field will not be populated and therefore not displayed. This was causing an issue when rendering the review page.

BI-5145