### PR TITLE
BI-9422 - Downgrade spring-boot to fix issue in live

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
 
         <spring-security-core.version>5.2.11.RELEASE</spring-security-core.version>
 
-        <spring-boot-dependencies.version>2.5.5</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.3.6.RELEASE</spring-boot-dependencies.version>
         <spring-test.version>5.1.3.RELEASE</spring-test.version>
-        <spring-boot-maven-plugin.version>2.5.5</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>2.3.6.RELEASE</spring-boot-maven-plugin.version>
 
 
         <!-- Maven and Surefire plugins -->


### PR DESCRIPTION
in versions of spring-boot past 2.4.0+ a breaking
change was introduced which causes one of our user
journeys to break.

Downgrade to latest working version 2.3.6.RELEASE until we
find a suitable fix for the issue.