### PR TITLE
Refactor template URLs to use model attributes

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/accounts/controller/attributes/ModelAttributes.java
+++ b/src/main/java/uk/gov/companieshouse/web/accounts/controller/attributes/ModelAttributes.java
@@ -19,4 +19,39 @@ public class ModelAttributes {
     protected String getFeedbackUrl() {
         return environment.getProperty("feedback.url", "");
     }
+
+    @ModelAttribute("envChsUrl")
+    protected String getEnvChsUrl() {
+        return environment.getProperty("chs.url", "");
+    }
+
+    @ModelAttribute("cdnUrl")
+    protected String getCdnUrl() {
+        return environment.getProperty("cdn.url", "");
+    }
+
+    @ModelAttribute("developerUrl")
+    protected String getDeveloperUrl() {
+        return environment.getProperty("developer.url", "");
+    }
+
+    @ModelAttribute("enquiriesUrl")
+    protected String getEnquiriesUrl() {
+        return environment.getProperty("enquiries", "");
+    }
+
+    @ModelAttribute("piwikUrl")
+    protected String getPiwikUrl() {
+        return environment.getProperty("piwik.url", "");
+    }
+
+    @ModelAttribute("piwikSiteId")
+    protected String getPiwikSiteId() {
+        return environment.getProperty("piwik.siteId", "");
+    }
+
+    @ModelAttribute("accountUrl")
+    protected String getAccountUrl() {
+        return environment.getProperty("account.url", "");
+    }
 }

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -17,7 +17,7 @@
             <p>Try again in a few moments.</p>
             <p>
                 If this problem continues please
-                <a th:href="@{{enquiries}(enquiries=${@environment.getProperty('enquiries')})}">email us</a>
+                <a th:href="@{${enquiriesUrl}}">email us</a>
             </p>
           
         </div>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -9,10 +9,10 @@
                 <div>
                     <ul>
                         <li><a id="policies-link" href="http://resources.companieshouse.gov.uk/serviceInformation.shtml">Policies</a></li>
-                        <li><a id="cookies-link" th:href="@{{chsUrl}/help/cookies(chsUrl=${@environment.getProperty('chs.url')})}">Cookies</a></li>
-                        <li><a id="contact-us-link" th:href="@{{chsUrl}/help/contact-us(chsUrl=${@environment.getProperty('chs.url')})}">Contact us</a></li>
-                        <li><a id="accessibility-statement-link" th:href="@{{chsUrl}/help/accessibility-statement(chsUrl=${@environment.getProperty('chs.url')})}">Accessibility statement</a></li>
-                        <li><a id="developer-link" th:href="${@environment.getProperty('developer.url')}">Developers</a></li>
+                        <li><a id="cookies-link" th:href="@{${envChsUrl} + '/help/cookies'}">Cookies</a></li>
+                        <li><a id="contact-us-link" th:href="@{${envChsUrl} + '/help/contact-us'}">Contact us</a></li>
+                        <li><a id="accessibility-statement-link" th:href="@{${envChsUrl} + '/help/accessibility-statement'}">Accessibility statement</a></li>
+                        <li><a id="developer-link" th:href="${developerUrl}">Developers</a></li>
                     </ul>
                 </div>
             </nav>

--- a/src/main/resources/templates/fragments/piwik.html
+++ b/src/main/resources/templates/fragments/piwik.html
@@ -7,13 +7,12 @@
 <div th:fragment="piwik" class="govuk-visually-hidden">
   <script th:inline="javascript">
                 (function() {
-                    bindPiwikListener('company-accounts', /*[[${@environment.getProperty('piwik.url')}]]*/, /*[[${@environment.getProperty('piwik.siteId')}]]*/);
+                    bindPiwikListener('company-accounts', /*[[${piwikUrl}]]*/, /*[[${piwikSiteId}]]*/);
                 })();
             </script>
   <noscript>
     <p>
-      <img th:src="@{{piwikUrl}/piwik.php?idsite={siteId}(piwikUrl=${@environment.getProperty('piwik.url')},
-                             siteId=${@environment.getProperty('piwik.site.id')})}" style="border:0;" alt="" />
+      <img th:src="@{${piwikUrl} + '/piwik.php?idsite=' + ${piwikSiteId}}" style="border:0;" alt="" />
     </p>
   </noscript>
 </div>

--- a/src/main/resources/templates/fragments/userBar.html
+++ b/src/main/resources/templates/fragments/userBar.html
@@ -9,9 +9,9 @@
             <nav class="content" role="navigation">
                 <ul id="navigation" class="mobile-hidden">
                     <li class="user" id="signed-in-user"th:text="${userEmail + ':'}"></li>
