### PR TITLE
update register URL to reference sign-in  register page

### DIFF
--- a/src/main/resources/templates/govuk/smallfull/criteria.html
+++ b/src/main/resources/templates/govuk/smallfull/criteria.html
@@ -29,7 +29,7 @@
                 </ul>
                 <h3 class="govuk-heading-s">If you’re filing for the first time</h3>
                 <p class="govuk-body">You can
-                    <a class="piwik-event" data-event-id="register online" th:href="@{{chsAccountUrl}/user/register?request=''(chsAccountUrl=${@environment.getProperty('account.url')})}">register online</a>. You’ll need your email address and create a password.</p>
+                    <a class="piwik-event" data-event-id="register online" th:href="@{{chsAccountUrl}/signin(chsAccountUrl=${@environment.getProperty('account.url')})}">register online</a>. You’ll need your email address and create a password.</p>
                 <p class="govuk-body">Once registered, we’ll post an authentication code to your registered office. If your company already has a code, a reminder will be sent.</p>
                 <p class="govuk-body">Allow up to 5 days for delivery of your code.</p>
                 <p class="govuk-body">For security reasons your code can’t be provided by email or over the phone.</p>


### PR DESCRIPTION
Changed the register online link to point to the services sign in page which contains a register link as suggested by the bug log (DB-1464)