### PR TITLE
remove 'api/docs' from developer hub url in footer fragment

### DIFF
--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -12,7 +12,7 @@
                         <li><a id="cookies-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">Cookies</a></li>
                         <li><a id="contact-us-link" th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">Contact us</a></li>
                         <li><a id="accessibility-statement-link" th:href="@{{chsUrl}/help/accessibility-statement(chsUrl=${@environment.getProperty('chs.url')})}">Accessibility statement</a></li>
-                        <li><a id="developer-link" th:href="@{${@environment.getProperty('developer.url')}}>Developers</a></li>
+                        <li><a id="developer-link" th:href="@{${@environment.getProperty('developer.url')}}">Developers</a></li>
                     </ul>
                 </div>
             </nav>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -12,7 +12,7 @@
                         <li><a id="cookies-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">Cookies</a></li>
                         <li><a id="contact-us-link" th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">Contact us</a></li>
                         <li><a id="accessibility-statement-link" th:href="@{{chsUrl}/help/accessibility-statement(chsUrl=${@environment.getProperty('chs.url')})}">Accessibility statement</a></li>
-                        <li><a id="developer-link" th:href="@{${@environment.getProperty('developer.url')}}">Developers</a></li>
+                        <li><a id="developer-link" th:href="${@environment.getProperty('developer.url')}">Developers</a></li>
                     </ul>
                 </div>
             </nav>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -12,7 +12,7 @@
                         <li><a id="cookies-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">Cookies</a></li>
                         <li><a id="contact-us-link" th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">Contact us</a></li>
                         <li><a id="accessibility-statement-link" th:href="@{{chsUrl}/help/accessibility-statement(chsUrl=${@environment.getProperty('chs.url')})}">Accessibility statement</a></li>
-                        <li><a id="developer-link" th:href="@{{developerUrl}/api/docs/(developerUrl=${@environment.getProperty('developer.url')})}">Developers</a></li>
+                        <li><a id="developer-link" th:href="@{${@environment.getProperty('developer.url')}}>Developers</a></li>
                     </ul>
                 </div>
             </nav>


### PR DESCRIPTION
**Context:** Old URL = ${current_developer_hub_url}/api/docs

In live and staging, there is an auto-redirect from this 'old' URL to the new one:

<img width="512" alt="image" src="https://user-images.githubusercontent.com/89859322/165270752-14e936bf-6e1b-438a-ac2c-e81eeb3556a5.png">

In dev environments this is not the case, so automated tests are broken. However, this should not break anything in staging or live - it will simply avoid the need to redirect. The 'new' URL is also already being used with no problems and no redirect in other parts of the live site eg. in the footer of the main page: 

<img width="910" alt="image" src="https://user-images.githubusercontent.com/89859322/165270249-6385f3fd-d067-44df-9f9b-cbe1af62ce58.png">

It is only in the companies filing journey that I can see the 'old' URL still being used e.g.:

<img width="927" alt="image" src="https://user-images.githubusercontent.com/89859322/165270482-cc1ad977-a85b-4a58-979a-529fa145c360.png">
