### PR TITLE
Hide balance at period start

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveRptTransactionsController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveRptTransactionsController.java
@@ -13,6 +13,7 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.annotation.NextController;
 import uk.gov.companieshouse.web.accounts.annotation.PreviousController;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
@@ -20,6 +21,7 @@ import uk.gov.companieshouse.web.accounts.controller.BaseController;
 import uk.gov.companieshouse.web.accounts.controller.ConditionalController;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.relatedpartytransactions.AddOrRemoveRptTransactions;
+import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.RelatedPartyTransactionsService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.RptTransactionService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.SmallFullService;
@@ -45,6 +47,8 @@ public class AddOrRemoveRptTransactionsController extends BaseController impleme
 
     private static final String COMPANY_ACCOUNTS_ID = "companyAccountsId";
 
+    private static final String MULTI_YEAR_FILER = "multiYearFiler";
+
     @Autowired
     private RptTransactionService rptTransactionService;
 
@@ -60,6 +64,9 @@ public class AddOrRemoveRptTransactionsController extends BaseController impleme
     @Autowired
     private HttpServletRequest request;
 
+    @Autowired
+    private CompanyService companyService;
+
     @GetMapping
     public String getAddOrRemoveRptTransactions(@PathVariable String companyNumber,
                                                 @PathVariable String transactionId,
@@ -73,7 +80,11 @@ public class AddOrRemoveRptTransactionsController extends BaseController impleme
 
         ApiClient apiClient = apiClientService.getApiClient();
 
+        CompanyProfileApi companyProfile;
+
         try {
+
+             companyProfile = companyService.getCompanyProfile(companyNumber);
 
             SmallFullApi smallFullApi = smallFullService.getSmallFullAccounts(apiClient, transactionId, companyAccountsId);
 
@@ -92,6 +103,7 @@ public class AddOrRemoveRptTransactionsController extends BaseController impleme
         model.addAttribute(COMPANY_NUMBER, companyNumber);
         model.addAttribute(TRANSACTION_ID, transactionId);
         model.addAttribute(COMPANY_ACCOUNTS_ID, companyAccountsId);
+        model.addAttribute(MULTI_YEAR_FILER, companyService.isMultiYearFiler(companyProfile));
 
         return getTemplateName();
     }

--- a/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
@@ -105,7 +105,7 @@
                                             </strong>
                                         </div>
                                     </div>
-                                    <div class="govuk-grid-row">
+                                    <div th:if="${multiYearFiler == true}" class="govuk-grid-row">
                                         <div class="govuk-grid-column-one-half govuk-body cya-desktop-only"
                                              th:id="rptTransactions-table-breakdown-balance-at-period-start-heading[__${stat.index}__]"
                                              th:text="'Balance at ' + ${#temporals.format(addOrRemoveTransactions.nextAccount.periodStartOn, 'd MMMM yyyy')}">
@@ -310,7 +310,7 @@
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-one-half">&nbsp;</div>
                     </div>
-                    <div class="govuk-grid-row">
+                    <div th:if="${multiYearFiler == true}" class="govuk-grid-row">
                         <div class="govuk-grid-column-one-half"
                              id="rptTransactionToAdd-breakdown-balance-at-period-heading"
                              th:text="'Balance at ' + *{#temporals.format(nextAccount.periodStartOn, 'd MMMM yyyy')}">

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveRptTransactionsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/AddOrRemoveRptTransactionsControllerTest.java
@@ -16,10 +16,12 @@ import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.api.ApiClient;
 import uk.gov.companieshouse.api.model.accounts.smallfull.SmallFullApi;
 import uk.gov.companieshouse.api.model.accounts.smallfull.relatedpartytransactions.RelatedPartyTransactionsApi;
+import uk.gov.companieshouse.api.model.company.CompanyProfileApi;
 import uk.gov.companieshouse.web.accounts.api.ApiClientService;
 import uk.gov.companieshouse.web.accounts.exception.ServiceException;
 import uk.gov.companieshouse.web.accounts.model.relatedpartytransactions.AddOrRemoveRptTransactions;
 import uk.gov.companieshouse.web.accounts.model.relatedpartytransactions.RptTransaction;
+import uk.gov.companieshouse.web.accounts.service.company.CompanyService;
 import uk.gov.companieshouse.web.accounts.service.navigation.NavigatorService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.RelatedPartyTransactionsService;
 import uk.gov.companieshouse.web.accounts.service.smallfull.RptTransactionService;
@@ -69,6 +71,8 @@ class AddOrRemoveRptTransactionsControllerTest {
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
 
+    private static final String MULTI_YEAR_FILER = "multiYearFiler";
+
     private MockMvc mockMvc;
 
     @Mock
@@ -104,9 +108,14 @@ class AddOrRemoveRptTransactionsControllerTest {
     @Mock
     private BindingResult bindingResult;
 
+    @Mock
+    private CompanyService companyService;
+
+    @Mock
+    private CompanyProfileApi companyProfileApi;
+
     @InjectMocks
     private AddOrRemoveRptTransactionsController controller;
-
 
     @BeforeEach
     private void setup() {
@@ -121,6 +130,8 @@ class AddOrRemoveRptTransactionsControllerTest {
         when(apiClientService.getApiClient()).thenReturn(apiClient);
         when(smallFullService.getSmallFullAccounts(apiClient, TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(smallFullApi);
         when(rptTransactionService.getAllRptTransactions(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenReturn(new RptTransaction[0]);
+        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
+        when(companyService.isMultiYearFiler(companyProfileApi)).thenReturn(true);
 
         this.mockMvc.perform(get(ADD_OR_REMOVE_RPT_TRANSACTIONS_PATH))
                 .andExpect(status().isOk())
@@ -129,6 +140,7 @@ class AddOrRemoveRptTransactionsControllerTest {
                 .andExpect(model().attributeExists(COMPANY_NUMBER))
                 .andExpect(model().attributeExists(TRANSACTION_ID))
                 .andExpect(model().attributeExists(COMPANY_ACCOUNTS_ID))
+                .andExpect(model().attributeExists(MULTI_YEAR_FILER))
                 .andExpect(model().attributeExists(TEMPLATE_NAME_MODEL_ATTR));
     }
 
@@ -137,6 +149,7 @@ class AddOrRemoveRptTransactionsControllerTest {
     void getRequestServiceException() throws Exception {
 
         when(rptTransactionService.getAllRptTransactions(TRANSACTION_ID, COMPANY_ACCOUNTS_ID)).thenThrow(ServiceException.class);
+        when(companyService.getCompanyProfile(COMPANY_NUMBER)).thenReturn(companyProfileApi);
 
         this.mockMvc.perform(get(ADD_OR_REMOVE_RPT_TRANSACTIONS_PATH))
                 .andExpect(status().isOk())


### PR DESCRIPTION
This commit hides the field balance at period start if accounts filer is a single year filer. For multi year filers, that field would be visible and it also deals with the added transaction and hides that field for single year filer as well

Resolves: BI-5316

Screenshot for single year filer:

![image](https://user-images.githubusercontent.com/53441646/101472725-db9b2480-3940-11eb-95d3-b4cc695f9f3c.png)
