### PR TITLE
Fix Sonar issues by changing pom parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,6 @@
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
         <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
 
-        <!-- Jacoco -->
-        <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -282,7 +280,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
 
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
-        <artifactId>companies-house-spring-boot-parent</artifactId>
-        <version>1.2.0</version>
+        <artifactId>companies-house-parent</artifactId>
+        <version>1.3.0</version>
     </parent>
 
     <properties>
@@ -52,7 +52,10 @@
 
         <spring-security-core.version>5.2.5.RELEASE</spring-security-core.version>
 
-        <spring-test.version>4.3.3.RELEASE</spring-test.version>
+        <spring-boot-dependencies.version>2.1.3.RELEASE</spring-boot-dependencies.version>
+        <spring-test.version>5.1.3.RELEASE</spring-test.version>
+        <spring-boot-maven-plugin.version>2.1.3.RELEASE</spring-boot-maven-plugin.version>
+
 
         <!-- Maven and Surefire plugins -->
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
@@ -63,6 +66,18 @@
         <!-- Jacoco -->
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -268,21 +283,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <id>default-prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes failure to gather Sonar coverage reports.

We changed Sonar and, in doing so, needed to upgrade to use a more
 recent companies house parent pom. Just changing to use a newer
 companies-house-spring-boot-parent did not work breaking lots of
 tests. We are not supposed to use that as a parent any more, so
 this is a chance to use the proper companies-house-parent. In doing
 so, other changes to pull in correct spring dependencies were
 needed.