### PR TITLE
Bumped spring-boot and kotlin versions to fix CVE-2020-29582 CVE-2026-24734

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
                     </dependency>
                     <!--
                         Override dependency to fix CVE-2025-68161
-                       CVE-2020-29582(5.3)if spring-boot... > 3.5.12
+                        Review to see if spring-boot... > 3.5.12
                         supply an updated version of this,
                         allowing removal of this dependency.
                     -->

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,7 @@
                     <dependency>
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-stdlib</artifactId>
-                        <version>2.3.20</version>
-                        <scope>compile</scope>
+                        <version>${kotlin-stdlib.version}</version>
                     </dependency>
         </dependencies>
     </dependencyManagement>
@@ -110,6 +109,9 @@
         <mockito-junit-jupiter.version>5.18.0</mockito-junit-jupiter.version>
 
         <opentelemetry-instrumentation-bom.version>2.26.0</opentelemetry-instrumentation-bom.version>
+
+        <kotlin-stdlib.version>2.3.20</kotlin-stdlib.version>
+
 
         <spring-boot-dependencies.version>3.5.12</spring-boot-dependencies.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,16 +47,28 @@
                         <artifactId>commons-lang3</artifactId>
                         <version>${commons-lang3.version}</version>
                     </dependency>
-                    <!-- 
+                    <!--
                         Override dependency to fix CVE-2025-68161
-                        Review to see if spring-boot... > 3.5.10
-                        supply an updated version of this, 
+                       CVE-2020-29582(5.3)if spring-boot... > 3.5.12
+                        supply an updated version of this,
                         allowing removal of this dependency.
                     -->
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-api</artifactId>
                         <version>${log4j-api.version}</version>
+                    </dependency>
+                    <!--
+                        Override dependency to fix  CVE-2020-29582(5.3)
+                        Review to see if opentelemetry-instrumentation-bom.version > 2.26.0
+                        supply an updated version of this,
+                        allowing removal of this dependency
+                    -->
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib</artifactId>
+                        <version>2.3.20</version>
+                        <scope>compile</scope>
                     </dependency>
         </dependencies>
     </dependencyManagement>
@@ -97,9 +109,9 @@
         <junit-jupiter-engine.version>5.13.1</junit-jupiter-engine.version>
         <mockito-junit-jupiter.version>5.18.0</mockito-junit-jupiter.version>
 
-        <opentelemetry-instrumentation-bom.version>2.23.0</opentelemetry-instrumentation-bom.version>
+        <opentelemetry-instrumentation-bom.version>2.26.0</opentelemetry-instrumentation-bom.version>
 
-        <spring-boot-dependencies.version>3.5.10</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>3.5.12</spring-boot-dependencies.version>
 
         <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <mockito-junit-jupiter.version>5.18.0</mockito-junit-jupiter.version>
 
         <opentelemetry-instrumentation-bom.version>2.26.0</opentelemetry-instrumentation-bom.version>
-
+        <!-- Temporarily overridden dependencies -->
         <kotlin-stdlib.version>2.3.20</kotlin-stdlib.version>
 
 


### PR DESCRIPTION
Bumped spring-boot and kotlin versions to fix CVE-2020-29582 CVE-2026-24734