### PR TITLE
Move the skip link from header to base layout

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -5,7 +5,6 @@
     </head>
     <body class="govuk-template__body">
         <th:block th:fragment="header">
-            <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
             <header role="banner" id="global-header" class="govuk-header">
                 <div class="govuk-header__container govuk-width-container">
                     <div class="header-global">

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -30,6 +30,8 @@
     <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
     <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
 
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
     <div th:replace="fragments/piwikWithCookieCheck :: cookieBanner"></div>
 
 


### PR DESCRIPTION
The skip link which is used by our accessibility users
wasn't displaying correctly on our pages. By moving it
into the baseLayout fragmenet I have been able to get the
text to correctly display when tabbing onto the anchor link.

Resolves BI-8197