### PR TITLE
Add summary query parameter to the path to disable the summary screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/BaseController.java
@@ -29,6 +29,8 @@ public abstract class BaseController {
 
     protected static final String ERROR_VIEW = "error";
 
+    protected static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
+
     private static final String COMPANY_ACCOUNTS_DATA_STATE = "companyAccountsDataState";
 
     protected BaseController() {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/payment/PayFilingFeeController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/payment/PayFilingFeeController.java
@@ -25,8 +25,6 @@ public class PayFilingFeeController extends BaseController {
 
     private static final String YOUR_FILINGS_PATH = "/user/transactions";
 
-    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
-
     @Autowired
     private PaymentService paymentService;
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/payment/PayFilingFeeController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/payment/PayFilingFeeController.java
@@ -25,6 +25,8 @@ public class PayFilingFeeController extends BaseController {
 
     private static final String YOUR_FILINGS_PATH = "/user/transactions";
 
+    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
+
     @Autowired
     private PaymentService paymentService;
 
@@ -50,7 +52,7 @@ public class PayFilingFeeController extends BaseController {
         try {
             if(Boolean.TRUE.equals(payFilingFee.getPayFilingFeeChoice())) {
                 return UrlBasedViewResolver.REDIRECT_URL_PREFIX +
-                    paymentService.createPaymentSessionForTransaction(transactionId);
+                    paymentService.createPaymentSessionForTransaction(transactionId) + SUMMARY_FALSE_PARAMETER;
             } else {
                 return UrlBasedViewResolver.REDIRECT_URL_PREFIX
                     + YOUR_FILINGS_PATH;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -44,6 +44,7 @@ public class ApprovalController extends BaseController {
     private static final String IS_PAYABLE_TRANSACTION = "isPayableTransaction";
 
     private static final UriTemplate SUBMITTED_ACCOUNTS_PATH = new UriTemplate("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/approved-accounts");
+    private static final String SUMMARY_SCREEN_FALSE = "?summary=false";
 
     @Autowired
     private TransactionService transactionService;
@@ -143,7 +144,7 @@ public class ApprovalController extends BaseController {
                 transactionService.updateResumeLink(transactionId, RESUME_URI.expand(companyNumber, transactionId, companyAccountsId).toString());
 
                 return UrlBasedViewResolver.REDIRECT_URL_PREFIX +
-                        paymentService.createPaymentSessionForTransaction(transactionId);
+                        paymentService.createPaymentSessionForTransaction(transactionId) + SUMMARY_SCREEN_FALSE;
             }
 
         } catch (ServiceException e) {

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -44,7 +44,6 @@ public class ApprovalController extends BaseController {
     private static final String IS_PAYABLE_TRANSACTION = "isPayableTransaction";
 
     private static final UriTemplate SUBMITTED_ACCOUNTS_PATH = new UriTemplate("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/approved-accounts");
-    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
 
     @Autowired
     private TransactionService transactionService;

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalController.java
@@ -44,7 +44,7 @@ public class ApprovalController extends BaseController {
     private static final String IS_PAYABLE_TRANSACTION = "isPayableTransaction";
 
     private static final UriTemplate SUBMITTED_ACCOUNTS_PATH = new UriTemplate("/company/{companyNumber}/transaction/{transactionId}/company-accounts/{companyAccountsId}/small-full/approved-accounts");
-    private static final String SUMMARY_SCREEN_FALSE = "?summary=false";
+    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
 
     @Autowired
     private TransactionService transactionService;
@@ -144,7 +144,7 @@ public class ApprovalController extends BaseController {
                 transactionService.updateResumeLink(transactionId, RESUME_URI.expand(companyNumber, transactionId, companyAccountsId).toString());
 
                 return UrlBasedViewResolver.REDIRECT_URL_PREFIX +
-                        paymentService.createPaymentSessionForTransaction(transactionId) + SUMMARY_SCREEN_FALSE;
+                        paymentService.createPaymentSessionForTransaction(transactionId) + SUMMARY_FALSE_PARAMETER;
             }
 
         } catch (ServiceException e) {

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/payment/PayFilingFeeControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/payment/PayFilingFeeControllerTest.java
@@ -25,6 +25,8 @@ import uk.gov.companieshouse.web.accounts.service.payment.PaymentService;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PayFilingFeeControllerTest {
 
+    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
+
     private MockMvc mockMvc;
 
     @Mock
@@ -70,7 +72,7 @@ class PayFilingFeeControllerTest {
         mockMvc.perform(post(PAY_FILING_FEE_PATH).
             param(PAY_FILING_FEE_MODEL_ATTR, "1"))
             .andExpect(status().is3xxRedirection())
-            .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX+paymentService.createPaymentSessionForTransaction(TRANSACTION_ID)));
+            .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX+paymentService.createPaymentSessionForTransaction(TRANSACTION_ID) + SUMMARY_FALSE_PARAMETER));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -84,7 +84,7 @@ class ApprovalControllerTests {
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
 
-    private static final String SUMMARY_SCREEN_FALSE = "?summary=false";
+    private static final String SUMMARY_FALSE_PARAMETER = "?summary=false";
 
     private static final String PAYMENT_WEB_ENDPOINT = "/paymentWebEndpoint";
 
@@ -277,7 +277,7 @@ class ApprovalControllerTests {
         this.mockMvc.perform(post(APPROVAL_PATH)
                 .param(DIRECTOR_NAME, NAME))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + PAYMENT_WEB_ENDPOINT + SUMMARY_SCREEN_FALSE));
+                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + PAYMENT_WEB_ENDPOINT + SUMMARY_FALSE_PARAMETER));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/smallfull/ApprovalControllerTests.java
@@ -84,6 +84,8 @@ class ApprovalControllerTests {
 
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
 
+    private static final String SUMMARY_SCREEN_FALSE = "?summary=false";
+
     private static final String PAYMENT_WEB_ENDPOINT = "/paymentWebEndpoint";
 
     private static final String DIRECTOR_NAME = "directorName";
@@ -275,7 +277,7 @@ class ApprovalControllerTests {
         this.mockMvc.perform(post(APPROVAL_PATH)
                 .param(DIRECTOR_NAME, NAME))
                 .andExpect(status().is3xxRedirection())
-                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + PAYMENT_WEB_ENDPOINT));
+                .andExpect(view().name(UrlBasedViewResolver.REDIRECT_URL_PREFIX + PAYMENT_WEB_ENDPOINT + SUMMARY_SCREEN_FALSE));
     }
 
     @Test


### PR DESCRIPTION
Payment summary screen is shown by default. We do not need the summary
screen for CIC payments anymore and providing the query parameter as false,
the service goes to the payment page rather than summary screen.

Resolves: BI-8836