### PR TITLE
The upgrade maven surefire and failsafe plugin to work with upgraded …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
         <spring-security-core.version>5.2.11.RELEASE</spring-security-core.version>
 
         <spring-boot-dependencies.version>2.5.5</spring-boot-dependencies.version>
-        <spring-test.version>5.1.3.RELEASE</spring-test.version>
+        <spring-test.version>5.2.3.RELEASE</spring-test.version>
         <spring-boot-maven-plugin.version>2.5.5</spring-boot-maven-plugin.version>
 
 
         <!-- Maven and Surefire plugins -->
-        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-plugin.version>2.22.0</maven-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
         <junit-platform-surefire-provider.version>1.2.0</junit-platform-surefire-provider.version>
 
@@ -84,7 +84,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
@@ -220,7 +224,12 @@
             <version>${spring-test.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter-engine.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
@@ -282,14 +291,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven-surefire-plugin.version}</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>${junit-platform-surefire-provider.version}</version>
-                    </dependency>
-                </dependencies>
+                <version>${maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
- Unit test stopped working when a new version of spring boot was upgraded . 
- Fix was to include a maven failesafe plugin and a maven sure fire plugin correctly . 
- Upgrade the spring test version to avoid failure like ClassDefNotfound on Spring MockMvcBuilders. 

Fixed as per the blog  - https://dzone.com/articles/why-your-junit-5-tests-are-not-running-under-maven