### PR TITLE
Fix broken link on CIC start page

### DIFF
--- a/src/main/resources/templates/cic/cicBeforeYouStart.html
+++ b/src/main/resources/templates/cic/cicBeforeYouStart.html
@@ -35,7 +35,7 @@
               <p id="cicBeforeYouStart-guidance">Read guidance on
                 <a id="cicBeforeYouStart-guidance-link" href="https://www.gov.uk/prepare-file-annual-accounts-for-limited-company">what your annual accounts should include</a>.</p>
               <p id="cicBeforeYouStart-completed-report-example">See a
-                <a id="cicBeforeYouStart-report-link" href="http://resources.companieshouse.gov.uk/cic-report-completed-example.pdf">completed example of a CIC report (PDF 111kb)</a>.</p>
+                <a id="cicBeforeYouStart-report-link" href="https://www.gov.uk/government/publications/form-cic34-community-interest-company-report">completed example of a CIC report</a>.</p>
               <p id="cicBeforeYouStart-password-needed">You’ll need a Companies House password and authentication code to use this service - you’ll be able to register for these if you don’t have them.</p>
               <p id="cicBeforeYouStart-authentication-information">The authentication code will be sent by post within 5 days. For security reasons, it can’t be sent by email or text.</p>
               <p id="cicBeforeYouStart-contact-companies-house">


### PR DESCRIPTION
An outdated link on a CIC start page has been changed to use the correct URL.

Text on the <a> link has been changed to remove the size of the document as it is no longer a PDF download link.