### PR TITLE
Fix package accounts radio option disappearing on error

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/accountselector/SelectAccountTypeController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/accountselector/SelectAccountTypeController.java
@@ -57,6 +57,7 @@ public class SelectAccountTypeController extends BaseController {
             BindingResult bindingResult, Model model, RedirectAttributes redirectAttributes) {
 
         if (bindingResult.hasErrors()) {
+            model.addAttribute("packageAccountsEnabled", packageAccountsEnabled);
             return getTemplateName();
         }
 

--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukSelectAccountTypeController.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/govuk/GovukSelectAccountTypeController.java
@@ -58,6 +58,7 @@ public class GovukSelectAccountTypeController extends BaseController {
         addBackPageAttributeToModel(model);
 
         if (bindingResult.hasErrors()) {
+            model.addAttribute("packageAccountsEnabled", packageAccountsEnabled);
             return getTemplateName();
         }
 


### PR DESCRIPTION
When there is an error in the select accounts type screen the page is re-rendered with the errors, however the `packageAccountsEnabled` wasn't added back in leading to the package accounts radio button disappearing. 
This PR fixes that by adding the attribute in when the template is re-rendered with the errors. 

Resolves: [AOAF-643](https://companieshouse.atlassian.net/browse/AOAF-643)

[AOAF-643]: https://companieshouse.atlassian.net/browse/AOAF-643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