### PR TITLE
Fix button alignment on RPT and LTD pages

### DIFF
--- a/src/main/resources/templates/smallfull/addOrRemoveLoans.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveLoans.html
@@ -418,20 +418,20 @@
                     </div>
                 </div>
 
-                <div class="govuk-form-group">
-                    <input id="save-and-continue-button" class="govuk-button piwik-event"
-                           data-event-id="Loans to directors - save and continue"
-                           th:name="submit"
-                           type="submit" role="button" value="Save and continue"/>
+                <div>&nbsp</div>
 
-                    <th:block
-                            th:if="${addOrRemoveLoans.existingLoans == null or addOrRemoveLoans.existingLoans.length < 20}">
-                        <input id="add-loan-button" class="govuk-button govuk-button-grey piwik-event"
-                               th:name="add"
-                               data-event-id="Loans to directors - add loan"
-                               role="button" type="submit" value="Add another loan"/>
-                    </th:block>
-                </div>
+                <input id="save-and-continue-button" class="govuk-button piwik-event"
+                       data-event-id="Loans to directors - save and continue"
+                       th:name="submit"
+                       type="submit" role="button" value="Save and continue"/>
+
+                <th:block
+                        th:if="${addOrRemoveLoans.existingLoans == null or addOrRemoveLoans.existingLoans.length < 20}">
+                    <input id="add-loan-button" class="govuk-button govuk-button-grey piwik-event"
+                           th:name="add"
+                           data-event-id="Loans to directors - add loan"
+                           role="button" type="submit" value="Add another loan"/>
+                </th:block>
                 <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
             </form>
         </div>

--- a/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveTransactions.html
@@ -335,18 +335,18 @@
                 </div>
 
 
-                <div class="govuk-form-group">
+                <div>&nbsp</div>
+
+                
                     <input id="save-and-continue-button" class="govuk-button piwik-event"
                            data-event-id="Related party transactions - save and continue"
                            th:name="submit"
                            type="submit" role="button" value="Save and continue"/>
-                    <th:block>
-                        <input id="add-transaction-button" class="govuk-button govuk-button-grey piwik-event"
-                               th:name="add"
-                               data-event-id="Related party transaction - add transaction"
-                               role="button" type="submit" value="Add another related party transaction"/>
-                    </th:block>
-                </div>
+                    <input id="add-transaction-button" class="govuk-button govuk-button-grey piwik-event"
+                           th:name="add"
+                           data-event-id="Related party transaction - add transaction"
+                           role="button" type="submit" value="Add another related party transaction"/>
+                
             </form>
         </div>
     </div>


### PR DESCRIPTION
An issue was found with alignment of the buttons on the Related Party Transaction page was displayed at a tablet resolution, approx 642x614. Removed the <div> around the buttons and added a new <div> above as a spacer and this has resolved the issue. Also applied the change to the Loans to Directors page as this had the same issue.

BI-5336