-                    <li><a th:href="@{{chsAccountUrl}/user/account(chsAccountUrl=${@environment.getProperty('account.url')})}" id="your-details" class="piwik-event" data-event-id="Your details - top menu">Manage Account</a></li>
+                    <li><a th:href="@{${accountUrl} + '/user/account'}" id="your-details" class="piwik-event" data-event-id="Your details - top menu">Manage Account</a></li>
                     <li><a href="/user/transactions" id="your-filings" class="piwik-event" data-event-id="Your filings - top menu">Your filings</a></li>
-                    <li><a th:href="@{{chsFollowUrl}/admin/monitor(chsFollowUrl=${@environment.getProperty('monitorGui.url')})}" id="companies-you-follow" class="piwik-event" data-event-id="Companies you follow">Companies you follow</a></li>
+                    <li><a th:href="@{${chsFollowUrl} + '/admin/monitor'}" id="companies-you-follow" class="piwik-event" data-event-id="Companies you follow">Companies you follow</a></li>
                     <li><a href="/signout" id="user-signout" class="piwik-event" data-event-id="Sign out">Sign out</a></li>
                 </ul>
             </nav>

--- a/src/main/resources/templates/govuk/smallfull/criteria.html
+++ b/src/main/resources/templates/govuk/smallfull/criteria.html
@@ -29,7 +29,7 @@
                 </ul>
                 <h3 class="govuk-heading-s">If you’re filing for the first time</h3>
                 <p class="govuk-body">You can
-                    <a class="piwik-event" data-event-id="register online" th:href="@{{chsAccountUrl}/signin(chsAccountUrl=${@environment.getProperty('account.url')})}">register online</a>. You’ll need your email address and create a password.</p>
+                    <a class="piwik-event" data-event-id="register online" th:href="@{${accountUrl} + '/signin'}">register online</a>. You’ll need your email address and create a password.</p>
                 <p class="govuk-body">Once registered, we’ll post an authentication code to your registered office. If your company already has a code, a reminder will be sent.</p>
                 <p class="govuk-body">Allow up to 5 days for delivery of your code.</p>
                 <p class="govuk-body">For security reasons your code can’t be provided by email or over the phone.</p>

--- a/src/main/resources/templates/layouts/baseLayout.html
+++ b/src/main/resources/templates/layouts/baseLayout.html
@@ -8,26 +8,26 @@
     <div id="templateName" th:attr="data-id=${templateName},data-metadata=${metadata}" hidden></div>
 
     <link
-        th:href="@{{cdnUrl}/stylesheets/chs-styles.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        th:href="@{${cdnUrl} + '/stylesheets/chs-styles.css'}"
         media="all" rel="stylesheet" type="text/css" />
 
     <link
         rel="icon"
-        th:href="@{{cdnUrl}/images/favicon.ico?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        th:href="@{${cdnUrl} + '/images/favicon.ico?0.17.3'}"
         type="image/x-icon" />
 
     <script th:inline="javascript">
         window.SERVICE_NAME = 'company-accounts-web'
-        window.PIWIK_URL = [[${@environment.getProperty('piwik.url')}]];
-        window.PIWIK_SITE_ID = [[${@environment.getProperty('piwik.siteId')}]];
+        window.PIWIK_URL = [[${piwikUrl}]];
+        window.PIWIK_SITE_ID = [[${piwikSiteId}]];
     </script>
 
 </head>
 <body>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/details-polyfill.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/details-polyfill.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/body-js-enable.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/vendor/require.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/vendor/jquery-3.3.1.min.js'}" type="text/javascript"></script>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
@@ -48,13 +48,13 @@
     </div>
     <div th:replace="fragments/footer :: footer"></div>
 
-    <script th:src="@{{cdnUrl}/javascripts/app/js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/radio-buttons.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/cookie-consent-1.0.0.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/app/cookie-consent/piwik-only-cookie-consent.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/autocalculate-input-fields.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/disable-button.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/js-enable.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/radio-buttons.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/piwik-enable.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/cookie-consent/cookie-consent-1.0.0.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/cookie-consent/piwik-only-cookie-consent.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/autocalculate-input-fields.js'}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/disable-button.js'}" type="text/javascript"></script>
 
 </body>
 </html>

--- a/src/main/resources/templates/smallfull/addOrRemoveLoans.html
+++ b/src/main/resources/templates/smallfull/addOrRemoveLoans.html
@@ -464,7 +464,7 @@
                  th:name="add" type="submit" value="Add another loan"/>
         </th:block>
         <script
-            th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
+            th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js'}"
             type="text/javascript"></script>
       </form>
     </div>

