### PR TITLE
 Add validation on web for transaction type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveRptTransactionsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveRptTransactionsController.java
@@ -131,9 +131,14 @@ public class AddOrRemoveRptTransactionsController extends BaseController impleme
                                     @PathVariable String transactionId,
                                     @PathVariable String companyAccountsId,
                                     @ModelAttribute(ADD_OR_REMOVE_RPT_TRANSACTIONS) AddOrRemoveRptTransactions addOrRemoveRptTransactions,
+                                    BindingResult bindingResult,
                                     Model model) {
 
         addBackPageAttributeToModel(model, companyNumber, transactionId, companyAccountsId);
+
+        if (bindingResult.hasErrors()) {
+            return getTemplateName();
+        }
 
         try {
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.web.accounts.service.smallfull.impl;
 
-import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
@@ -20,7 +19,6 @@ import uk.gov.companieshouse.web.accounts.validation.ValidationError;
 import uk.gov.companieshouse.web.accounts.validation.helper.ServiceExceptionHandler;
 import uk.gov.companieshouse.web.accounts.validation.smallfull.RptTransactionValidator;
 
-import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -33,8 +31,6 @@ public class RptTransactionsServiceImpl implements RptTransactionService {
             new UriTemplate("/transactions/{transactionId}/company-accounts/{companyAccountsId}/small-full/notes/related-party-transactions/transactions/{transactionId}");
 
     private static final String RESOURCE_NAME = "transactions";
-
-    private static final String NOT_PROVIDED = "Not provided";
 
     @Autowired
     private ApiClientService apiClientService;
@@ -59,13 +55,7 @@ public class RptTransactionsServiceImpl implements RptTransactionService {
         String uri = RPT_TRANSACTIONS_URI.expand(transactionId, companyAccountsId).toString();
 
         try {
-            RptTransactionApi[] rptTransactions = Arrays.stream(apiClient.smallFull().relatedPartyTransactions().rptTransactions().getAll(uri).execute().getData())
-                    .map(transaction -> {
-                        if (StringUtils.isBlank(transaction.getNameOfRelatedParty())) {
-                            transaction.setNameOfRelatedParty(NOT_PROVIDED);
-                        }
-                        return transaction;
-                    }).toArray(RptTransactionApi[]::new);
+            RptTransactionApi[] rptTransactions = apiClient.smallFull().relatedPartyTransactions().rptTransactions().getAll(uri).execute().getData();
 
             return rptTransactionsTransformer.getAllRptTransactions(rptTransactions);
         } catch (ApiErrorResponseException e) {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/validation/smallfull/RptTransactionValidator.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/validation/smallfull/RptTransactionValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.web.accounts.validation.smallfull;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.web.accounts.model.relatedpartytransactions.RptTransactionToAdd;
+import uk.gov.companieshouse.web.accounts.validation.ValidationError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class RptTransactionValidator {
+
+    private static final String RPT_TRANSACTION_TO_ADD = "rptTransactionToAdd";
+
+    private static final String TRANSACTION_TYPE = RPT_TRANSACTION_TO_ADD + ".transactionType";
+    private static final String RPT_TRANSACTIONS_TRANSACTION_TYPE_NOT_PRESENT = "validation.element.missing." + TRANSACTION_TYPE;
+
+    public List<ValidationError> validateRptTransactionToAdd(RptTransactionToAdd rptTransactionToAdd) {
+
+        List<ValidationError> validationErrors = new ArrayList<>();
+
+        if (StringUtils.isBlank(rptTransactionToAdd.getTransactionType())) {
+
+            ValidationError error = new ValidationError();
+            error.setFieldPath(TRANSACTION_TYPE);
+            error.setMessageKey(RPT_TRANSACTIONS_TRANSACTION_TYPE_NOT_PRESENT);
+            validationErrors.add(error);
+        }
+
+        return validationErrors;
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -504,3 +504,7 @@ validation.addOrRemoveLoans.oneRequired=You must have at least one loan
 # Loans To Directors Additional information
 validation.characters.invalid.additional_information.details=Enter valid characters
 validation.length.invalidInputLength.additional_information.details=You must not exceed {1} characters
+
+# Related party transactions, transactions
+rptTransactionToAdd.transactionType=Transaction type:
+validation.element.missing.rptTransactionToAdd.transactionType=Tell us the nature of the transaction

--- a/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
@@ -149,6 +149,8 @@
                   headingText = 'Related party transactions')">
                 </div>
 
+                <div th:replace="fragments/globalErrors :: globalErrors"></div>
+
                 <!--Hidden fields for form binding-->
                 <input th:field="*{nextAccount.periodStartOn}" type="hidden">
                 <input th:field="*{nextAccount.periodEndOn}" type="hidden">
@@ -189,6 +191,13 @@
                             </legend>
 
                             <div class="govuk-radios" data-module="radios" >
+
+                                 <span class="govuk-error-message"
+                                       id="rptTransactionToAdd.transactionType-errorId"
+                                       th:if="${#fields.hasErrors('rptTransactionToAdd.transactionType')}"
+                                       th:each="e : ${#fields.errors('rptTransactionToAdd.transactionType')}" th:text="${e}" >
+                            </span>
+
 
                                 <div class="govuk-radios__item">
                                     <input class="govuk-radios__input piwik-event" id="transactionTypeCompanyByRelatedParty" th:field="*{rptTransactionToAdd.transactionType}" type="radio" value="Money given to the company by a related party" data-event-id="money-given-by-a-related-party">

--- a/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/service/smallfull/impl/RptTransactionsServiceImplTest.java
@@ -151,14 +151,12 @@ class RptTransactionsServiceImplTest {
         when(responseWithMultipleRptTransactions.getData()).thenReturn(rptTransactionApi);
         RptTransaction[] allRptTransactions = new RptTransaction[1];
         RptTransaction transaction = new RptTransaction();
-        transaction.setNameOfRelatedParty("Not provided");
         allRptTransactions[0] = transaction;
         when(rptTransactionsTransformer.getAllRptTransactions(rptTransactionApi)).thenReturn(allRptTransactions);
 
         RptTransaction[] response = rptTransactionsService.getAllRptTransactions(TRANSACTION_ID, COMPANY_ACCOUNTS_ID);
 
         assertEquals(allRptTransactions, response);
-        assertEquals("Not provided", response[0].getNameOfRelatedParty());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/validation/smallfull/RptTransactionValidatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/validation/smallfull/RptTransactionValidatorTest.java
@@ -1,0 +1,53 @@
+package uk.gov.companieshouse.web.accounts.validation.smallfull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.web.accounts.model.relatedpartytransactions.RptTransactionToAdd;
+import uk.gov.companieshouse.web.accounts.validation.ValidationError;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RptTransactionValidatorTest {
+
+
+    private static final String RPT_TRANSACTION_TO_ADD = "rptTransactionToAdd";
+
+    private static final String RPT_TRANSACTION_TYPE = "Money given to a related party by the company";
+    private static final String TRANSACTION_TYPE = RPT_TRANSACTION_TO_ADD + ".transactionType";
+    private static final String RPT_TRANSACTIONS_TRANSACTION_TYPE_NOT_PRESENT = "validation.element.missing." + TRANSACTION_TYPE;
+
+    private final RptTransactionValidator validator = new RptTransactionValidator();
+
+    @Test
+    @DisplayName("Validate RPT transaction - success")
+    void validateRptTransactionToAddSuccess() {
+
+        RptTransactionToAdd rptTransactionToAdd = new RptTransactionToAdd();
+        rptTransactionToAdd.setTransactionType(RPT_TRANSACTION_TYPE);
+        List<ValidationError> validationErrors = validator.validateRptTransactionToAdd(rptTransactionToAdd);
+
+        assertTrue(validationErrors.isEmpty());
+    }
+
+    @Test
+    @DisplayName("Validate loan to add for multi year filer - missing director name")
+    void validateLoanToAddForMultiYearFilerMissingDirectorName() {
+
+        RptTransactionToAdd rptTransactionToAdd = new RptTransactionToAdd();
+
+        List<ValidationError> validationErrors = validator.validateRptTransactionToAdd(rptTransactionToAdd);
+
+        assertFalse(validationErrors.isEmpty());
+        assertEquals(1, validationErrors.size());
+        assertEquals(RPT_TRANSACTIONS_TRANSACTION_TYPE_NOT_PRESENT, validationErrors.get(0).getMessageKey());
+    }
+}


### PR DESCRIPTION
This commit adds code for validation regarding related party transactions, transaction resources's transaction_type field.
It passes when users select one of the radio button and errors when neither is selected. Similar validation is performed on api side
Resolves: BI-6089

Screenshot:

![image](https://user-images.githubusercontent.com/53441646/100989252-8d54e280-3548-11eb-9527-d16201f8cc57.png)
