### PR TITLE
Add aria-label and role to nav element to fix axe accessibility issue

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -5,7 +5,7 @@
     </head>
     <body>
         <footer th:fragment="footer" class="group js-footer" id="footer" role="contentinfo">
-            <nav>
+            <nav aria-label="footer-nav" role="navigation">
                 <div>
                     <ul>
                         <li><a id="policies-link" href="http://resources.companieshouse.gov.uk/serviceInformation.shtml">Policies</a></li>


### PR DESCRIPTION
Axe was complaining that landmarks must have a unique role, and to fix this issue:

Fix the following:
The landmark must have a unique aria-label, aria-labelledby

So I have added an aria-label and role to the footer nav element to make it unique.