### PR TITLE
Update spring-boot version to latest for upcoming mongoDB update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,7 +303,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.4</version>
                 <configuration>
                     <container>
                         <expandClasspathDependencies>true</expandClasspathDependencies>


### PR DESCRIPTION
Include extra deps while updating due to changes in spring-boot 2.3+
if you use bind result errors you now need to include 2 extra
deps. Dev tools and spring-boot-start-validation.

Added needed dependencies to fix issue where bind result wasn't working properly.

Also updated Jib plugin to fix concourse pipeline docker build failures.