### PR TITLE
Update Log4j to version 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,9 @@
 
         <sdk-manager-java.version>1.4.0-rc1</sdk-manager-java.version>
 
-        <structured-logging.version>1.5.0-rc2</structured-logging.version>
+        <structured-logging.version>1.9.10</structured-logging.version>
+
+        <log4j-bom.version>2.15.0</log4j-bom.version>
 
         <common-web-java.version>1.5.0</common-web-java.version>
 
@@ -69,6 +71,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-bom</artifactId>
+                <version>${log4j-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Updates log4j to version 2.15.0 due to security vulnerability found in older versions.
This dependency has been directly added to the pom.xml file due to springboot dependency
management bringing in old version of log4j regardless of what is being
used in structured-logging.

This will should be removed when springboot has been upgraded to the required patch 2.5.8 or
2.6.2.

More information can be found here: https://spring.io/blog/2021/12/10/log4j2-vulnerability-and-spring-boot

Structured-logging version updated to 1.9.10.

Resolves DEBT-1437.

Results of running  mvn dependency:tree | grep log4j:

[INFO] |  |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-core:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
