### PR TITLE
Update strcutured logging to 1.9.12 and log4j to 2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
 
         <structured-logging.version>1.9.12</structured-logging.version>
 
-        <log4j-bom.version>2.17.0</log4j-bom.version>
-
         <common-web-java.version>1.5.0</common-web-java.version>
 
         <web-security-java.version>1.4.2</web-security-java.version>
@@ -71,13 +69,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j-bom.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <web-security-java.version>1.4.2</web-security-java.version>
 
-        <company-accounts-library.version>1.2.13</company-accounts-library.version>
+        <company-accounts-library.version>1.2.14</company-accounts-library.version>
 
         <environment-reader-library.version>1.2.0-rc1</environment-reader-library.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
 
         <sdk-manager-java.version>1.4.0-rc1</sdk-manager-java.version>
 
-        <structured-logging.version>1.9.10</structured-logging.version>
+        <structured-logging.version>1.9.12</structured-logging.version>
 
-        <log4j-bom.version>2.16.0</log4j-bom.version>
+        <log4j-bom.version>2.17.0</log4j-bom.version>
 
         <common-web-java.version>1.5.0</common-web-java.version>
 


### PR DESCRIPTION
-  Update structured logging to 1.9.12 version .

- Update company accounts library version.

mvn dependency:tree | grep log4j now shows no results

Resolves  DEBT-1565