### PR TITLE
Add another related-party-transaction Transaction functionality & rpt question bug fix

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/RelatedPartyTransactionsQuestionController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/RelatedPartyTransactionsQuestionController.java
@@ -84,8 +84,10 @@ public class RelatedPartyTransactionsQuestionController extends BaseController {
         try {
             RelatedPartyTransactionsApi relatedPartyTransactionsApi = relatedPartyTransactionsService.getRelatedPartyTransactions(apiClient, transactionId, companyAccountsId);
 
-            if (Boolean.TRUE.equals(relatedPartyTransactionsQuestion.getHasIncludedRelatedPartyTransactions()) && relatedPartyTransactionsApi == null) {
-                relatedPartyTransactionsService.createRelatedPartyTransactions(transactionId, companyAccountsId);
+            if (Boolean.TRUE.equals(relatedPartyTransactionsQuestion.getHasIncludedRelatedPartyTransactions())) {
+                if (relatedPartyTransactionsApi == null) {
+                    relatedPartyTransactionsService.createRelatedPartyTransactions(transactionId, companyAccountsId);
+                }
             } else {
                 relatedPartyTransactionsService.deleteRelatedPartyTransactions(transactionId, companyAccountsId);
             }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
-import uk.gov.companieshouse.api.model.accounts.smallfull.loanstodirectors.LoanApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.relatedpartytransactions.RptTransactionApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;

--- a/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
@@ -13,6 +13,137 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
+            <table id="rptTransactions-table" class="govuk-table"
+                   th:if="${addOrRemoveTransactions.existingRptTransactions != null and addOrRemoveTransactions.existingRptTransactions.length > 0}">
+                <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                    <th id="rptTransactions-table-related-party-name-heading"
+                        class="govuk-table__header"
+                        scope="col">
+                        Name of related party
+                    </th>
+                    <th id="rptTransactions-table-balance-at-period-end-heading"
+                        class="govuk-table__header"
+                        scope="col"
+                        th:text="'Balance at ' + ${#temporals.format(addOrRemoveTransactions.nextAccount.periodEndOn, 'd MMMM yyyy')}">
+                    </th>
+                    <th class="govuk-table__header" scope="col"></th>
+                </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                <th:block th:each="transaction, stat : ${addOrRemoveTransactions.existingRptTransactions}">
+                    <tr class="govuk-table__row">
+                        <th th:id="rptTransactions-table-related-party-name[__${stat.index}__]"
+                            class="govuk-table__header--summary"
+                            scope="row"
+                            th:text="${transaction.nameOfRelatedParty}">
+                        </th>
+                        <td th:id="rptTransactions-table-balance-at-period-end[__${stat.index}__]"
+                            class="govuk-table__cell--summary"
+                            th:text="${new java.text.DecimalFormat('£###,###;-£###,###').format(transaction.breakdown.balanceAtPeriodEnd)}">
+                        </td>
+                        <td class="govuk-table__cell--summary">
+                            <form class="form" th:action="@{/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/note/add-or-remove-transactions/remove/{rptTransactionId}
+                                      (companyNumber=${companyNumber},transactionId=${transactionId},companyAccountsId=${companyAccountsId},rptTransactionId=${transaction.id})}"
+                                  method="get">
+                                <div class="flex-container-center-align">
+                                    <input th:id="rptTransactions-table-remove[__${stat.index}__]"
+                                           class="button-display-as-link piwik-event"
+                                           data-event-id="Related party transactions - remove transaction"
+                                           type="submit" role="button" value="Remove"/>
+                                </div>
+                            </form>
+                        </td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__cell" colspan="3">
+                            <details class="govuk-details" role="group">
+                                <summary class="govuk-details__summary" role="button"
+                                         th:aria-controls="rptTransactions-table-breakdown[__${stat.index}__]">
+                                          <span th:id="rptTransactions-table-breakdown-expand[__${stat.index}__]"
+                                                class="govuk-details__summary-text">
+                                            Expand
+                                          </span>
+                                </summary>
+                                <div class="review-reveal govuk-body govuk-!-margin-top-4"
+                                     th:id="rptTransactions-table-breakdown[__${stat.index}__]" aria-hidden="true">
+                                    <p>
+                                        <span th:id="rptTransactions-table-breakdown-transaction-type-header[__${stat.index}__]">
+                                            Transaction type
+                                        </span>
+                                        <br>
+                                        <span th:id="rptTransactions-table-breakdown-transaction-type[__${stat.index}__]"
+                                              th:text="${transaction.transactionType}">
+                                    </span>
+                                    </p>
+
+                                    <p>
+                                        <span th:id="rptTransactions-table-breakdown-relationship-to-company-header[__${stat.index}__]">
+                                            Relationship to company
+                                        </span>
+                                        <br>
+                                        <span th:id="rptTransactions-table-breakdown-relationship-to-company[__${stat.index}__]"
+                                              th:text="${transaction.relationship}">
+                                        </span>
+                                    </p>
+
+                                    <p>
+                                        <span th:id="rptTransactions-table-breakdown-description-header[__${stat.index}__]">
+                                            Description of the transaction
+                                        </span>
+                                        <br>
+                                        <span th:id="rptTransactions-table-breakdown-description[__${stat.index}__]"
+                                              th:text="${transaction.descriptionOfTransaction}">
+                                        </span>
+                                    </p>
+
+                                    <div class="govuk-grid-row">
+                                        <div class="govuk-grid-column-one-half govuk-body"></div>
+                                        <div class="govuk-grid-column-one-half column-flex govuk-summary__align--right cya-desktop-only">
+                                            <strong th:id="rptTransactions-table-breakdown-currency[__${stat.index}__]">
+                                                £
+                                            </strong>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-grid-row">
+                                        <div class="govuk-grid-column-one-half govuk-body cya-desktop-only"
+                                             th:id="rptTransactions-table-breakdown-balance-at-period-start-heading[__${stat.index}__]"
+                                             th:text="'Balance at ' + ${#temporals.format(addOrRemoveTransactions.nextAccount.periodStartOn, 'd MMMM yyyy')}">
+                                        </div>
+                                        <div class="mobile-only-label column-fifth">
+                                                <span th:id="rptTransactions-table-breakdown-balance-at-period-start-mobile-heading[__${stat.index}__]"
+                                                      th:text="'Balance at ' + ${#temporals.format(addOrRemoveTransactions.nextAccount.periodStartOn, 'd MMMM yyyy')} + ' in £'"></span>
+                                        </div>
+                                        <div class="govuk-grid-column-one-half column-flex govuk-summary__align--right">
+                                                <span th:id="rptTransactions-table-breakdown-balance-at-period-start[__${stat.index}__]"
+                                                      th:text="${transaction.breakdown.balanceAtPeriodStart}">
+                                                </span>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-grid-row">
+                                        <div class="govuk-grid-column-one-half govuk-body cya-desktop-only">
+                                            <strong th:id="rptTransactions-table-breakdown-balance-at-period-end-heading[__${stat.index}__]"
+                                                    th:text="'Balance at ' + ${#temporals.format(addOrRemoveTransactions.nextAccount.periodEndOn, 'd MMMM yyyy')}">
+                                            </strong>
+                                        </div>
+                                        <div class="mobile-only-label column-fifth">
+                                            <strong th:id="rptTransactions-table-breakdown-balance-at-period-end-mobile-heading[__${stat.index}__]"
+                                                    th:text="'Balance at ' + ${#temporals.format(addOrRemoveTransactions.nextAccount.periodEndOn, 'd MMMM yyyy')} + ' in £'"></strong>
+                                        </div>
+                                        <div class="govuk-grid-column-one-half column-flex govuk-summary__align--right">
+                                            <strong th:id="rptTransactions-table-breakdown-balance-at-period-end[__${stat.index}__]"
+                                                    th:text="${transaction.breakdown.balanceAtPeriodEnd}">
+                                            </strong>
+                                        </div>
+                                    </div>
+                                </div>
+                            </details>
+                        </td>
+                    </tr>
+                </th:block>
+                </tbody>
+            </table>
+
             <form th:object="${addOrRemoveTransactions}" id="data-submission-form" class="form currency-included-within-inputs govuk-body" th:action="@{''}" method="post">
                 <div th:replace="fragments/numberedHeading :: numberedHeading (
                   headingText = 'Related party transactions')">
@@ -22,9 +153,32 @@
                 <input th:field="*{nextAccount.periodStartOn}" type="hidden">
                 <input th:field="*{nextAccount.periodEndOn}" type="hidden">
 
+                <div th:each="transaction, stat : ${addOrRemoveTransactions.existingRptTransactions}">
+                    <input type="hidden" th:field="*{existingRptTransactions[__${stat.index}__].nameOfRelatedParty}"
+                           th:id="existingRptTransactions[__${stat.index}__].nameOfRelatedParty"/>
+                    <input type="hidden"
+                           th:field="*{existingRptTransactions[__${stat.index}__].breakdown.balanceAtPeriodEnd}"
+                           th:id="existingRptTransactions[__${stat.index}__].breakdown.balanceAtPeriodEnd"/>
+                    <input type="hidden"
+                           th:field="*{existingRptTransactions[__${stat.index}__].breakdown.balanceAtPeriodStart}"
+                           th:id="existingRptTransactions[__${stat.index}__].breakdown.balanceAtPeriodStart"/>
+                    <input type="hidden"
+                           th:field="*{existingRptTransactions[__${stat.index}__].descriptionOfTransaction}"
+                           th:id="existingRptTransactions[__${stat.index}__].descriptionOfTransaction"/>
+                    <input type="hidden"
+                           th:field="*{existingRptTransactions[__${stat.index}__].transactionType}"
+                           th:id="existingRptTransactions[__${stat.index}__].transactionType"/>
+                    <input type="hidden"
+                           th:field="*{existingRptTransactions[__${stat.index}__].relationship}"
+                           th:id="existingRptTransactions[__${stat.index}__].relationship"/>
+                    <input type="hidden" th:field="*{existingRptTransactions[__${stat.index}__].id}"
+                           th:id="existingRptTransactions[__${stat.index}__].id"/>
+                </div>
+
+
                 <span id="relatedPartyTransactions-help-text" class="govuk-hint">
                 You can report up to 20 related party transactions.
-            </span>
+                </span>
 
                 <div class="govuk-form-group govuk-form-group-block-important">
 
@@ -37,14 +191,14 @@
                             <div class="govuk-radios" data-module="radios" >
 
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input piwik-event" id="transactionTypeCompanyByRelatedParty" th:field="*{rptTransactionToAdd.transactionType}" type="radio" value="money-given-by-a-related-party" data-event-id="money-given-by-a-related-party">
+                                    <input class="govuk-radios__input piwik-event" id="transactionTypeCompanyByRelatedParty" th:field="*{rptTransactionToAdd.transactionType}" type="radio" value="Money given to the company by a related party" data-event-id="money-given-by-a-related-party">
                                     <label class="govuk-label govuk-radios__label" id="transactionTypeCompanyByRelatedParty-label" for="transactionTypeCompanyByRelatedParty">
                                         Money given to the company by a related party
                                     </label>
                                 </div>
 
                                 <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input piwik-event" id="transactionTypeRelatedPartyByCompany" th:field="*{rptTransactionToAdd.transactionType}" type="radio" value="money-given-to-a-related-party" data-event-id="money-given-to-a-related-party">
+                                    <input class="govuk-radios__input piwik-event" id="transactionTypeRelatedPartyByCompany" th:field="*{rptTransactionToAdd.transactionType}" type="radio" value="Money given to a related party by the company" data-event-id="money-given-to-a-related-party">
                                     <label class="govuk-label govuk-radios__label" id="transactionTypeRelatedPartyByCompany-label" for="transactionTypeRelatedPartyByCompany">
                                         Money given to a related party by the company
                                     </label>
@@ -93,6 +247,7 @@
 
                         <textarea class="govuk-textarea"
                                   id="rptTransactionToAdd-description-of-transaction"
+                                  th:field="*{rptTransactionToAdd.descriptionOfTransaction}"
                                   type="text" rows="5">
                                  </textarea>
                     </div>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/RelatedPartyTransactionsQuestionControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/RelatedPartyTransactionsQuestionControllerTest.java
@@ -170,6 +170,23 @@ class RelatedPartyTransactionsQuestionControllerTest {
     }
 
     @Test
+    @DisplayName("Post related party transactions - has included related party transactions with existing api resource")
+    void postRequestHasIncludedRelatedPartyTransactionsWithExistingAPi() throws Exception {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+
+        when(relatedPartyTransactionsService.getRelatedPartyTransactions(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(relatedPartyTransactionsApi);
+
+        when(navigatorService.getNextControllerRedirect(any(), ArgumentMatchers.<String>any())).thenReturn(MOCK_CONTROLLER_PATH);
+
+        this.mockMvc.perform(post(RELATED_PARTY_TRANSACTIONS_QUESTION_PATH)
+                .param(RELATED_PARTY_TRANSACTIONS_SELECTION, "1")
+                .sessionAttr(COMPANY_ACCOUNTS_DATA_STATE, new CompanyAccountsDataState()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name(MOCK_CONTROLLER_PATH));
+    }
+
+    @Test
     @DisplayName("Post related party transactions - throws exception")
     void postRequestThrowsException() throws Exception {
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImplTest.java
@@ -122,6 +122,35 @@ class RptTransactionsServiceImplTest {
         assertEquals(allRptTransactions, response);
     }
 
+
+    @Test
+    @DisplayName("GET - all RPT transactions some with blank name - success")
+    void getAllRptTransactionsSomeBlankNameSuccess()
+            throws ServiceException, ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(apiClient.smallFull()).thenReturn(smallFullResourceHandler);
+        when(smallFullResourceHandler.relatedPartyTransactions()).thenReturn(relatedPartyTransactionsResourceHandler);
+        when(relatedPartyTransactionsResourceHandler.rptTransactions()).thenReturn(rptTransactionResourceHandler);
+        when(rptTransactionResourceHandler.getAll(RPT_TRANSACTION_URI)).thenReturn(rptTransactionGetAll);
+        when(rptTransactionGetAll.execute()).thenReturn(responseWithMultipleRptTransactions);
+        RptTransactionApi[] rptTransactionApi = new RptTransactionApi[1];
+        RptTransactionApi rptTransaction = new RptTransactionApi();
+        rptTransaction.setNameOfRelatedParty("");
+        rptTransactionApi[0] = rptTransaction;
+        when(responseWithMultipleRptTransactions.getData()).thenReturn(rptTransactionApi);
+        RptTransaction[] allRptTransactions = new RptTransaction[1];
+        RptTransaction transaction = new RptTransaction();
+        transaction.setNameOfRelatedParty("Not provided");
+        allRptTransactions[0] = transaction;
+        when(rptTransactionsTransformer.getAllRptTransactions(rptTransactionApi)).thenReturn(allRptTransactions);
+
+        RptTransaction[] response = rptTransactionsService.getAllRptTransactions(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
+
+        assertEquals(allRptTransactions, response);
+        assertEquals(response[0].getNameOfRelatedParty(), "Not provided");
+    }
+
     @Test
     @DisplayName("DELETE - RPT transaction - success")
     void deleteRptTransactionSuccess() throws ApiErrorResponseException, URIValidationException, ServiceException {
@@ -192,6 +221,53 @@ class RptTransactionsServiceImplTest {
 
         when(apiClientService.getApiClient()).thenReturn(apiClient);
         when(addOrRemoveRptTransactions.getRptTransactionToAdd()).thenReturn(rptTransactionToAdd);
+
+        when(rptTransactionsTransformer.getRptTransactionsApi(rptTransactionToAdd)).thenReturn(rptTransactionApi);
+
+        when(apiClient.smallFull()).thenReturn(smallFullResourceHandler);
+        when(smallFullResourceHandler.relatedPartyTransactions()).thenReturn(relatedPartyTransactionsResourceHandler);
+        when(relatedPartyTransactionsResourceHandler.rptTransactions()).thenReturn(rptTransactionResourceHandler);
+        when(rptTransactionResourceHandler.create(RPT_TRANSACTION_URI, rptTransactionApi)).thenReturn(rptTransactionCreate);
+        when(rptTransactionCreate.execute()).thenReturn(responseWithSingleRptTransaction);
+
+        List<ValidationError> validationErrors = rptTransactionsService.createRptTransaction(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, addOrRemoveRptTransactions);
+
+        assertNotNull(validationErrors);
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("POST - RPT transaction - success with some transactions having no name provided")
+    void createRptTransactionSomeNoNameProvidedSuccess()
+            throws ServiceException, ApiErrorResponseException, URIValidationException {
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(addOrRemoveRptTransactions.getRptTransactionToAdd()).thenReturn(rptTransactionToAdd);
+        when(rptTransactionToAdd.getNameOfRelatedParty()).thenReturn("");
+
+        when(rptTransactionsTransformer.getRptTransactionsApi(rptTransactionToAdd)).thenReturn(rptTransactionApi);
+
+        when(apiClient.smallFull()).thenReturn(smallFullResourceHandler);
+        when(smallFullResourceHandler.relatedPartyTransactions()).thenReturn(relatedPartyTransactionsResourceHandler);
+        when(relatedPartyTransactionsResourceHandler.rptTransactions()).thenReturn(rptTransactionResourceHandler);
+        when(rptTransactionResourceHandler.create(RPT_TRANSACTION_URI, rptTransactionApi)).thenReturn(rptTransactionCreate);
+        when(rptTransactionCreate.execute()).thenReturn(responseWithSingleRptTransaction);
+
+        List<ValidationError> validationErrors = rptTransactionsService.createRptTransaction(TRANSACTION_ID, COMPANY_ACCOUNTS_ID, addOrRemoveRptTransactions);
+
+        assertNotNull(validationErrors);
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("POST - RPT transaction - success with some transactions having prefer not to say")
+    void createRptTransactionSomePreferNotToSaySuccess()
+            throws ServiceException, ApiErrorResponseException, URIValidationException {
+        String PREFER_NOT_TO_SAY = "Prefer not to say";
+
+        when(apiClientService.getApiClient()).thenReturn(apiClient);
+        when(addOrRemoveRptTransactions.getRptTransactionToAdd()).thenReturn(rptTransactionToAdd);
+        when(rptTransactionToAdd.getNameOfRelatedParty()).thenReturn(PREFER_NOT_TO_SAY);
 
         when(rptTransactionsTransformer.getRptTransactionsApi(rptTransactionToAdd)).thenReturn(rptTransactionApi);
 

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImplTest.java
@@ -112,6 +112,7 @@ class RptTransactionsServiceImplTest {
         when(rptTransactionResourceHandler.getAll(RPT_TRANSACTION_URI)).thenReturn(rptTransactionGetAll);
         when(rptTransactionGetAll.execute()).thenReturn(responseWithMultipleRptTransactions);
         RptTransactionApi[] rptTransactionApi = new RptTransactionApi[1];
+        rptTransactionApi[0] = new RptTransactionApi();
         when(responseWithMultipleRptTransactions.getData()).thenReturn(rptTransactionApi);
         RptTransaction[] allRptTransactions = new RptTransaction[1];
         when(rptTransactionsTransformer.getAllRptTransactions(rptTransactionApi)).thenReturn(allRptTransactions);


### PR DESCRIPTION
Added functionality where user can now add new transactions to their existing rpt transactions. New transactions will now appear at the top of the web page in a summary table.

Unit tests have also been added to cover new code.

 bug fix regarding displaying the page logic found in the rpt question controller has also been fixed in this PR and unit test updated.

Image of new table for reference when viewing HTML of table and changes:
![image](https://user-images.githubusercontent.com/46924568/100848217-ba39c480-3478-11eb-8b51-1ecfaf1e932d.png)