--- a/src/main/resources/templates/smallfull/approval.html
+++ b/src/main/resources/templates/smallfull/approval.html
@@ -193,7 +193,7 @@
 
       </div>
     </div>
-    <script th:src="@{{cdnUrl}/javascripts/app/accounts-pdf.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/app/accounts-pdf.js'}" type="text/javascript"></script>
   </form>
 
 </div>

--- a/src/main/resources/templates/smallfull/balanceSheet.html
+++ b/src/main/resources/templates/smallfull/balanceSheet.html
@@ -816,7 +816,7 @@
                     <div class="form-group">
                         <input id="next-button" class="govuk-button piwik-event" th:attr="data-event-id=*{lbg}?'Balance Sheet - LBG Save and continue':'Balance Sheet - Save and continue'" type="submit" role="button" value="Save and continue"/>
                     </div>
-                <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+                <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}" type="text/javascript"></script>
 
             </form>
         </div>

--- a/src/main/resources/templates/smallfull/creditorsAfterOneYear.html
+++ b/src/main/resources/templates/smallfull/creditorsAfterOneYear.html
@@ -180,7 +180,7 @@
         <input id="next-button" class="govuk-button piwik-event" data-event-id="Creditors After More Than One Year - Save and continue" type="submit" role="button" value="Save and continue"/>
       </div>
     </div>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}" type="text/javascript"></script>
   </form>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/creditorsWithinOneYear.html
+++ b/src/main/resources/templates/smallfull/creditorsWithinOneYear.html
@@ -273,7 +273,7 @@
                 <input id="next-button" class="govuk-button piwik-event" data-event-id="Creditors Within One Year - Save and continue" type="submit" role="button" value="Save and continue"/>
             </div>
         </div>
-        <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+        <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}" type="text/javascript"></script>
     </form>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/currentAssetsInvestments.html
+++ b/src/main/resources/templates/smallfull/currentAssetsInvestments.html
@@ -45,6 +45,6 @@
                    value="Save and continue"/>
         </div>
     </form>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/balancesheet-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/balancesheet-validation.js'}" type="text/javascript"></script>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/debtors.html
+++ b/src/main/resources/templates/smallfull/debtors.html
@@ -211,7 +211,7 @@
                 <input id="next-button" class="govuk-button piwik-event" data-event-id="Debtors - Save and continue" type="submit" role="button" value="Save and continue"/>
             </div>
         </div>
-        <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+        <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}" type="text/javascript"></script>
     </form>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/employees.html
+++ b/src/main/resources/templates/smallfull/employees.html
@@ -104,7 +104,7 @@
       </div>
     </div>
     <script
-        th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}"
+        th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}"
         type="text/javascript"></script>
   </form>
 </div>

--- a/src/main/resources/templates/smallfull/fixedAssetsInvestments.html
+++ b/src/main/resources/templates/smallfull/fixedAssetsInvestments.html
@@ -44,6 +44,6 @@
                    value="Save and continue"/>
         </div>
     </form>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/balancesheet-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/balancesheet-validation.js'}" type="text/javascript"></script>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/intangibleAssetsNote.html
+++ b/src/main/resources/templates/smallfull/intangibleAssetsNote.html
@@ -594,7 +594,7 @@
            data-event-id="Intangible assets note - Save and continue" type="submit" role="button"
            value="Save and continue"/>
   </form>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js'}" type="text/javascript"></script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/smallfull/profitAndLoss.html
+++ b/src/main/resources/templates/smallfull/profitAndLoss.html
@@ -398,7 +398,7 @@
                     <input id="next-button" class="govuk-button piwik-event" data-event-id="Profit and loss account - Save and continue" type="submit" role="button" value="Save and continue"/>
                 </div>
 
-                <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+                <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}" type="text/javascript"></script>
 
             </form>
         </div>

--- a/src/main/resources/templates/smallfull/stocks.html
+++ b/src/main/resources/templates/smallfull/stocks.html
@@ -155,6 +155,6 @@
                    value="Save and continue"/>
         </div>
     </form>
-    <script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/two-column-accounts-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+    <script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/two-column-accounts-validation.js'}" type="text/javascript"></script>
 </div>
 </html>

--- a/src/main/resources/templates/smallfull/tangibleAssetsNote.html
+++ b/src/main/resources/templates/smallfull/tangibleAssetsNote.html
@@ -8,20 +8,20 @@
   <div id="templateName" th:attr="data-id=${templateName},data-metadata=${metadata}" hidden></div>
 
   <link
-      th:href="@{{cdnUrl}/stylesheets/chs-styles.css(cdnUrl=${@environment.getProperty('cdn.url')})}"
+      th:href="@{${cdnUrl} + '/stylesheets/chs-styles.css'}"
       media="all" rel="stylesheet" type="text/css" />
 
   <link
       rel="icon"
