### PR TITLE
change will-render method too use API

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalController.java
@@ -11,8 +11,10 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import uk.gov.companieshouse.api.model.accounts.directorsreport.DirectorsReportApi;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
+import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.controller.ConditionalController;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
@@ -21,6 +23,7 @@ import uk.gov.companieshouse.web.accounts.model.directorsreport.DirectorsReportA
 import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorsReportApprovalService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorsReportService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SecretaryService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
@@ -42,7 +45,13 @@ public class DirectorsReportApprovalController extends BaseController implements
     private DirectorsReportApprovalService directorsReportApprovalService;
 
     @Autowired
+    private DirectorsReportService directorsReportService;
+
+    @Autowired
     private DirectorService directorService;
+
+    @Autowired
+    private ApiClientService apiClientService;
 
     @Autowired
     private SecretaryService secretaryService;
@@ -139,7 +148,8 @@ public class DirectorsReportApprovalController extends BaseController implements
     public boolean willRender(String companyNumber, String transactionId, String companyAccountsId)
             throws ServiceException {
 
-        CompanyAccountsDataState companyAccountsDataState = getStateFromRequest(request);
-        return BooleanUtils.isTrue(companyAccountsDataState.getHasIncludedDirectorsReport());
+        DirectorsReportApi directorsReportApi = directorsReportService.getDirectorsReport(apiClientService.getApiClient(), transactionId, companyAccountsId);
+
+        return directorsReportApi != null;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/DirectorsReportApprovalControllerTest.java
@@ -13,6 +13,9 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
+import uk.gov.companieshouse.api.ApiClient;
+import uk.gov.companieshouse.api.model.accounts.directorsreport.DirectorsReportApi;
+import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.directorsreport.Director;
 import uk.gov.companieshouse.web.accounts.model.directorsreport.DirectorsReportApproval;
@@ -20,6 +23,7 @@ import uk.gov.companieshouse.web.accounts.model.state.CompanyAccountsDataState;
 import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorsReportApprovalService;
+import uk.gov.companieshouse.web.accounts.service.smallfull.DirectorsReportService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SecretaryService;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 
@@ -54,6 +58,12 @@ class DirectorsReportApprovalControllerTest {
     private DirectorsReportApprovalService directorsReportApprovalService;
 
     @Mock
+    private DirectorsReportService directorsReportService;
+
+    @Mock
+    private DirectorsReportApi directorsReportApi;
+
+    @Mock
     private DirectorService directorService;
 
     @Mock
@@ -79,6 +89,12 @@ class DirectorsReportApprovalControllerTest {
 
     @Mock
     private Director director;
+
+    @Mock
+    private ApiClientService apiClientService;
+
+    @Mock
+    private ApiClient apiClient;
 
     @InjectMocks
     private DirectorsReportApprovalController controller;
@@ -245,9 +261,8 @@ class DirectorsReportApprovalControllerTest {
     @DisplayName("Will render - false")
     void willRenderFalse() throws ServiceException {
 
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(COMPANY_ACCOUNTS_DATA_STATE)).thenReturn(companyAccountsDataState);
-        when(companyAccountsDataState.getHasIncludedDirectorsReport()).thenReturn(false);
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(directorsReportService.getDirectorsReport(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(null);
 
         assertFalse(controller.willRender(COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
     }
@@ -256,9 +271,8 @@ class DirectorsReportApprovalControllerTest {
     @DisplayName("Will render - true")
     void willRenderTrue() throws ServiceException {
 
-        when(request.getSession()).thenReturn(session);
-        when(session.getAttribute(COMPANY_ACCOUNTS_DATA_STATE)).thenReturn(companyAccountsDataState);
-        when(companyAccountsDataState.getHasIncludedDirectorsReport()).thenReturn(true);
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(directorsReportService.getDirectorsReport(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(directorsReportApi);
 
         assertTrue(controller.willRender(COMPANY_NUMBER, TRANSACTION_ID, COMPANY_ACCOUNTS_ID));
     }


### PR DESCRIPTION
linked too the issue raised on story SFA-3230. A user could possibly skip the approval page accidentally if their JWT token deleted the state, or if they changed browsers and the state wasn't shared between those browsers...

Now it will always grab the resource from the API and if a user has a directors report, it will always show the approval page.