### PR TITLE
Add div around buttons on Related Party Transaction page

### DIFF
--- a/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
@@ -335,14 +335,18 @@
                 </div>
 
 
-                <input id="save-and-continue-button" class="govuk-button piwik-event"
-                       data-event-id="Related party transactions - save and continue"
-                       th:name="submit"
-                       type="submit" role="button" value="Save and continue"/>
-                <input id="add-transaction-button" class="govuk-button govuk-button-grey piwik-event"
-                       th:name="add"
-                       data-event-id="Related party transaction - add transaction"
-                       role="button" type="submit" value="Add another related party transaction"/>
+                <div class="govuk-form-group">
+                    <input id="save-and-continue-button" class="govuk-button piwik-event"
+                           data-event-id="Related party transactions - save and continue"
+                           th:name="submit"
+                           type="submit" role="button" value="Save and continue"/>
+                    <th:block>
+                        <input id="add-transaction-button" class="govuk-button govuk-button-grey piwik-event"
+                               th:name="add"
+                               data-event-id="Related party transaction - add transaction"
+                               role="button" type="submit" value="Add another related party transaction"/>
+                    </th:block>
+                </div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Issue found that when the RPT page was zoomed to 200% that the Save and Continue and Add another related party transaction buttons would be misaligned. Added a div around both buttons as it is for the Loans to Directors page which corrects the alignment.

BI-5336