### PR TITLE
Resolve issues with disappearing text

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveLoansController.java
@@ -174,6 +174,8 @@ public class AddOrRemoveLoansController extends BaseController implements Condit
             List<ValidationError> validationErrors = loanService.createLoan(transactionId, companyAccountsId, addOrRemoveLoans);
 
             if(!validationErrors.isEmpty()) {
+                addOrRemoveLoans.setExistingLoans(
+                        loanService.getAllLoans(transactionId, companyAccountsId));
                 bindValidationErrors(bindingResult, validationErrors);
                 return getTemplateName();
             }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/validation/smallfull/LoanValidator.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/validation/smallfull/LoanValidator.java
@@ -16,6 +16,9 @@ public class LoanValidator {
     private static final String DESCRIPTION = LOAN_TO_ADD + ".description";
     private static final String DESCRIPTION_NOT_PRESENT = "validation.element.missing.loanToAdd.description";
 
+    private static final String DIRECTOR_NAME = LOAN_TO_ADD + ".directorName";
+    private static final String DIRECTOR_NAME_NOT_PRESENT = "validation.element.missing.loanToAdd.directorName";
+
     private static final String BALANCE_AT_START = LOAN_TO_ADD + ".breakdown.balanceAtPeriodStart";
     private static final String BAS_NOT_PRESENT = "validation.element.missing.loanToAdd.breakdown.balanceAtPeriodStart";
 
@@ -24,9 +27,17 @@ public class LoanValidator {
 
     private static final String AT_LEAST_ONE_LOAN_REQUIRED = "validation.addOrRemoveLoans.oneRequired";
 
-    public List<ValidationError> validateLoanToAdd(LoanToAdd loanToAdd, Boolean isMultiYearFiler) {
+    public List<ValidationError> validateLoanToAdd(LoanToAdd loanToAdd, Boolean isMultiYearFiler, boolean directorReportPresent) {
 
         List<ValidationError> validationErrors = new ArrayList<>();
+
+        if (directorReportPresent && StringUtils.isBlank(loanToAdd.getDirectorName())) {
+
+            ValidationError error = new ValidationError();
+            error.setFieldPath(DIRECTOR_NAME);
+            error.setMessageKey(DIRECTOR_NAME_NOT_PRESENT);
+            validationErrors.add(error);
+        }
 
         if (StringUtils.isBlank(loanToAdd.getDescription())) {
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -487,7 +487,7 @@ loanToAdd.breakdown.balanceAtPeriodEnd = Balance at period end:
 loanToAdd.breakdown.advancesCreditsMade = Advances and credits made:
 loanToAdd.breakdown.advancesCreditsRepaid = Advances and credits repaid:
 
-validation.element.missing.loanToAdd.directorName = Enter the director's name
+validation.element.missing.loanToAdd.directorName = Enter the director's name or select 'Prefer not to say'
 validation.cross_validation_dr_ltd.loan.director_name = Name provided must match one previously given in the directors report
 validation.element.missing.loanToAdd.description = Enter a description
 validation.element.missing.loanToAdd.breakdown.balanceAtPeriodStart = Enter a value

--- a/src/main/resources/templates/smallfull/addOrRemoveLoans.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveLoans.html
@@ -53,7 +53,7 @@
                         <th th:id="loans-table-director-name[__${stat.index}__]"
                             class="govuk-table__header--summary"
                             scope="row"
-                            th:text="${loan.directorName != null ? loan.directorName : 'Not provided'}">
+                            th:text="${loan.directorName}">
                         </th>
                         <td th:id="loans-table-balance-at-period-end[__${stat.index}__]"
                             class="govuk-table__cell--summary"
@@ -150,7 +150,7 @@
                                     <div class="govuk-grid-row">
                                         <div class="govuk-grid-column-one-half govuk-body cya-desktop-only">
                                             <strong th:id="loans-table-breakdown-balance-at-period-end-heading[__${stat.index}__]"
-                                                    th:text="'Balance at ' + ${#temporals.format(addOrRemoveLoans.nextAccount.periodStartOn, 'd MMMM yyyy')}">
+                                                    th:text="'Balance at ' + ${#temporals.format(addOrRemoveLoans.nextAccount.periodEndOn, 'd MMMM yyyy')}">
                                             </strong>
                                         </div>
                                         <div class="mobile-only-label column-fifth">
@@ -222,33 +222,6 @@
                                   type="text" rows="1">
                             </textarea>
                         </div>
-                    </th:block>
-
-                    <th:block th:if="*{validDirectorNames != null and validDirectorNames.size() == 1}">
-                        <label id="loanToAdd-director-name-label-single-radio"
-                               class="govuk-label govuk-label--m"
-                               for="loanToAdd-director-name">
-                            Name of director receiving advance or credit (optional)
-                        </label>
-                        <dl class="app-check-your-answers app-check-your-answers--very-long">
-                            <div class="app-check-your-answers__contents">
-                                <dt class="app-check-your-answers__question"
-                                    th:text="*{validDirectorNames[0]}"
-                                    th:id="0-label">
-                                </dt>
-                                <dd class="app-check-your-answers__change">
-                                    <a id="director-change-link"
-                                       th:href="@{|/company/${companyNumber}/transaction/${transactionId}/company-accounts/${companyAccountsId}/small-full/add-or-remove-directors|}"
-                                       class="govuk-body piwik-event"
-                                       data-event-id="Change director - LTD">
-                                        Change
-                                    </a>
-                                </dd>
-
-                                <input th:field="*{loanToAdd.directorName}" type="hidden">
-
-                            </div>
-                        </dl>
                     </th:block>
 
                     <th:block th:if="*{validDirectorNames != null and validDirectorNames.size() > 1}">

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/LoansServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/LoansServiceImplTest.java
@@ -1,20 +1,6 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -44,6 +30,20 @@ import uk.gov.companieshouse.web.accounts.util.ValidationContext;
 import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 import uk.gov.companieshouse.web.accounts.validation.helper.ServiceExceptionHandler;
 import uk.gov.companieshouse.web.accounts.validation.smallfull.LoanValidator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -140,10 +140,11 @@ class LoansServiceImplTest {
         when(loansToDirectorsResourceHandler.loans()).thenReturn(loansResourceHandler);
         when(loansResourceHandler.getAll(LOANS_URI)).thenReturn(loanGetAll);
         when(loanGetAll.execute()).thenReturn(responseWithMultipleLoans);
-        LoanApi[] loanApi = new LoanApi[1];
-        when(responseWithMultipleLoans.getData()).thenReturn(loanApi);
+        LoanApi[] loansApi = new LoanApi[1];
+        loansApi[0] = new LoanApi();
+        when(responseWithMultipleLoans.getData()).thenReturn(loansApi);
         Loan[] allLoans = new Loan[1];
-        when(loanTransformer.getAllLoans(loanApi)).thenReturn(allLoans);
+        when(loanTransformer.getAllLoans(loansApi)).thenReturn(allLoans);
 
         Loan[] response = loansService.getAllLoans(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
@@ -243,7 +244,7 @@ class LoansServiceImplTest {
 
         mockAddOrRemoveLoans.setIsMultiYearFiler(true);
         
-        when(loanValidator.validateLoanToAdd(loanToAdd, mockAddOrRemoveLoans.getIsMultiYearFiler())).thenReturn(new ArrayList<>());
+        when(loanValidator.validateLoanToAdd(loanToAdd, mockAddOrRemoveLoans.getIsMultiYearFiler(), false)).thenReturn(new ArrayList<>());
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
 
@@ -273,7 +274,7 @@ class LoansServiceImplTest {
     void createLoanValidationForSingleYearFiler()
             throws ServiceException, ApiErrorResponseException, URIValidationException {
 
-        when(loanValidator.validateLoanToAdd(loanToAdd, false)).thenReturn(new ArrayList<>());
+        when(loanValidator.validateLoanToAdd(loanToAdd, false, false)).thenReturn(new ArrayList<>());
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
 
@@ -310,7 +311,7 @@ class LoansServiceImplTest {
         
         when(mockAddOrRemoveLoans.getLoanToAdd()).thenReturn(loanToAdd);
 
-        when(loanValidator.validateLoanToAdd(loanToAdd, mockAddOrRemoveLoans.getIsMultiYearFiler())).thenReturn(nameValidationError);
+        when(loanValidator.validateLoanToAdd(loanToAdd, mockAddOrRemoveLoans.getIsMultiYearFiler(), false)).thenReturn(nameValidationError);
 
         List<ValidationError> validationErrors = loansService.createLoan(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, mockAddOrRemoveLoans);
 
@@ -329,7 +330,7 @@ class LoansServiceImplTest {
 
         when(mockAddOrRemoveLoans.getLoanToAdd()).thenReturn(loanToAdd);
 
-        when(loanValidator.validateLoanToAdd(loanToAdd, false)).thenReturn(nameValidationError);
+        when(loanValidator.validateLoanToAdd(loanToAdd, false, false)).thenReturn(nameValidationError);
 
         List<ValidationError> validationErrors = loansService.createLoan(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, mockAddOrRemoveLoans);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/validation/smallfull/LoanValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/validation/smallfull/LoanValidatorTest.java
@@ -37,6 +37,7 @@ class LoanValidatorTest {
     private static final String BAE_NOT_PRESENT = "validation.element.missing.loanToAdd.breakdown.balanceAtPeriodEnd";
 
     private static final String AT_LEAST_ONE_LOAN_REQUIRED = "validation.addOrRemoveLoans.oneRequired";
+    private static final String DIRECTOR_REPORT_PRESENT_NAME_MISSING = "validation.element.missing.loanToAdd.directorName";
 
     @Test
     @DisplayName("Validate loan to add for multi year filer - success")
@@ -47,7 +48,7 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(true, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true, true);
 
         assertTrue(validationErrors.isEmpty());
     }
@@ -61,7 +62,7 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(false, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false, true);
 
         assertTrue(validationErrors.isEmpty());
     }
@@ -74,7 +75,7 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(true, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true, false);
 
         assertTrue(validationErrors.isEmpty());
         assertEquals(0, validationErrors.size());
@@ -88,10 +89,25 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(true, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false, false);
 
         assertTrue(validationErrors.isEmpty());
         assertEquals(0, validationErrors.size());
+    }
+
+    @Test
+    @DisplayName("Validate loan to add for single year filer - missing director name and directors report present")
+    void validateLoanToAddForSingleYearMissingDirectorNameWithDirectorsReportPresent() {
+
+        LoanToAdd loanToAdd = new LoanToAdd();
+        loanToAdd.setDescription(DESCRIPTION);
+        loanToAdd.setBreakdown(createBreakdown(true, true));
+
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false, true);
+
+        assertFalse(validationErrors.isEmpty());
+        assertEquals(1, validationErrors.size());
+        assertEquals(DIRECTOR_REPORT_PRESENT_NAME_MISSING, validationErrors.get(0).getMessageKey());
     }
 
     @Test
@@ -102,7 +118,7 @@ class LoanValidatorTest {
         loanToAdd.setDirectorName(DIRECTOR_NAME);
         loanToAdd.setBreakdown(createBreakdown(true, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true, true);
 
         assertFalse(validationErrors.isEmpty());
         assertEquals(1, validationErrors.size());
@@ -118,7 +134,7 @@ class LoanValidatorTest {
         loanToAdd.setDirectorName(DIRECTOR_NAME);
         loanToAdd.setBreakdown(createBreakdown(true, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false, true);
 
         assertFalse(validationErrors.isEmpty());
         assertEquals(1, validationErrors.size());
@@ -135,7 +151,7 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(false, true));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true, true);
 
         assertFalse(validationErrors.isEmpty());
         assertEquals(1, validationErrors.size());
@@ -152,7 +168,7 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(true, false));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, true, true);
 
         assertFalse(validationErrors.isEmpty());
         assertEquals(1, validationErrors.size());
@@ -169,7 +185,7 @@ class LoanValidatorTest {
         loanToAdd.setDescription(DESCRIPTION);
         loanToAdd.setBreakdown(createBreakdown(true, false));
 
-        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false);
+        List<ValidationError> validationErrors = validator.validateLoanToAdd(loanToAdd, false, true);
 
         assertFalse(validationErrors.isEmpty());
         assertEquals(1, validationErrors.size());
@@ -409,7 +425,6 @@ class LoanValidatorTest {
         AddOrRemoveLoans addOrRemoveLoans = new AddOrRemoveLoans();
 
         addOrRemoveLoans.setIsMultiYearFiler(false);
-        addOrRemoveLoans.getLoanToAdd().setDirectorName(DIRECTOR_NAME);
         addOrRemoveLoans.getLoanToAdd().setBreakdown(createBreakdown(false, true));
 
         List<ValidationError> validationErrors = validator.validateAtLeastOneLoan(addOrRemoveLoans, true);


### PR DESCRIPTION
- Resolves issue related to text `Not provided` which disappears for previous loans when validation errors fire
- Resolves issues with disappearing field values for previous loans of the same director when validation fires
- Resolves text that displays as of period start but is actually period end
- Remove unnecessary code blocks from addOrRemoveLoans.html file
- Resolves issue where if no `director` or `Prefer not to say` is not selected
- Update unit tests

Resolves: BI-5474 