### PR TITLE
remove auto selection of radio buttons due to minimum being 2 not 1 now

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
@@ -99,10 +99,6 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
                 validDirectorNames.add(director.getName());
             }
 
-            if (validDirectorNames.size() == 1) {
-                addOrRemoveLoans.getLoanToAdd().setDirectorName(validDirectorNames.get(0));
-            }
-
             if(!validDirectorNames.isEmpty()) {
                 validDirectorNames.add(PREFER_NOT_TO_SAY);
             }


### PR DESCRIPTION
New radio button "Prefer not to say" is always present if a DR is present, meaning auto selecting the first choice if only one DR name is present causes validation to stick and not let user pass.