### PR TITLE
Implement banner notification for small full accounts via govuk route

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,13 +33,13 @@
             <type>pom</type>
             <scope>import</scope>
           </dependency>
-            <!-- 
+            <!--
                 Override dependency to fix CVE-2025-48924
                 Review to see if all:
                 - sdk-manager-java >3.0.14
                 - sonar-maven-plugin >5.5.0.6356
                 - common-web-java >4.1.0
-                supply an updated version of this, 
+                supply an updated version of this,
                 allowing removal of this dependency.
             -->
             <dependency>
@@ -137,11 +137,11 @@
 
         <!-- Temporarily overridden dependencies -->
         <commons-lang3.version>3.19.0</commons-lang3.version>
-        <log4j-api.version>2.25.4</log4j-api.version>
+        <log4j-api.version>2.25.5</log4j-api.version>
         <kotlin-stdlib.version>2.3.20</kotlin-stdlib.version>
         <plexus-utils.version>4.0.3</plexus-utils.version>
         <!-- Removed this if spring-boot > 3.5.16 updated this dependency to >= 10.1.55-->
-        <tomcat-embed.version>10.1.56</tomcat-embed.version>
+        <tomcat-embed.version>10.1.57</tomcat-embed.version>
         <!-- End of temporarily overridden dependencies -->
 
         <!--sonar configuration-->

--- a/src/main/resources/templates/fragments/changesToAccountsBanner.html
+++ b/src/main/resources/templates/fragments/changesToAccountsBanner.html
@@ -9,7 +9,7 @@
      aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
      data-govuk-notification-banner-init="">
     <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Changes to accounts </h2>
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Changes to accounts</h2>
     </div>
     <div class="govuk-notification-banner__content">
         <p class="govuk-notification-banner__heading">
@@ -18,8 +18,10 @@
             This applies to directors who file accounts themselves, and agents or accountants who file accounts for
             their clients. </p>
         <p class="govuk-body"> You will no longer be able to file accounts on paper or using our digital services. To
-            prepare for the change, find out more about<a class="govuk-notification-banner__link"  rel="noreferrer noopener" target="_blank" href="#"> using
-                software to file company information. (opens in new tab) </a>.</p>
+            prepare for the change, find out more about<a class="govuk-notification-banner__link"
+                                                          rel="noreferrer noopener" target="_blank"
+                                                          href="https://www.gov.uk/guidance/using-software-to-file-your-companys-information">
+                using software to file company information (opens in new tab)</a>.</p>
     </div>
 </div>
 

--- a/src/main/resources/templates/fragments/changesToAccountsBanner.html
+++ b/src/main/resources/templates/fragments/changesToAccountsBanner.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+      layout:decorate="~{layouts/baseLayout}">
 <head>
     <title></title>
 </head>
 <body>
 
-<div th:fragment="changesToAccountsBanner" class="govuk-notification-banner" role="region"
+<section th:fragment="changesToAccountsBanner" class="govuk-notification-banner"
      aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
      data-govuk-notification-banner-init="">
     <div class="govuk-notification-banner__header">
@@ -23,7 +24,7 @@
                                                           href="https://www.gov.uk/guidance/using-software-to-file-your-companys-information">
                 using software to file company information (opens in new tab)</a>.</p>
     </div>
-</div>
+</section>
 
 </body>
 </html>

--- a/src/main/resources/templates/fragments/changesToAccountsBanner.html
+++ b/src/main/resources/templates/fragments/changesToAccountsBanner.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="en">
-      layout:decorate="~{layouts/baseLayout}">
 <head>
     <title></title>
 </head>

--- a/src/main/resources/templates/fragments/changesToAccountsBanner.html
+++ b/src/main/resources/templates/fragments/changesToAccountsBanner.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title></title>
+</head>
+<body>
+
+<div th:fragment="changesToAccountsBanner" class="govuk-notification-banner" role="region"
+     aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner"
+     data-govuk-notification-banner-init="">
+    <div class="govuk-notification-banner__header">
+        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Changes to accounts </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+        <p class="govuk-notification-banner__heading">
+            From 1 April 2028, all companies must file their accounts using commercial software.</p>
+        <p class="govuk-body">
+            This applies to directors who file accounts themselves, and agents or accountants who file accounts for
+            their clients. </p>
+        <p class="govuk-body"> You will no longer be able to file accounts on paper or using our digital services. To
+            prepare for the change, find out more about<a class="govuk-notification-banner__link"  rel="noreferrer noopener" target="_blank" href="#"> using
+                software to file company information. (opens in new tab) </a>.</p>
+    </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/govuk/smallfull/criteria.html
+++ b/src/main/resources/templates/govuk/smallfull/criteria.html
@@ -5,13 +5,16 @@
       layout:decorate="~{layouts/baseLayout}">
 <head>
     <title>File full accounts with Companies House</title>
+
+    <link th:href="@{${cdnUrl} + '/stylesheets/services/bankrupt-officers/app.min.css'}"
+          media="all" rel="stylesheet" type="text/css" />
 </head>
 
 <body>
 <div id="main-content" layout:fragment="content">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-
+            <div th:replace="fragments/changesToAccountsBanner :: changesToAccountsBanner"></div>
             <form id="criteria-form" class="form" th:action="@{''}" method="post">
                 <header>
                     <h1 id="page-title" class="govuk-heading-l">

--- a/src/main/resources/templates/govuk/smallfull/criteria.html
+++ b/src/main/resources/templates/govuk/smallfull/criteria.html
@@ -6,7 +6,7 @@
 <head>
     <title>File full accounts with Companies House</title>
 
-    <link th:href="@{${cdnUrl} + '/stylesheets/services/bankrupt-officers/app.min.css'}"
+    <link th:href="@{${cdnUrl} + '/stylesheets/services/company-accounts/app.css'}"
           media="all" rel="stylesheet" type="text/css" />
 </head>
 


### PR DESCRIPTION
This pull request introduces a notification banner informing users about upcoming changes to account filing requirements and updates some dependency versions. The most important changes are the addition of a reusable HTML fragment for the notification banner, its integration into the relevant page, and dependency upgrades for improved security and compatibility.

**User-facing changes:**

* Added a new `changesToAccountsBanner` notification banner fragment in `fragments/changesToAccountsBanner.html` to inform users that, from 1 April 2028, all companies must file accounts using commercial software.
* Integrated the `changesToAccountsBanner` fragment into the `govuk/smallfull/criteria.html` page so that users are notified about the upcoming filing changes.

**Dependency upgrades:**

* Upgraded `log4j-api` from version 2.25.4 to 2.25.5 in `pom.xml` for improved security and bug fixes.
* Upgraded `tomcat-embed` from version 10.1.56 to 10.1.57 in `pom.xml` for compatibility and maintenance updates.