### PR TITLE
Bump spring boot to 2.5.5 and also up other deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <hamcrest-library-version>1.3</hamcrest-library-version>
 
-        <java-session-handler.version>2.0.0-rc4</java-session-handler.version>
+        <java-session-handler.version>2.2.4</java-session-handler.version>
 
         <api-sdk-java.version>4.3.5</api-sdk-java.version>
 
@@ -37,7 +37,7 @@
 
         <common-web-java.version>1.5.0</common-web-java.version>
 
-        <web-security-java.version>1.3.10</web-security-java.version>
+        <web-security-java.version>1.4.2</web-security-java.version>
 
         <company-accounts-library.version>1.1.0-rc1</company-accounts-library.version>
 
@@ -54,9 +54,9 @@
 
         <spring-security-core.version>5.2.11.RELEASE</spring-security-core.version>
 
-        <spring-boot-dependencies.version>2.3.6.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.5.5</spring-boot-dependencies.version>
         <spring-test.version>5.1.3.RELEASE</spring-test.version>
-        <spring-boot-maven-plugin.version>2.3.6.RELEASE</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>2.5.5</spring-boot-maven-plugin.version>
 
 
         <!-- Maven and Surefire plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-devtools</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.sonarsource.scanner.maven</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
             <version>${sonar-maven-plugin.version}</version>


### PR DESCRIPTION
java-session-handler bumped to 2.2.4
web-security-java bumped to 1.4.2

Remove spring-boot-dev-tools as its not being actively used and has been causing issues with classpaths in company-accounts-web after the spring-boot upgrade.