-      th:href="@{{cdnUrl}/images/favicon.ico?0.17.3(cdnUrl=${@environment.getProperty('cdn.url')})}"
+      th:href="@{${cdnUrl} + '/images/favicon.ico?0.17.3'}"
       type="image/x-icon" />
 
 </head>
 <body>
-<script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/details-polyfill.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/app/body-js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/vendor/require.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/vendor/jquery-3.3.1.min.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/details-polyfill.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/app/body-js-enable.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/vendor/require.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/vendor/jquery-3.3.1.min.js'}" type="text/javascript"></script>
 <div class="entire-wrapper">
   <div class="govuk-width-container govuk-width-container-override">
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
@@ -1044,11 +1044,11 @@
 <div class="push"></div>
 </div>
 <div th:replace="fragments/footer :: footer"></div>
-<script th:src="@{{cdnUrl}/javascripts/app/js-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/app/radio-buttons.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/app/piwik-enable.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/autocalculate-input-fields.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
-<script th:src="@{{cdnUrl}/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js(cdnUrl=${@environment.getProperty('cdn.url')})}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/app/js-enable.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/app/radio-buttons.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/app/piwik-enable.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/autocalculate-input-fields.js'}" type="text/javascript"></script>
+<script th:src="@{${cdnUrl} + '/javascripts/lib/company-accounts-web/resource-numeric-field-validation.js'}" type="text/javascript"></script>
 <div th:replace="fragments/piwik :: piwik"></div>
 </body>
 </html>

--- a/src/test/java/uk/gov/companieshouse/web/accounts/controller/attributes/ModelAttributesTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/accounts/controller/attributes/ModelAttributesTest.java
@@ -29,4 +29,131 @@ class ModelAttributesTest {
         String feedbackUrl = attributes.getFeedbackUrl();
         assertEquals("", feedbackUrl);
     }
+
+    @Test
+    void getEnvChsUrlReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("chs.url", "")).thenReturn("http://chs");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("http://chs", attributes.getEnvChsUrl());
+    }
+
+    @Test
+    void getCdnUrlReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("cdn.url", "")).thenReturn("http://cdn");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("http://cdn", attributes.getCdnUrl());
+    }
+
+    @Test
+    void getDeveloperUrlReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("developer.url", "")).thenReturn("http://developer");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("http://developer", attributes.getDeveloperUrl());
+    }
+
+    @Test
+    void getEnquiriesUrlReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("enquiries", "")).thenReturn("http://enquiries");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("http://enquiries", attributes.getEnquiriesUrl());
+    }
+
+    @Test
+    void getPiwikUrlReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("piwik.url", "")).thenReturn("http://piwik");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("http://piwik", attributes.getPiwikUrl());
+    }
+
+    @Test
+    void getPiwikSiteIdReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("piwik.siteId", "")).thenReturn("42");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("42", attributes.getPiwikSiteId());
+    }
+
+    @Test
+    void getAccountUrlReturnsPropertyFromEnvironment() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("account.url", "")).thenReturn("http://account");
+
+        ModelAttributes attributes = new ModelAttributes(env);
+
+        assertEquals("http://account", attributes.getAccountUrl());
+    }
+
+    @Test
+    void getEnvChsUrlReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("chs.url", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getEnvChsUrl());
+    }
+
+    @Test
+    void getCdnUrlReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("cdn.url", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getCdnUrl());
+    }
+
+    @Test
+    void getDeveloperUrlReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("developer.url", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getDeveloperUrl());
+    }
+
+    @Test
+    void getEnquiriesUrlReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("enquiries", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getEnquiriesUrl());
+    }
+
+    @Test
+    void getPiwikUrlReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("piwik.url", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getPiwikUrl());
+    }
+
+    @Test
+    void getPiwikSiteIdReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("piwik.siteId", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getPiwikSiteId());
+    }
+
+    @Test
+    void getAccountUrlReturnsEmptyStringWhenPropertyNotSet() {
+        Environment env = mock(Environment.class);
+        when(env.getProperty("account.url", "")).thenReturn("");
+        ModelAttributes attributes = new ModelAttributes(env);
+        assertEquals("", attributes.getAccountUrl());
+    }
+
 }


### PR DESCRIPTION
- Updated various HTML templates to replace direct environment property references with model attributes for URLs.
- Added new model attributes in ModelAttributes.java for `envChsUrl`, `cdnUrl`, `developerUrl`, `enquiriesUrl`, `piwikUrl`, `piwikSiteId`, and `accountUrl`.