### PR TITLE
Use environment specific URLs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCriteriaController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukCriteriaController.java
@@ -22,10 +22,6 @@ import uk.gov.companieshouse.web.accounts.model.smallfull.Criteria;
 @PreviousController(GovukFullAccountsCriteriaController.class)
 @RequestMapping("/accounts/criteria")
 public class GovukCriteriaController extends BaseController {
-
-    @Value("${accounts-selector.uri}")
-    private String govUkAccountsSelectorUrl;
-
     @Override
     protected String getTemplateName() {
         return "smallfull/criteria";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,8 +8,7 @@ piwik.url=${PIWIK_URL}
 piwik.siteId=${PIWIK_SITE_ID}
 feedback.url=${FEEDBACK_URL}
 
-micro-entity-accounts.uri=https://${CHS_URL}.companieshouse.gov.uk/guides/accounts/chooser/micro-entity
-dormant-accounts.uri=https://${CHS_URL}.companieshouse.gov.uk/guides/accounts/chooser/dormant
-abridged-accounts.uri=https://${CHS_URL}.companieshouse.gov.uk/guides/accounts/chooser/abridged
-accounts-selector.uri=https://${CHS_URL}.companieshouse.gov.uk/accounts/select-account-type
+micro-entity-accounts.uri=${CHS_URL}/guides/accounts/chooser/micro-entity
+dormant-accounts.uri=${CHS_URL}/guides/accounts/chooser/dormant
+abridged-accounts.uri=${CHS_URL}/guides/accounts/chooser/abridged
 gov-uk-file-your-accounts.uri=https://www.gov.uk/file-your-company-annual-accounts


### PR DESCRIPTION
Changed the urls in the application.properties file to use the CHS_URL environment variable so that links will link to other services in the same environment. 

Removed unused property `accounts-selector.uri`.

[BI-11618](https://companieshouse.atlassian.net/browse/BI-11618)