### PR TITLE
Add a not null check to avoid a NPE on LTD

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/LoansToDirectorsQuestionController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/LoansToDirectorsQuestionController.java
@@ -23,6 +23,7 @@ import uk.gov.companieshouse.web.accounts.service.smallfull.LoansToDirectorsServ
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+import java.util.Map;
 
 @Controller
 @PreviousController(FinancialCommitmentsController.class)
@@ -96,8 +97,9 @@ public class LoansToDirectorsQuestionController extends BaseController {
             } else {
                 if (loansToDirectorsApi != null) {
                     if (loansToDirectorsApi.getLinks().getAdditionalInformation() != null) {
-                        if (loansToDirectorsApi.getLoans() != null) {
-                            for (String loanId : loansToDirectorsApi.getLoans().keySet()) {
+                        Map<String, String> loans = loansToDirectorsApi.getLoans();
+                        if (loans != null) {
+                            for (String loanId : loans.keySet()) {
                                 loansService.deleteLoan(transactionId, companyAccountsId, loanId);
                             }
                         }

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/LoansToDirectorsQuestionController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/LoansToDirectorsQuestionController.java
@@ -96,8 +96,10 @@ public class LoansToDirectorsQuestionController extends BaseController {
             } else {
                 if (loansToDirectorsApi != null) {
                     if (loansToDirectorsApi.getLinks().getAdditionalInformation() != null) {
-                        for (String loanId : loansToDirectorsApi.getLoans().keySet()) {
-                            loansService.deleteLoan(transactionId, companyAccountsId, loanId);
+                        if (loansToDirectorsApi.getLoans() != null) {
+                            for (String loanId : loansToDirectorsApi.getLoans().keySet()) {
+                                loansService.deleteLoan(transactionId, companyAccountsId, loanId);
+                            }
                         }
                     } else {
                         loansToDirectorsService.deleteLoansToDirectors(transactionId, companyAccountsId);


### PR DESCRIPTION
In the loans to directors question page if a user
selects no to loans to directors, but has a ltd
additional information resource, it will attempt
to delete the loans resource but will fail with NPE
as it doesn't exist. Added a null check to avoid this.