### PR TITLE
Bump Spring Boot and Log4j to address CVE vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,19 @@
                 <version>${commons-lang3.version}</version>
             </dependency>
             <!--
-                Override dependency to fix CVE-2025-68161
-                Review to see if spring-boot... > 3.5.14
+                Override dependency to fix  CVE-2026-34477(6.3), CVE-2026-34479(6.9)
+                Review to see if spring-boot... > 3.5.15
                 supply an updated version of this,
                 allowing removal of this dependency.
             -->
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
+                <version>${log4j-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
                 <version>${log4j-api.version}</version>
             </dependency>
             <!--
@@ -119,7 +124,7 @@
 
         <opentelemetry-instrumentation-bom.version>2.27.0</opentelemetry-instrumentation-bom.version>
 
-        <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>3.5.15</spring-boot-dependencies.version>
 
         <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
 


### PR DESCRIPTION
This pull request updates project dependencies in the `pom.xml` file to address security vulnerabilities and improve logging integration. The main changes include upgrading the Spring Boot version, updating comments to reflect new CVEs, and adding a missing logging dependency.

Dependency and security updates:

* Upgraded the `spring-boot-dependencies.version` from `3.5.14` to `3.5.15` to address recent security vulnerabilities and ensure compatibility with newer dependencies.
* Updated comments to reference CVE-2026-34477 and CVE-2026-34479 instead of the previous CVE, and noted the new minimum Spring Boot version required for the fix.

Logging improvements:

* Added the `log4j-to-slf4j` dependency to ensure proper bridging between Log4j and SLF4J, improving logging compatibility and consistency.