### PR TITLE
Add package accounts feature flag to other select-accounts-type page

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukSelectAccountTypeController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukSelectAccountTypeController.java
@@ -36,10 +36,15 @@ public class GovukSelectAccountTypeController extends BaseController {
     @Value("${package-accounts.uri}")
     private String packageAccountsUri;
 
+    @Value("${package-accounts.enabled}")
+    private String packageAccountsEnabled;
+
     @GetMapping
     public String getTypeOfAccounts(Model model) {
 
         model.addAttribute("typeOfAccounts", new TypeOfAccounts());
+        model.addAttribute("packageAccountsEnabled", packageAccountsEnabled);
+
         addBackPageAttributeToModel(model);
 
         return getTemplateName();


### PR DESCRIPTION
Package accounts enabled feature flag was only populated in the `/company/{companyNumber}/select-accounts-type` endpoint and not the `/select-accounts-type` endpoint.
This PR just adds the feature flag variable to the other endpoint to allow the package accounts option to be enabled. 

